### PR TITLE
Remove lint + AGP8 workaround

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/utils/AndroidDateTimeFormatter.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/utils/AndroidDateTimeFormatter.kt
@@ -7,9 +7,6 @@ import kotlinx.datetime.toJavaInstant
 import java.time.ZoneId
 
 class AndroidDateTimeFormatter: DateTimeFormatter {
-    // Suppress the error below.
-    // Error: Cast from Instant to TemporalAccessor requires API level 26 (current min is 21) [NewApi]
-    @SuppressLint("NewApi")
     override fun format(instant: Instant, timeZone: TimeZone, format: String): String {
         val formatter = java.time.format.DateTimeFormatter.ofPattern(format)
         return formatter.withZone(ZoneId.of(timeZone.id)).format(instant.toJavaInstant())


### PR DESCRIPTION
See https://issuetracker.google.com/issues/260755411

This was needed for AGP 8.0 but we don't use it yet and there's a fix in `8.0.0-alpha10` anyways