### PR TITLE
GraphQL backend: increase max instances

### DIFF
--- a/backend/service-graphql/src/main/appengine/app.yaml
+++ b/backend/service-graphql/src/main/appengine/app.yaml
@@ -5,7 +5,7 @@ instance_class: F2
 entrypoint: java -Xmx64m -jar service-graphql.jar
 
 automatic_scaling:
-  max_instances: 2
+  max_instances: 10
 
 inbound_services:
   - warmup


### PR DESCRIPTION
In prevision of DevFest Nantes next week, allow to use a bit more resources if needed