### PR TITLE
:atom: Configure Apollo Studio

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -1,8 +1,8 @@
 name: Update GraphQL schema
 on:
-#  schedule:
-#    - cron: "0 0 * * *"
-  pull_request
+  schedule:
+    - cron: "0 0 * * *"
+#  pull_request
 
 jobs:
   update:

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -1,7 +1,8 @@
 name: Update GraphQL schema
 on:
-  schedule:
-    - cron: "0 0 * * *"
+#  schedule:
+#    - cron: "0 0 * * *"
+  pull_request
 
 jobs:
   update:
@@ -10,5 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: apollographql/update-graphql-schema@main
         with:
-          endpoint: "https://confetti-349319.uw.r.appspot.com/graphql"
+          key: ${{ secrets.APOLLO_KEY }}
+          graph: "Confetti"
           schema: "shared/src/commonMain/graphql/schema.graphqls"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+apollo.key

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ buildscript {
         gradlePluginPortal()
         google()
         mavenCentral()
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.0")
@@ -20,6 +23,10 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
+
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 
 object Versions {
     const val kotlinVersion = "1.6.21"
-    const val apollo = "3.3.0"
+    const val apollo = "3.3.1-SNAPSHOT"
 
     const val kotlinCoroutines = "1.6.0"
     const val kmpNativeCoroutines = "0.11.1-new-mm"
@@ -49,6 +49,7 @@ object Apollo {
     const val apolloNormalizedCacheInMemory = "com.apollographql.apollo3:apollo-normalized-cache:${Versions.apollo}"
     const val apolloNormalizedCacheSqlite = "com.apollographql.apollo3:apollo-normalized-cache-sqlite:${Versions.apollo}"
     const val adapters = "com.apollographql.apollo3:apollo-adapters:${Versions.apollo}"
+    const val gradlePluginExternal = "com.apollographql.apollo3:apollo-gradle-plugin-external:${Versions.apollo}"
 }
 
 object Compose {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   implementation(Deps.okhttp)
   implementation(Kotlin.reflect)
   implementation(Deps.xoxo)
+  implementation(Apollo.gradlePluginExternal)
 
   testImplementation(Deps.junit)
 }

--- a/server/src/main/kotlin/fr/androidmakers/server/DefaultApplication.kt
+++ b/server/src/main/kotlin/fr/androidmakers/server/DefaultApplication.kt
@@ -6,23 +6,23 @@ import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.extensions.print
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
 import com.expediagroup.graphql.generator.toSchema
-import com.expediagroup.graphql.server.operations.Mutation
 import com.expediagroup.graphql.server.operations.Query
-import com.expediagroup.graphql.server.operations.Subscription
 import graphql.language.StringValue
 import graphql.schema.*
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import okio.buffer
 import okio.source
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.reactive.CorsWebFilter
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+
 
 @SpringBootApplication
 class DefaultApplication {
@@ -62,6 +62,19 @@ class DefaultApplication {
     }
 
     return schema
+  }
+
+  @Bean
+  fun corsWebFilter(): CorsWebFilter {
+    val corsConfig = CorsConfiguration().apply {
+      addAllowedOrigin("*")
+      addAllowedMethod("*")
+      addAllowedHeader("*")
+    }
+
+    val source = UrlBasedCorsConfigurationSource()
+    source.registerCorsConfiguration("/**", corsConfig)
+    return CorsWebFilter(source)
   }
 }
 

--- a/server/src/main/kotlin/fr/androidmakers/server/DefaultApplication.kt
+++ b/server/src/main/kotlin/fr/androidmakers/server/DefaultApplication.kt
@@ -1,15 +1,26 @@
 package fr.androidmakers.server
 
+import com.apollographql.apollo3.gradle.internal.SchemaUploader
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.extensions.print
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.expediagroup.graphql.generator.toSchema
+import com.expediagroup.graphql.server.operations.Mutation
+import com.expediagroup.graphql.server.operations.Query
+import com.expediagroup.graphql.server.operations.Subscription
 import graphql.language.StringValue
 import graphql.schema.*
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import okio.buffer
+import okio.source
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
+import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
@@ -17,6 +28,41 @@ import kotlin.reflect.KType
 class DefaultApplication {
   @Bean
   fun customHooks(): SchemaGeneratorHooks = CustomSchemaGeneratorHooks()
+
+  @Bean
+  fun schema(
+    query: Query,
+    schemaConfig: SchemaGeneratorConfig
+  ): GraphQLSchema {
+    val schema = toSchema(
+      config = schemaConfig,
+      queries = listOf(TopLevelObject(query, RootQuery::class)),
+      mutations = emptyList(),
+      subscriptions = emptyList()
+    )
+
+    val key = javaClass.classLoader.getResourceAsStream("apollo.key")?.use {
+      it.source().buffer().readUtf8().trim()
+    }
+    if (key != null) {
+      val graph = key.split(":").getOrNull(1)
+      if (graph == null) {
+        println("Cannot determine graph. Make sure to use a graph key")
+      } else {
+        println("Enabling Apollo reporting for graph $graph")
+        SchemaUploader.uploadSchema(
+          key = key,
+          sdl = schema.print(),
+          graph = graph,
+          variant = "current"
+        )
+      }
+    } else {
+      println("Skipping Apollo reporting")
+    }
+
+    return schema
+  }
 }
 
 fun runServer(): ConfigurableApplicationContext {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -109,6 +109,14 @@ apollo {
         //endpointUrl.set("http://localhost:8080/graphql")
         schemaFile.set(file("src/commonMain/graphql/schema.graphqls"))
     }
+    val apolloKey = System.getenv("APOLLO_KEY")
+    if (apolloKey.isNullOrBlank().not()) {
+        registry {
+            key.set(apolloKey)
+            graph.set("Confetti")
+            schemaFile.set(file("src/commonMain/graphql/schema.graphqls"))
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The backend will now upload the SDL to the registry every boot. 

The Github Action will download the SDL from the registry instead of introspection.

This way, we'll get the `@deprecated` usage propagated to the schema 🙌 


