### PR TITLE
Use Jetpack Paging

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.4.0")
     implementation("com.google.android.material:material:1.4.0")
 
-    with (Compose) {
+    with(Compose) {
         implementation(compiler)
         implementation(ui)
         implementation(uiGraphics)
@@ -59,9 +59,14 @@ dependencies {
         implementation(coilCompose)
     }
 
-    with (Koin) {
+    with(Koin) {
         implementation(core)
         implementation(android)
+        implementation(compose)
+    }
+
+    with(Paging) {
+        implementation(runtime)
         implementation(compose)
     }
 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -2,8 +2,10 @@ package dev.johnoreilly.confetti
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.*
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.*
 
@@ -11,7 +13,17 @@ import java.util.*
 class ConfettiViewModel(private val repository: ConfettiRepository) : ViewModel() {
     val enabledLanguages: Flow<Set<String>> = repository.enabledLanguages
 
-    val sessions = repository.sessions
+    val sessions = Pager(PagingConfig(pageSize = 10)) {
+        SessionPagingSource(repository)
+    }.flow
+        .map { pagingData ->
+            pagingData.filter {
+                val filterFavorites = repository.filterFavoriteSessions.value
+                !filterFavorites || it.node.sessionDetails.isFavorite
+            }
+        }
+        .cachedIn(viewModelScope)
+
     val speakers = repository.speakers
     val rooms = repository.rooms
 
@@ -56,5 +68,27 @@ class ConfettiViewModel(private val repository: ConfettiRepository) : ViewModel(
 
     fun onFavoriteFilterClick() {
         repository.filterFavoriteSessions.value = !repository.filterFavoriteSessions.value
+    }
+}
+
+private class SessionPagingSource(
+    private val repository: ConfettiRepository
+) : PagingSource<String, GetSessionsQuery.Edge>() {
+    override suspend fun load(params: LoadParams<String>): LoadResult<String, GetSessionsQuery.Edge> {
+        val cursor = params.key
+        return try {
+            val sessionEdges = repository.fetchSessionPage(cursor)
+            LoadResult.Page(
+                data = sessionEdges,
+                prevKey = null,
+                nextKey = sessionEdges.lastOrNull()?.cursor
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<String, GetSessionsQuery.Edge>): String? {
+        return null
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,3 +1,4 @@
+import Versions.paging
 
 object Versions {
     const val kotlinVersion = "1.7.0"
@@ -15,6 +16,8 @@ object Versions {
     const val multiplatformSettings = "0.8.1"
     const val koin = "3.2.0"
     const val junit = "4.13"
+
+    const val paging = "3.1.1"
 }
 
 
@@ -73,5 +76,7 @@ object Koin {
     val compose = "io.insert-koin:koin-androidx-compose:${Versions.koin}"
 }
 
-
-
+object Paging {
+    val runtime = "androidx.paging:paging-runtime:$paging"
+    val compose = "androidx.paging:paging-compose:1.0.0-alpha15"
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -137,4 +137,11 @@ class ConfettiRepository : KoinComponent {
             .execute()
     }
 
+    suspend fun fetchSessionPage(cursor: String?): List<GetSessionsQuery.Edge> {
+        return apolloClient.query(GetSessionsQuery(after = Optional.presentIfNotNull(cursor)))
+            .fetchPolicy(FetchPolicy.NetworkOnly)
+            .execute()
+            .dataAssertNoErrors.sessions.edges
+    }
+
 }


### PR DESCRIPTION
Demonstrates how to use the Paging component combined with Apollo Kotlin's recent pagination facilities.

Disclaimer: it seems to work well but I must admit I'm not 100% confident everything is correct, as it took me a good while of trial/error to settle on this.

The documentation is [here](https://developer.android.com/topic/libraries/architecture/paging/v3-network-db) but to summarize:
- a `SessionRemoteMediator` is responsible for downloading pages from the network, and to store them in the cache. In our case the storing is actually done automatically by the Apollo client.
- a `SessionPagingSource` is responsible for querying the cache for specific pages
- it is also responsible for invalidating _itself_ when it knows the data it has returned is stale. In our case we do this by using `watch` on the sessions.
- the UI observes the data returned by the PagingSource, via a `Pager` held by the ViewModel