### PR TITLE
Add timeToFullDisplayMs metric

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.28.0"
-activity-compose = "1.6.1"
+activity-compose = "1.7.0-alpha04"
 androidx-lifecycle = "2.5.1"
 apollo = "3.7.4"
 compose = "1.4.0-alpha04"

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -140,6 +140,7 @@ dependencies {
     implementation(libs.compose.navigation)
     implementation(libs.compose.material.icons.core)
     implementation(libs.compose.material.icons.extended)
+    implementation(libs.activity.compose)
 
     implementation(libs.koin.core)
     implementation(libs.koin.android)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -2,6 +2,9 @@
 
 package dev.johnoreilly.confetti.wear.conferences
 
+import androidx.activity.compose.ReportDrawn
+import androidx.activity.compose.ReportDrawnAfter
+import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentSize
@@ -59,6 +62,10 @@ fun ConferencesView(
     columnState: ScalingLazyColumnState,
     modifier: Modifier = Modifier
 ) {
+    ReportDrawnWhen {
+        conferenceList.isNotEmpty()
+    }
+
     ScalingLazyColumn(
         modifier = modifier.fillMaxSize(), columnState = columnState
     ) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
@@ -2,6 +2,8 @@
 
 package dev.johnoreilly.confetti.wear.sessions
 
+import androidx.activity.compose.ReportDrawn
+import androidx.activity.compose.ReportDrawnAfter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.wear.compose.material.CircularProgressIndicator
@@ -37,6 +39,8 @@ fun SessionListView(
         SessionsUiState.Loading -> CircularProgressIndicator()
 
         is SessionsUiState.Success -> {
+            ReportDrawn()
+
             val sessions = uiState.sessionsByStartTimeList[uiState.confDates.indexOf(date)]
             DaySessionList(date, sessions, sessionSelected, columnState)
         }

--- a/wearBenchmark/src/main/java/dev/johnoreilly/confetti/benchmark/ColdStartupBenchmark.kt
+++ b/wearBenchmark/src/main/java/dev/johnoreilly/confetti/benchmark/ColdStartupBenchmark.kt
@@ -20,5 +20,6 @@ class ColdStartupBenchmark {
         startupMode = StartupMode.COLD
     ) {
         startActivityAndWait()
+        Thread.sleep(2000)
     }
 }


### PR DESCRIPTION
Meaningless numbers from emulator

```
ColdStartupBenchmark_startup
timeToFullDisplayMs   min 519.0,   median 533.3,   max 834.0
timeToInitialDisplayMs   min 445.3,   median 460.3,   max 479.9
Traces: Iteration 0 1 2 3 4
```