### PR TITLE
Add orderBy argument to conferences

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.backend.datastore
 
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
 data class DSession(
@@ -64,6 +65,7 @@ data class DConfig(
   val id: String,
   val name: String,
   val timeZone: String,
+  val days: List<LocalDate> = emptyList()
 )
 
 /**
@@ -73,3 +75,13 @@ class DPage<T>(
   val items: List<T>,
   val nextPageCursor: String?,
 )
+
+class DOrderBy(
+  val field: String,
+  val direction: DDirection
+)
+
+enum class DDirection {
+  ASCENDING,
+  DESCENDING
+}

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
@@ -8,7 +8,8 @@ fun DConfig.toConference(): Conference {
     return Conference(
         id = id,
         name = name,
-        timezone = timeZone
+        timezone = timeZone,
+        days = days,
     )
 }
 class DataStoreDataSource(private val conf: String) : DataSource {

--- a/backend/service-import/README.md
+++ b/backend/service-import/README.md
@@ -5,5 +5,5 @@ Imports conference data into datastore
 To run locally:
 
 ```
-CONF_TO_UPDATE=devfestnantes ./gradlew localRun
+./gradlew localRun
 ```

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.confetti.backend.import
 
 import dev.johnoreilly.confetti.backend.datastore.ConferenceId
+import dev.johnoreilly.confetti.backend.datastore.DataStore
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
@@ -18,6 +19,10 @@ fun main(args: Array<String>) {
         exitProcess(0)
     }
 
+    println("""
+        - update a conference: curl -X POST http://localhost:8080/update/droidconsf
+        - update the days of a conference: curl -X POST http://localhost:8080/update-days
+    """.trimIndent())
     embeddedServer(CIO, port = 8080) {
         install(StatusPages) {
             exception<Throwable> { call, cause ->
@@ -30,8 +35,8 @@ fun main(args: Array<String>) {
                 update(call.parameters["conf"])
                 call.respond(HttpStatusCode.OK)
             }
-            post("/update/droidconsf") {
-                DroidConSF.import()
+            post("/update-days") {
+                DataStore().updateDays()
                 call.respond(HttpStatusCode.OK)
             }
         }
@@ -49,3 +54,4 @@ private fun update(conf: String?) {
         else -> error("")
     }
 }
+


### PR DESCRIPTION
The default is newest first. Can be changed with 

```graphql
{
  conferences(orderBy: {field: DAYS, direction: ASCENDING}) {
    id
    days
    name
  }
}

```