### PR TITLE
Fix Apollo Key path

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         java-version: 11
     - run: |
-        echo ${{ secrets.APOLLO_KEY }} > backend/graphql/src/main/resources/apollo.key
+        echo ${{ secrets.APOLLO_KEY }} > backend/service-graphql/src/main/resources/apollo.key
         ./gradlew :backend:setupGoogleServices
         ./gradlew appengineDeploy
       env:


### PR DESCRIPTION
The last deploy failed and the new schema wasn't uploaded to Studio. This PR fixes that so that the next automated "update GraphQL schema" PR returns the latests schema