### PR TITLE
Improve initial "Choose Conferences" screen on dark mode

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.core.view.WindowCompat
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 import dev.johnoreilly.confetti.conferences.ConferencesRoute
 import dev.johnoreilly.confetti.ui.ConfettiApp
+import dev.johnoreilly.confetti.ui.ConfettiTheme
+import dev.johnoreilly.confetti.ui.component.ConfettiBackground
 import org.koin.android.ext.android.inject
 
 
@@ -37,9 +39,13 @@ class MainActivity : ComponentActivity() {
             }
 
             if (showLandingScreen) {
-                ConferencesRoute(navigateToConference = { conference ->
-                    showLandingScreen = false
-                })
+                ConfettiTheme {
+                    ConfettiBackground {
+                        ConferencesRoute(navigateToConference = { _ ->
+                            showLandingScreen = false
+                        })
+                    }
+                }
             } else {
                 ConfettiApp(windowSizeClass, displayFeatures)
             }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/conferences/ConferencesView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/conferences/ConferencesView.kt
@@ -1,19 +1,31 @@
 package dev.johnoreilly.confetti.conferences
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.johnoreilly.confetti.Conference
 import dev.johnoreilly.confetti.ConfettiViewModel
+import dev.johnoreilly.confetti.ui.ConfettiTheme
+import dev.johnoreilly.confetti.ui.component.ConfettiBackground
 import org.koin.androidx.compose.getViewModel
-
 
 @Composable
 fun ConferencesRoute(
@@ -29,22 +41,49 @@ fun ConferencesRoute(
 
 @Composable
 fun ConferencesView(conferenceList: List<Conference>, navigateToConference: (String) -> Unit) {
-
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally)
-    {
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         Text("Choose Conference", style = MaterialTheme.typography.titleLarge)
-        Spacer(modifier = Modifier.size(16.dp))
+        Spacer(modifier = Modifier.size(24.dp))
         LazyColumn {
             items(conferenceList) { conference ->
-                Row(modifier = Modifier.padding(8.dp).clickable(onClick = {
-                    navigateToConference(conference.id)
-                })) {
+                Row(
+                    modifier = Modifier
+                        .clip(shape = RoundedCornerShape(8.dp))
+                        .clickable(onClick = {
+                            navigateToConference(conference.id)
+                        })
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
                     Text(conference.name, style = MaterialTheme.typography.bodyLarge)
                 }
             }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Preview(showBackground = true, showSystemUi = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ConferencesViewPreview() {
+    ConfettiTheme {
+        ConfettiBackground {
+            ConferencesView(
+                conferenceList = listOf(
+                    Conference("0", "Droidcon San Francisco 2022"),
+                    Conference("1", "FrenchKit 2022"),
+                    Conference("2", "Droidcon London 2022"),
+                    Conference("3", "DevFest Ukraine 2023"),
+                ),
+                navigateToConference = {}
+            )
         }
     }
 }


### PR DESCRIPTION
The "Choose Conference" screen didn't have a surface background on the first run. I also tweaked its UI a tiny a bit.

Before:
![Screenshot_1671371789](https://user-images.githubusercontent.com/372852/208302442-db4e73e8-4726-4dfb-a277-27907b7e0448.png)


After:
![Screenshot_1671371756](https://user-images.githubusercontent.com/372852/208302448-b11e99b1-5819-4b41-a526-211a6a8788ea.png)
