### PR TITLE
Use OkHttp 5 - coroutines and happy eyeballs

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ConfettiApplication.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ConfettiApplication.kt
@@ -1,12 +1,16 @@
 package dev.johnoreilly.confetti
 
 import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import dev.johnoreilly.confetti.di.initKoin
 import dev.johnoreilly.confetti.di.appModule
+import org.koin.android.ext.android.get
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 
-class ConfettiApplication : Application() {
+class ConfettiApplication : Application(), ImageLoaderFactory {
+    override fun newImageLoader(): ImageLoader = get()
 
     override fun onCreate() {
         super.onCreate()

--- a/backend/service-import/build.gradle.kts
+++ b/backend/service-import/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     val jvmMain by getting {
       dependencies {
         implementation(libs.okhttp)
+        implementation(libs.okhttp.coroutines)
         implementation(libs.xoxo)
         implementation(libs.ktor.cio)
         implementation(libs.ktor.status.pages)

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DevFestNantes.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DevFestNantes.kt
@@ -33,12 +33,14 @@ object DevFestNantes {
         val request = Request(url.toHttpUrl())
         val response = okHttpClient.newCall(request).executeAsync()
 
-        check(response.isSuccessful) {
-            "Cannot get $url: ${response.body.string()}"
-        }
+        return response.use {
+            check(response.isSuccessful) {
+                "Cannot get $url: ${response.body.string()}"
+            }
 
-        return withContext(Dispatchers.IO) {
-            response.body.string()
+            withContext(Dispatchers.IO) {
+                response.body.string()
+            }
         }
     }
 

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DevFestNantes.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DevFestNantes.kt
@@ -20,7 +20,6 @@ import kotlin.time.Duration.Companion.minutes
 private val timeZone = "Europe/Paris"
 
 private val okHttpClient = OkHttpClient.Builder()
-    .fastFallback(true)
     .build()
 
 private val baseUrl = "https://raw.githubusercontent.com/GDG-Nantes/Devfest2022/master/"

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DroidConSF.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/DroidConSF.kt
@@ -68,7 +68,7 @@ object DroidConSF {
             }.toList()
     }
 
-    fun import() {
+    suspend fun import() {
         val items = items()
 
         val dataStore = DataStore()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/FrenchKit.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/FrenchKit.kt
@@ -17,7 +17,7 @@ object FrenchKit {
         }
     }
 
-    fun import() {
+    suspend fun import() {
         val schedule = getJsonUrl("https://frenchkit.fr/schedule/schedule-14.json")
         val speakersJson = getJsonUrl("https://frenchkit.fr/speakers/speakers-8.json")
 

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
@@ -1,6 +1,12 @@
 package dev.johnoreilly.confetti.backend.import
 
-import dev.johnoreilly.confetti.backend.datastore.*
+import dev.johnoreilly.confetti.backend.datastore.ConferenceId
+import dev.johnoreilly.confetti.backend.datastore.DConfig
+import dev.johnoreilly.confetti.backend.datastore.DRoom
+import dev.johnoreilly.confetti.backend.datastore.DSession
+import dev.johnoreilly.confetti.backend.datastore.DSpeaker
+import dev.johnoreilly.confetti.backend.datastore.DVenue
+import dev.johnoreilly.confetti.backend.datastore.DataStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
@@ -11,15 +17,11 @@ import net.mbonnin.bare.graphql.asList
 import net.mbonnin.bare.graphql.asMap
 import net.mbonnin.bare.graphql.asString
 import net.mbonnin.bare.graphql.toAny
-import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.executeAsync
-import okio.Buffer
-import okio.BufferedSink
 
 object GraphQLSummit {
     private val okHttpClient = OkHttpClient.Builder()
@@ -45,13 +47,17 @@ object GraphQLSummit {
             )
             .post(body.toRequestBody("application/json".toMediaType()))
             .build()
-        val response = okHttpClient.newCall(request).executeAsync().also {
+
+        val response = okHttpClient.newCall(request).executeAsync()
+
+        return response.use {
             check(it.isSuccessful) {
                 "Cannot get $url: ${it.body.string()}"
             }
-        }
-        return withContext(Dispatchers.IO) {
-            response.body.string()
+
+            withContext(Dispatchers.IO) {
+                response.body.string()
+            }
         }
     }
 

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
@@ -25,7 +25,6 @@ import okhttp3.executeAsync
 
 object GraphQLSummit {
     private val okHttpClient = OkHttpClient.Builder()
-        .fastFallback(true)
         .build()
 
     private suspend fun getUrl(url: String, body: String): String {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/GraphQLSummit.kt
@@ -1,6 +1,8 @@
 package dev.johnoreilly.confetti.backend.import
 
 import dev.johnoreilly.confetti.backend.datastore.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -14,46 +16,46 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.executeAsync
+import okio.Buffer
 import okio.BufferedSink
 
 object GraphQLSummit {
-    private val okHttpClient = OkHttpClient()
+    private val okHttpClient = OkHttpClient.Builder()
+        .fastFallback(true)
+        .build()
 
-    private fun getUrl(url: String, body: String): String {
-        return Request.Builder()
+    private suspend fun getUrl(url: String, body: String): String {
+        val request = Request.Builder()
             .url(url)
             .header(
                 "x-cvent-csrf",
                 "4d7e148fa2023d86fcf2a5e64536ec540af5e676ce5fcd7c902f8848f04ec90b756d54fa3ae8b40f213f5f8a0802fe6c84c9928bba3e1c164a661e81a032bb70"
             )
-            .header("sec-ch-ua", "\"Google Chrome\";v=\"105\", \"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"105\"")
+            .header(
+                "sec-ch-ua",
+                "\"Google Chrome\";v=\"105\", \"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"105\""
+            )
             .header("sec-ch-ua-mobile", "?0")
             .header("sec-ch-ua-platform", "\"macOS\"")
             .header(
                 "cookie",
                 "cvt_cookielocale=%5B%7B%22eventId%22%3A%229cabb0aa-eb3c-4bfd-bf74-3dcc4c82c066%22%2C%22locale%22%3A%22en-US%22%7D%5D; engage-auth=8f04c60759e743aa41129b7e5d57fd6c; cvt_id=CA1.84fdd5c51dbb66d3398c731bc93cfcefb3e10f06e921cd4b00f47682a4a299af; cvt_cookieconsent=[%229cabb0aa-eb3c-4bfd-bf74-3dcc4c82c066%22]; CSNSearchDeviceId=d3c22eab-fe8a-4fc8-92ed-ab527e6e41c4; CSNSearchSessionId=8eaffe3a-ce36-4bca-a432-389756952221; _adssid=7aefa298-f879-376e-fcad-2b94a0531d19; CSNSearchRFPSessionId=1773c929-ca22-3422-eb39-26bfdcf4e870; s_cc=true; s_sq=%5B%5BB%5D%5D; _dd_s="
             )
-            .post(object : RequestBody() {
-                override fun contentType(): MediaType? {
-                    return "application/json".toMediaType()
-                }
-
-                override fun writeTo(sink: BufferedSink) {
-                    sink.writeUtf8(body)
-                }
-
-            })
+            .post(body.toRequestBody("application/json".toMediaType()))
             .build()
-            .let {
-                okHttpClient.newCall(it).execute().also {
-                    check(it.isSuccessful) {
-                        "Cannot get $url: ${it.body?.string()}"
-                    }
-                }
-            }.body!!.string()
+        val response = okHttpClient.newCall(request).executeAsync().also {
+            check(it.isSuccessful) {
+                "Cannot get $url: ${it.body.string()}"
+            }
+        }
+        return withContext(Dispatchers.IO) {
+            response.body.string()
+        }
     }
 
-    private fun getJsonUrl(url: String, body: String) = Json.parseToJsonElement(getUrl(url, body)).toAny()
+    private suspend fun getJsonUrl(url: String, body: String) = Json.parseToJsonElement(getUrl(url, body)).toAny()
 
     private val sessionsBody =
         "{\"operationName\":\"SEARCH_SESSIONS\",\"variables\":{\"criteria\":{\"pageCriteria\":{\"limit\":20},\"timeframes\":[{\"start\":\"2022-10-04T22:00:00.000Z\",\"end\":\"2022-10-06T22:00:00.000Z\"}],\"categories\":[],\"admissionItemId\":\"c928fe6c-0a45-460a-9da6-9fa4fa1d9149\",\"useDisplayInAttendeeHub\":true,\"locale\":\"en-US\",\"exhibitorTranslationsFlag\":false}},\"query\":\"fragment BaseSession on Session {\\n  id\\n  name\\n  code\\n  start\\n  end\\n  description\\n  enrolled\\n  included\\n  featured\\n \\n  openForRegistration\\n  category {\\n    id\\n    name\\n    code\\n    __typename\\n  }\\n  location {\\n    id\\n    name\\n    code\\n    __typename\\n  }\\n  __typename\\n}\\n\\nquery SEARCH_SESSIONS(\$criteria: SearchSessionCriteria) {\\n  searchSessions(criteria: \$criteria) {\\n    pagination {\\n      currentToken\\n      nextToken\\n      previousToken\\n      limit\\n      totalCount\\n      __typename\\n    }\\n    data {\\n      ...BaseSession\\n      admissionItems\\n      upgrade\\n      openForAttendeeHub\\n      recommended\\n      exhibitors {\\n        id\\n        name\\n        description\\n        profileLogoId\\n        profileLogoUrl\\n        hidden\\n        featured\\n        eventSponsor\\n        sponsorshipLevelId\\n        __typename\\n      }\\n      webcast {\\n        id\\n        sessionId\\n        eventId\\n        format\\n        playerType\\n        player {\\n          id\\n          videoId\\n          videoUrl\\n          password\\n          playerTypeProvider\\n          stream {\\n            id\\n            status\\n            __typename\\n          }\\n          duration\\n          simuliveOffset\\n          __typename\\n        }\\n        links {\\n          recording {\\n            href\\n            __typename\\n          }\\n          __typename\\n        }\\n        __typename\\n      }\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}"
@@ -69,7 +71,7 @@ object GraphQLSummit {
         }
     }
 
-    fun import() {
+    suspend fun import() {
         val data = getJsonUrl("https://web.cvent.com/hub/graphqlv2", sessionsBody)
 
         val rooms = mutableListOf<DRoom>()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -12,17 +12,12 @@ import io.ktor.server.routing.*
 import kotlin.system.exitProcess
 
 @Suppress("UNUSED_PARAMETER")
-fun main(args: Array<String>) {
-    val confToUpdate = System.getenv("CONF_TO_UPDATE")
-    if (!confToUpdate.isNullOrBlank()) {
-        update(confToUpdate)
-        exitProcess(0)
-    }
-
+suspend fun main(args: Array<String>) {
     println("""
         - update a conference: curl -X POST http://localhost:8080/update/droidconsf
         - update the days of a conference: curl -X POST http://localhost:8080/update-days
     """.trimIndent())
+
     embeddedServer(CIO, port = 8080) {
         install(StatusPages) {
             exception<Throwable> { call, cause ->
@@ -43,7 +38,7 @@ fun main(args: Array<String>) {
     }.start(wait = true)
 }
 
-private fun update(conf: String?) {
+private suspend fun update(conf: String?) {
     when (ConferenceId.from(conf)) {
         ConferenceId.DroidConSF2022 -> DroidConSF.import()
         ConferenceId.DevFestNantes2022 -> DevFestNantes.import()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -7,10 +7,10 @@ import net.mbonnin.bare.graphql.*
 object Sessionize {
     private val droidConLondon2022 = "https://sessionize.com/api/v2/qi0g29hw/view/All"
 
-    fun importDroidConLondon2022() {
+    suspend fun importDroidConLondon2022() {
         import(ConferenceId.DroidConLondon2022.id, "droidcon London", droidConLondon2022)
     }
-    private fun import(conf: String, confName: String, url: String) {
+    private suspend fun import(conf: String, confName: String, url: String) {
         val data = getJsonUrl(url)
 
         val categories = data.asMap["categories"].asList.map { it.asMap }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
@@ -1,23 +1,28 @@
 package dev.johnoreilly.confetti.backend.import
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import net.mbonnin.bare.graphql.toAny
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.executeAsync
 
-private val okHttpClient = OkHttpClient()
+private val okHttpClient = OkHttpClient.Builder()
+    .fastFallback(true)
+    .build()
 
-fun getUrl(url: String): String {
-    return Request.Builder()
-        .url(url)
-        .build()
-        .let {
-            okHttpClient.newCall(it).execute().also {
-                check(it.isSuccessful) {
-                    "Cannot get $url: ${it.body?.string()}"
-                }
-            }
-        }.body!!.string()
+suspend fun getUrl(url: String): String {
+    val request = Request(url.toHttpUrl())
+
+    val response = okHttpClient.newCall(request).executeAsync().also {
+        check(it.isSuccessful) {
+            "Cannot get $url: ${it.body.string()}"
+        }
+    }
+
+    return withContext(Dispatchers.IO) { response.body.string() }
 }
 
-fun getJsonUrl(url: String) = Json.parseToJsonElement(getUrl(url)).toAny()
+suspend fun getJsonUrl(url: String) = Json.parseToJsonElement(getUrl(url)).toAny()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
@@ -10,7 +10,6 @@ import okhttp3.Request
 import okhttp3.executeAsync
 
 private val okHttpClient = OkHttpClient.Builder()
-    .fastFallback(true)
     .build()
 
 suspend fun getUrl(url: String): String {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/utils.kt
@@ -16,13 +16,17 @@ private val okHttpClient = OkHttpClient.Builder()
 suspend fun getUrl(url: String): String {
     val request = Request(url.toHttpUrl())
 
-    val response = okHttpClient.newCall(request).executeAsync().also {
+    val response = okHttpClient.newCall(request).executeAsync()
+
+    return response.use {
         check(it.isSuccessful) {
             "Cannot get $url: ${it.body.string()}"
         }
-    }
 
-    return withContext(Dispatchers.IO) { response.body.string() }
+        withContext(Dispatchers.IO) {
+            response.body.string()
+        }
+    }
 }
 
 suspend fun getJsonUrl(url: String) = Json.parseToJsonElement(getUrl(url)).toAny()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,9 +65,9 @@ material3-core = { module = "androidx.compose.material3:material3", version.ref 
 material3-window-size = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "compose-material-3" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
-okhttp = "com.squareup.okhttp3:okhttp:5.0.0-alpha.10"
-okhttp-coroutines = "com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.10"
-okhttp-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.10"
+okhttp = "com.squareup.okhttp3:okhttp:5.0.0-alpha.11"
+okhttp-coroutines = "com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.11"
+okhttp-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11"
 reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 splash-screen = "androidx.core:core-splashscreen:1.0.0"
 xoxo = "net.mbonnin.xoxo:xoxo:0.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,8 @@ apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo3:apollo-no
 apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime" }
 apollo-tooling = { module = "com.apollographql.apollo3:apollo-tooling", version.ref = "apollo" }
 bare-graphQL = "net.mbonnin.bare-graphql:bare-graphql:0.0.2"
-coil-compose = "io.coil-kt:coil-compose:2.0.0"
+coil-base = "io.coil-kt:coil-base:2.2.2"
+coil-compose = "io.coil-kt:coil-compose:2.2.2"
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "compose" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
@@ -64,7 +65,9 @@ material3-core = { module = "androidx.compose.material3:material3", version.ref 
 material3-window-size = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "compose-material-3" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
-okhttp = "com.squareup.okhttp3:okhttp:4.9.3"
+okhttp = "com.squareup.okhttp3:okhttp:5.0.0-alpha.10"
+okhttp-coroutines = "com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.10"
+okhttp-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.10"
 reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 splash-screen = "androidx.core:core-splashscreen:1.0.0"
 xoxo = "net.mbonnin.xoxo:xoxo:0.2"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0"
 
 kotlin {
     android()
-    //jvm()
+    jvm()
 
     listOf(
         iosX64(),
@@ -47,6 +47,11 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 implementation(libs.androidx.lifecycle.viewmodel.ktx)
+                implementation(libs.okhttp)
+                implementation(libs.okhttp.coroutines)
+                implementation(libs.okhttp.logging.interceptor)
+                implementation(libs.coil.base)
+                implementation(libs.koin.android)
             }
         }
         val iosX64Main by getting
@@ -68,12 +73,14 @@ kotlin {
             iosSimulatorArm64Test.dependsOn(this)
         }
 
-//        val jvmMain by getting {
-//            dependencies {
-//                // hack to allow use of MainScope() in shared code used by JVM console app
-//                implementation(libs.kotlinx.coroutines.swing)
-//            }
-//        }
+        val jvmMain by getting {
+            dependencies {
+                // hack to allow use of MainScope() in shared code used by JVM console app
+                implementation(libs.kotlinx.coroutines.swing)
+                implementation(libs.okhttp)
+                implementation(libs.okhttp.coroutines)
+            }
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -1,15 +1,39 @@
 package dev.johnoreilly.confetti.di
 
 import android.content.Context
+import coil.ImageLoader
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.network.okHttpClient
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.SharedPreferencesSettings
 import dev.johnoreilly.confetti.utils.AndroidDateTimeFormatter
 import dev.johnoreilly.confetti.utils.DateTimeFormatter
+import okhttp3.OkHttpClient
+import okhttp3.logging.LoggingEventListener
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
     single<ObservableSettings> { createObservableSettings(get()) }
     single<DateTimeFormatter> { AndroidDateTimeFormatter() }
+    single<OkHttpClient> {
+        OkHttpClient.Builder()
+            // Happy eyeballs
+            .fastFallback(true)
+            .apply {
+                // TODO enable based on debug flag
+                eventListenerFactory(LoggingEventListener.Factory())
+            }
+            .build()
+    }
+    factory {
+        ApolloClient.Builder().okHttpClient(get())
+    }
+    single {
+        ImageLoader.Builder(androidContext())
+            .okHttpClient { get() }
+            .build()
+    }
 }
 
 

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -18,8 +18,6 @@ actual fun platformModule() = module {
     single<DateTimeFormatter> { AndroidDateTimeFormatter() }
     single<OkHttpClient> {
         OkHttpClient.Builder()
-            // Happy eyeballs
-            .fastFallback(true)
             .apply {
                 // TODO enable based on debug flag
                 eventListenerFactory(LoggingEventListener.Factory())

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -18,6 +18,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import okio.use
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 import org.koin.core.component.inject
 
 class ConfettiRepository : KoinComponent {
@@ -129,7 +130,7 @@ class ConfettiRepository : KoinComponent {
         val memoryFirstThenSqlCacheFactory = MemoryCacheFactory(10 * 1024 * 1024)
             .chain(sqlNormalizedCacheFactory)
 
-        return ApolloClient.Builder()
+        return get<ApolloClient.Builder>()
             .serverUrl("https://graphql-dot-confetti-349319.uw.r.appspot.com/graphql?conference=$conference")
             //.serverUrl("http://10.0.2.2:8080/graphql?conference=graphqlsummit2022")
             .normalizedCache(memoryFirstThenSqlCacheFactory, writeToCacheAsynchronously = writeToCacheAsynchronously)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import com.apollographql.apollo3.ApolloClient
 import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.ConfettiViewModel

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.russhwolf.settings.NSUserDefaultsSettings
@@ -13,6 +14,9 @@ actual fun platformModule() = module {
     single<ObservableSettings> { NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults) }
     single<NormalizedCacheFactory> { SqlNormalizedCacheFactory("confetti.db") }
     single<DateTimeFormatter> { IosDateTimeFormatter() }
+    factory {
+        ApolloClient.Builder()
+    }
 }
 
 actual fun getDatabaseName(conference: String) = "$conference.db"

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -15,8 +15,6 @@ actual fun platformModule() = module {
     single<DateTimeFormatter> { JvmDateTimeFormatter() }
     single<OkHttpClient> {
         OkHttpClient.Builder()
-            // Happy eyeballs
-            .fastFallback(true)
             .build()
     }
     factory {

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -1,15 +1,27 @@
 package dev.johnoreilly.confetti.di
 
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.network.okHttpClient
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.PreferencesSettings
 import dev.johnoreilly.confetti.utils.DateTimeFormatter
 import dev.johnoreilly.confetti.utils.JvmDateTimeFormatter
+import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import java.util.prefs.Preferences
 
 actual fun platformModule() = module {
     single<ObservableSettings> { PreferencesSettings(Preferences.userRoot()) }
     single<DateTimeFormatter> { JvmDateTimeFormatter() }
+    single<OkHttpClient> {
+        OkHttpClient.Builder()
+            // Happy eyeballs
+            .fastFallback(true)
+            .build()
+    }
+    factory {
+        ApolloClient.Builder().okHttpClient(get())
+    }
 }
 
 actual fun getDatabaseName(conference: String) = "jdbc:sqlite:$conference.db"

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ConfettiApplication.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ConfettiApplication.kt
@@ -1,12 +1,17 @@
 package dev.johnoreilly.confetti.wear
 
 import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import dev.johnoreilly.confetti.di.initKoin
 import dev.johnoreilly.confetti.wear.di.appModule
+import org.koin.android.ext.android.get
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 
-class ConfettiApplication : Application() {
+class ConfettiApplication : Application(), ImageLoaderFactory {
+
+    override fun newImageLoader(): ImageLoader = get()
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
For discussion - happy to close if not in scope.  But you seem to use modern versions a lot.

Uses a single instance of OkHttp across Apollo and Coil.  Uses clean coroutines code in all places also, and happy eyeballs to speed up IPv6/IPv4 related issues.