### PR TITLE
[RFC] Refactor to make conference un-special

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -41,21 +41,7 @@ class MainActivity : ComponentActivity() {
             val windowSizeClass = calculateWindowSizeClass(this)
             val displayFeatures = calculateDisplayFeatures(this)
 
-            var showLandingScreen by remember {
-                mutableStateOf(repository.getConference().isEmpty())
-            }
-
-            if (showLandingScreen) {
-                ConfettiTheme {
-                    ConfettiBackground {
-                        ConferencesRoute(navigateToConference = { _ ->
-                            showLandingScreen = false
-                        })
-                    }
-                }
-            } else {
-                ConfettiApp(navController, windowSizeClass, displayFeatures)
-            }
+            ConfettiApp(navController, windowSizeClass, displayFeatures)
 
             LaunchedEffect(Unit) {
                 navController.currentBackStackEntryFlow.collect { navEntry ->

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.sessiondetails.SessionDetailsViewModel
 import dev.johnoreilly.confetti.speakerdetails.SpeakerDetailsViewModel
@@ -10,5 +11,5 @@ val appModule = module {
     viewModel { ConfettiViewModel() }
     viewModel { SessionDetailsViewModel(get(), get()) }
     viewModel { SpeakerDetailsViewModel(get(), get()) }
-
+    single { FetchPolicy.CacheAndNetwork }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.kmmbridge).apply(false)
     alias(libs.plugins.google.services).apply(false)
     alias(libs.plugins.firebase.crashlytics).apply(false)
+    alias(libs.plugins.wire).apply(false)
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 accompanist = "0.28.0"
 activity-compose = "1.7.0-alpha04"
 androidx-lifecycle = "2.5.1"
+androidx-datastore = "1.0.0"
 apollo = "3.7.4"
 compose = "1.4.0-alpha05"
 compose-compiler = "1.4.3-dev-k1.8.20-Beta-15b4f4328eb"
@@ -26,6 +27,8 @@ accompanist-pager = { module = "com.google.accompanist:accompanist-pager", versi
 accompanist-pager-indicator = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-benchmarkmacro = "androidx.benchmark:benchmark-macro-junit4:1.1.1"
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidx-datastore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 apollo-adapters = { module = "com.apollographql.apollo3:apollo-adapters" }
 apollo-normalized-cache-in-memory = { module = "com.apollographql.apollo3:apollo-normalized-cache" }
@@ -49,7 +52,7 @@ compose-ui-manifest = { module = "androidx.compose.ui:ui-test-manifest", version
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 fastlane-screengrab = "tools.fastlane:screengrab:2.1.1"
 firebase-analytics = "com.google.firebase:firebase-analytics-ktx:21.2.0"
-firebase-crashlytics = "com.google.firebase:firebase-crashlytics-ktx:18.3.3"
+firebase-crashlytics = "com.google.firebase:firebase-crashlytics-ktx:18.3.4"
 firebase-performance = "com.google.firebase:firebase-perf-ktx:20.3.1"
 google-cloud-datastore = "com.google.cloud:google-cloud-datastore:2.11.0"
 google-services = "com.google.gms:google-services:4.3.15"
@@ -73,6 +76,7 @@ material3-core = { module = "androidx.compose.material3:material3", version.ref 
 material3-window-size = { module = "androidx.compose.material3:material3-window-size-class", version.ref = "compose-material-3" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
+multiplatform-settings-datastore = { module = "com.russhwolf:multiplatform-settings-datastore", version.ref = "multiplatform-settings" }
 okhttp = "com.squareup.okhttp3:okhttp:5.0.0-alpha.11"
 okhttp-coroutines = "com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.11"
 okhttp-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11"
@@ -86,6 +90,7 @@ horologist-base-ui = "com.google.android.horologist:horologist-base-ui:0.3.1"
 horologist-compose-layout = "com.google.android.horologist:horologist-compose-layout:0.3.1"
 horologist-compose-tools = "com.google.android.horologist:horologist-compose-tools:0.3.1"
 horologist-composables = "com.google.android.horologist:horologist-composables:0.3.1"
+horologist-datalayer = "com.google.android.horologist:horologist-datalayer:0.3.1"
 horologist-tiles = "com.google.android.horologist:horologist-tiles:0.3.1"
 test-junit-ktx = "androidx.test.ext:junit-ktx:1.1.5"
 test-runner = "androidx.test:runner:1.5.2"
@@ -98,7 +103,7 @@ multiplatform-settings = ["multiplatform-settings", "multiplatform-settings-coro
 apollo = ["apollo-normalized-cache-in-memory", "apollo-normalized-cache-sqlite", "apollo-adapters"]
 
 [plugins]
-android-application = { id = "com.android.application", version = "7.4.0" }
+android-application = { id = "com.android.application", version = "7.4.1" }
 apollo = { id = "com.apollographql.apollo3", version.ref = "apollo" }
 appengine = { id = "com.google.cloud.tools.appengine", version = "2.4.5" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "2.9.2" }
@@ -110,3 +115,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version = "1.8.20-Beta-1.0.9" }
 spring-boot = { id = "org.springframework.boot", version = "2.5.6" }
+wire = { id = "com.squareup.wire", version = "4.5.1" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.google.devtools.ksp")
     id("com.rickclephas.kmp.nativecoroutines")
     id("co.touchlab.faktory.kmmbridge")
+    id("com.squareup.wire")
 }
 
 version = "1.0"
@@ -36,6 +37,8 @@ kotlin {
     sourceSets {
 
         val commonMain by getting {
+            kotlin.srcDir("$buildDir/generated/source/wire")
+
             dependencies {
                 implementation(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.datetime)
@@ -44,7 +47,7 @@ kotlin {
                 api(libs.koin.core)
 
                 api(libs.apollo.runtime)
-                implementation(libs.bundles.apollo)
+                api(libs.bundles.apollo)
             }
         }
         val commonTest by getting {
@@ -65,6 +68,10 @@ kotlin {
                 implementation(libs.google.services)
                 implementation(libs.firebase.analytics)
                 implementation(libs.compose.navigation)
+
+                api(libs.multiplatform.settings.datastore)
+                api(libs.androidx.datastore)
+                api(libs.androidx.datastore.preferences)
             }
         }
 
@@ -159,4 +166,8 @@ allprojects {
 
 kotlin.sourceSets.all {
     languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
+}
+
+wire {
+    kotlin {}
 }

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/analytics/NavigationHelper.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/analytics/NavigationHelper.kt
@@ -4,12 +4,13 @@ import androidx.navigation.NavBackStackEntry
 
 object NavigationHelper {
     @Suppress("DEPRECATION")
-    fun AnalyticsLogger.logNavigationEvent(conference: String, navEntry: NavBackStackEntry) {
+    fun AnalyticsLogger.logNavigationEvent(navEntry: NavBackStackEntry) {
         if (this == AnalyticsLogger.None) return
 
         val arguments = navEntry.arguments
+        val navArguments = navEntry.destination.arguments
         val loggingArguments: Map<String, String> = buildMap {
-            navEntry.destination.arguments.keys.forEach {
+            navArguments.keys.forEach {
                 val value = arguments?.get(it)
 
                 if (value != null) {
@@ -20,7 +21,7 @@ object NavigationHelper {
 
         logEvent(
             AnalyticsEvent.Navigation(
-                conference,
+                navArguments["conference"] as? String,
                 navEntry.destination.route ?: "none",
                 loggingArguments
             )

--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -14,6 +14,7 @@ query GetConferenceData($first: Int! = 1000, $after: String = null) {
         ...RoomDetails
     }
     config {
+        id,
         name
         timezone
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -1,0 +1,42 @@
+package dev.johnoreilly.confetti
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.normalizedCache
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import dev.johnoreilly.confetti.di.getDatabaseName
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class ApolloClientCache : KoinComponent {
+    val _clients = mutableMapOf<String, ApolloClient>()
+    val mutex = Mutex(false)
+
+    suspend fun getClient(conference: String): ApolloClient {
+        return mutex.withLock {
+            _clients.getOrPut(conference) {
+                clientFor(conference, conference != "all")
+            }
+        }
+    }
+
+    private fun clientFor(
+        conference: String,
+        writeToCacheAsynchronously: Boolean
+    ): ApolloClient {
+        val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(getDatabaseName(conference))
+        val memoryFirstThenSqlCacheFactory = MemoryCacheFactory(10 * 1024 * 1024)
+            .chain(sqlNormalizedCacheFactory)
+
+        return get<ApolloClient.Builder>()
+            .serverUrl("https://graphql-dot-confetti-349319.uw.r.appspot.com/graphql?conference=$conference")
+            //.serverUrl("http://10.0.2.2:8080/graphql?conference=graphqlsummit2022")
+            .normalizedCache(
+                memoryFirstThenSqlCacheFactory,
+                writeToCacheAsynchronously = writeToCacheAsynchronously
+            )
+            .build()
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
@@ -1,25 +1,13 @@
 package dev.johnoreilly.confetti
 
 import com.russhwolf.settings.ExperimentalSettingsApi
-import com.russhwolf.settings.ObservableSettings
-import com.russhwolf.settings.coroutines.getStringOrNullFlow
+import com.russhwolf.settings.coroutines.FlowSettings
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalSettingsApi::class)
-class AppSettings(val settings: ObservableSettings) {
+class AppSettings(val settings: FlowSettings) {
 
-    val enabledLanguages: Flow<Set<String>> =
-        settings.getStringOrNullFlow(ENABLED_LANGUAGES_SETTING).map { getEnabledLanguagesSetFromString(it) }
-
-    init {
-        if (settings.getString(ENABLED_LANGUAGES_SETTING, "").isEmpty()) {
-            settings.putString(ENABLED_LANGUAGES_SETTING, "en-US")
-        }
-    }
-
-
-    fun updateEnableLanguageSetting(language: String, checked: Boolean) {
+    suspend fun updateEnableLanguageSetting(language: String, checked: Boolean) {
         val currentEnabledLanguagesString = settings.getStringOrNull(ENABLED_LANGUAGES_SETTING)
         val currentEnabledLanguagesSet = getEnabledLanguagesSetFromString(currentEnabledLanguagesString)
 
@@ -31,12 +19,20 @@ class AppSettings(val settings: ObservableSettings) {
         settings.putString(ENABLED_LANGUAGES_SETTING, newEnabledLanguagesString.joinToString(separator = ","))
     }
 
-    fun getConference(): String {
-        return settings.getString(CONFERENCE_SETTING, "")
+    suspend fun getConference(): String? {
+        return settings.getStringOrNull(CONFERENCE_SETTING)
     }
 
-    fun setConference(conference: String) {
-        settings.putString(CONFERENCE_SETTING, conference)
+    fun getConferenceFlow(): Flow<String?> {
+        return settings.getStringOrNullFlow(CONFERENCE_SETTING)
+    }
+
+    suspend fun setConference(conference: String?) {
+        if (conference != null) {
+            settings.putString(CONFERENCE_SETTING, conference)
+        } else {
+            settings.remove(CONFERENCE_SETTING)
+        }
     }
 
     private fun getEnabledLanguagesSetFromString(settingsString: String?) =

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -1,141 +1,103 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package dev.johnoreilly.confetti
 
-import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
-import com.apollographql.apollo3.cache.normalized.normalizedCache
-import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
-import dev.johnoreilly.confetti.di.getDatabaseName
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import okio.use
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 import org.koin.core.component.inject
 
-class ConfettiRepository : KoinComponent {
+class ConfettiRepository(private val defaultFetchPolicy: FetchPolicy) : KoinComponent {
     val coroutineScope: CoroutineScope = MainScope()
 
-    private var apolloClient: ApolloClient? = null
     private val appSettings: AppSettings by inject()
 
-    private var refreshJob: Job? = null
+    private val apolloClientCache: ApolloClientCache by inject()
 
-    val conferenceList: Flow<List<GetConferencesQuery.Conference>> = createApolloClient("all", false).use {
-        it.query(GetConferencesQuery()).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()
-            .mapNotNull {
-                println(it)
+    val conferenceList: Flow<List<GetConferencesQuery.Conference>> = flow {
+        val client = apolloClientCache.getClient("all")
+
+        emitAll(client.query(GetConferencesQuery()).fetchPolicy(defaultFetchPolicy)
+            .toFlow().mapNotNull {
                 it.data?.conferences
-            }.catch {
-            // do nothing
+            })
+    }
+
+    // TODO: We fetch the first page only, assuming there are <100 conferences. Pagination should be implemented instead.
+    private fun conferenceQuery(conference: String): Flow<GetConferenceDataQuery.Data?> = flow {
+        emitAll(apolloClientCache.getClient(conference).query(GetConferenceDataQuery())
+            .fetchPolicy(defaultFetchPolicy)
+            .toFlow()
+            .map { it.data })
+    }
+
+    fun conferenceDataFlow(): Flow<GetConferenceDataQuery.Data?> = conferenceFlow().flatMapLatest {
+        if (it != null) {
+            conferenceQuery(it)
+        } else {
+            flowOf(null)
         }
     }
 
-    private val conferenceData = MutableStateFlow<GetConferenceDataQuery.Data?>(null)
+    fun conferenceDataFlow(conference: String): Flow<GetConferenceDataQuery.Data?> =
+        conferenceQuery(conference)
 
-    val timeZone = conferenceData.value?.config?.timezone?.let {
-        TimeZone.of(it)
-    } ?: TimeZone.currentSystemDefault()
-
-    val conferenceName = conferenceData.filterNotNull().map { it.config.name }
-
-    val sessions = conferenceData.filterNotNull().map {
-        it.sessions.nodes.map { it.sessionDetails }.sortedBy { it.startInstant }
-    }
-
-    val sessionsMap: Flow<Map<LocalDate, List<SessionDetails>>> = sessions.map {
-        it.groupBy {
-            it.startInstant.toLocalDateTime(
-                TimeZone.of(
-                    conferenceData.value?.config?.timezone ?: ""
-                )
-            ).date
-        }
-    }
-
-    val speakers = conferenceData.filterNotNull().map {
-        it.speakers.map { it.speakerDetails }
-    }
-
-    val rooms = conferenceData.filterNotNull().map {
-        it.rooms.map { it.roomDetails }
-    }
-
-
-    init {
-        val conference = appSettings.getConference()
-        if (conference.isNotEmpty()) {
-            setConference(conference)
-        }
-    }
-
-    fun getConference(): String {
+    suspend fun getConference(): String? {
         return appSettings.getConference()
     }
 
-    fun setConference(conference: String) {
-        refreshJob?.cancel()
-        conferenceData.value = null
+    fun conferenceFlow(): Flow<String?> {
+        return appSettings.getConferenceFlow()
+    }
+
+    suspend fun setConference(conference: String?) {
         appSettings.setConference(conference)
-
-        apolloClient?.close()
-        apolloClient = createApolloClient(conference)
-
-        refreshJob = coroutineScope.launch {
-            refresh(networkOnly = false)
-        }
     }
 
-    suspend fun getSession(sessionId: String): SessionDetails? {
-        val response = apolloClient?.query(GetSessionQuery(sessionId))?.execute()
-        return response?.data?.session?.sessionDetails
+    suspend fun getSession(conference: String, sessionId: String): SessionDetails? {
+        return apolloClientCache.getClient(conference).query(GetSessionQuery(sessionId))
+            .execute().data?.session?.sessionDetails
     }
 
-    fun updateEnableLanguageSetting(language: String, checked: Boolean) {
+    suspend fun updateEnableLanguageSetting(language: String, checked: Boolean) {
         appSettings.updateEnableLanguageSetting(language, checked)
     }
 
-    suspend fun refresh(networkOnly: Boolean = true) {
-        val fetchPolicy = if (networkOnly) FetchPolicy.NetworkOnly else FetchPolicy.CacheAndNetwork
-
-        // TODO: We fetch the first page only, assuming there are <100 conferences. Pagination should be implemented instead.
-        apolloClient?.let {
-            it.query(GetConferenceDataQuery())
-                .fetchPolicy(fetchPolicy)
-                .toFlow()
-                .catch {
-                    // this can be valid scenario of say offline and we get data from cache initially
-                    // but can't connect to network.  TODO should we surface this somewhere?
-                }.collect {
-                    println("got data, conf name = ${it.data?.config?.name}")
-                    conferenceData.value = it.data
-                }
+    fun refresh() {
+        coroutineScope.launch {
+            val conference = getConference()
+            if (conference != null) {
+                apolloClientCache.getClient(conference).query(
+                    GetConferenceDataQuery()
+                ).fetchPolicy(FetchPolicy.NetworkOnly)
+            }
         }
     }
-
-    private fun createApolloClient(conference: String, writeToCacheAsynchronously: Boolean = true): ApolloClient {
-        val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(getDatabaseName(conference))
-        val memoryFirstThenSqlCacheFactory = MemoryCacheFactory(10 * 1024 * 1024)
-            .chain(sqlNormalizedCacheFactory)
-
-        return get<ApolloClient.Builder>()
-            .serverUrl("https://graphql-dot-confetti-349319.uw.r.appspot.com/graphql?conference=$conference")
-            //.serverUrl("http://10.0.2.2:8080/graphql?conference=graphqlsummit2022")
-            .normalizedCache(memoryFirstThenSqlCacheFactory, writeToCacheAsynchronously = writeToCacheAsynchronously)
-            .build()
-    }
 }
+
+val GetConferenceDataQuery.Data.timeZone
+    get() = config.timezone.let {
+        TimeZone.of(it)
+    } ?: TimeZone.currentSystemDefault()
+
+val GetConferenceDataQuery.Data.sessionsList: List<SessionDetails>
+    get() = sessions.nodes.map { it.sessionDetails }.sortedBy { it.startInstant }
+
+val GetConferenceDataQuery.Data.sessionsMap
+    get() = sessionsList.groupBy {
+        it.startInstant.toLocalDateTime(TimeZone.of(config.timezone)).date
+    }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/analytics/AnalyticsEvent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/analytics/AnalyticsEvent.kt
@@ -4,14 +4,16 @@ interface AnalyticsEvent {
     val id: String
     val properties: Map<String, Any>
 
-    data class Navigation(val conference: String, val route: String?, val arguments: Map<String, String>): AnalyticsEvent {
+    data class Navigation(val conference: String?, val route: String?, val arguments: Map<String, String>): AnalyticsEvent {
         override val id: String = EventId
 
         override val properties: Map<String, Any> = buildMap {
             putAll(arguments)
 
             put(Route, (route ?: "none"))
-            put("conference", conference)
+            if (conference != null) {
+                put("conference", conference)
+            }
         }
 
         companion object {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.ConfettiRepository
 import org.koin.core.context.startKoin
@@ -19,8 +20,9 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
 fun initKoin() = initKoin() {}
 
 fun commonModule() = module {
-    single { ConfettiRepository() }
+    single { ConfettiRepository(get()) }
     single { AppSettings(get()) }
+    single { ApolloClientCache() }
 }
 
 expect fun getDatabaseName(conference: String): String

--- a/shared/src/commonMain/proto/settings.proto
+++ b/shared/src/commonMain/proto/settings.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package com.google.android.horologist.mediasample.domain.proto;
+
+option java_package = "dev.johnoreilly.confetti.proto";
+option java_outer_classname = "SettingsProto";
+
+message Settings {
+  int64 updated_at = 1;
+  string conference = 2;
+}

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.russhwolf.settings.NSUserDefaultsSettings
 import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.coroutines.toFlowSettings
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.utils.IosDateService
 import org.koin.dsl.module
@@ -12,11 +13,10 @@ import platform.Foundation.NSUserDefaults
 
 actual fun platformModule() = module {
     single<ObservableSettings> { NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults) }
+    single { get<ObservableSettings>().toFlowSettings() }
     single<NormalizedCacheFactory> { SqlNormalizedCacheFactory("confetti.db") }
     single<DateService> { IosDateService() }
-    factory {
-        ApolloClient.Builder()
-    }
+    factory { ApolloClient.Builder() }
 }
 
 actual fun getDatabaseName(conference: String) = "$conference.db"

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -4,16 +4,19 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.network.okHttpClient
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.PreferencesSettings
+import com.russhwolf.settings.coroutines.FlowSettings
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.utils.JvmDateService
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import java.util.prefs.Preferences
+import com.russhwolf.settings.coroutines.toFlowSettings
 
 actual fun platformModule() = module {
     single<ObservableSettings> { PreferencesSettings(Preferences.userRoot()) }
+    single { get<ObservableSettings>().toFlowSettings() }
     single<DateService> { JvmDateService() }
-    single<OkHttpClient> {
+    single {
         OkHttpClient.Builder()
             .build()
     }

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -158,6 +158,8 @@ dependencies {
     implementation(libs.horologist.tiles)
     implementation(libs.wear.complications.data)
 
+    implementation(libs.apollo.runtime)
+
     implementation(libs.google.services)
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)

--- a/wearApp/src/androidTest/java/dev/johnoreilly/confetti/wear/ScreenshotTest.kt
+++ b/wearApp/src/androidTest/java/dev/johnoreilly/confetti/wear/ScreenshotTest.kt
@@ -140,7 +140,8 @@ class ScreenshotTest {
         SessionDetailView(
             session = sessionDetails,
             columnState = ScalingLazyColumnDefaults.belowTimeText().create(),
-            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") }
+            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") },
+            timezone = session?.second
         )
     }
 

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
@@ -10,6 +10,7 @@ import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import com.google.android.horologist.tiles.ExperimentalHorologistTilesApi
 import com.google.android.horologist.tiles.complication.DataComplicationService
 import dev.johnoreilly.confetti.ConfettiRepository
+import dev.johnoreilly.confetti.sessionsMap
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
@@ -25,7 +26,7 @@ class NextSessionComplicationService :
 
     override suspend fun data(request: ComplicationRequest): NextSessionComplicationData {
         val today = LocalDate.now().toKotlinLocalDate()
-        val todaysSessions = repository.sessionsMap.first()[today].orEmpty()
+        val todaysSessions = repository.conferenceDataFlow().first()?.sessionsMap?.get(today).orEmpty()
 
         val now = Instant.now().toKotlinInstant()
 

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.wear.di
 
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -8,4 +9,5 @@ import org.koin.dsl.module
 val appModule = module {
     viewModel { ConfettiViewModel() }
     viewModel { SessionDetailsViewModel(get(), get(), get()) }
+    single { FetchPolicy.CacheFirst }
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeListView.kt
@@ -27,7 +27,10 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.sessions.SessionView
+import dev.johnoreilly.confetti.wear.sessions.navigation.ConferenceDateKey
 import dev.johnoreilly.confetti.wear.ui.ConfettiTheme
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewDevices
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewFontSizes
@@ -44,8 +47,8 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun HomeListView(
     uiState: SessionsUiState,
-    sessionSelected: (sessionId: String) -> Unit,
-    daySelected: (sessionId: LocalDate) -> Unit,
+    sessionSelected: (sessionId: SessionDetailsKey) -> Unit,
+    daySelected: (date: ConferenceDateKey) -> Unit,
     onSettingsClick: () -> Unit,
     onRefreshClick: () -> Unit,
     columnState: ScalingLazyColumnState
@@ -65,8 +68,8 @@ fun HomeListView(
 @Composable
 private fun HomeList(
     uiState: SessionsUiState.Success,
-    sessionSelected: (sessionId: String) -> Unit,
-    daySelected: (sessionId: LocalDate) -> Unit,
+    sessionSelected: (SessionDetailsKey) -> Unit,
+    daySelected: (date: ConferenceDateKey) -> Unit,
     onSettingsClick: () -> Unit,
     onRefreshClick: () -> Unit,
     columnState: ScalingLazyColumnState
@@ -92,7 +95,7 @@ private fun HomeList(
                 }
 
                 items(sessions) { session ->
-                    SessionView(session, sessionSelected)
+                    SessionView(uiState.conference, session, sessionSelected)
                 }
             }
         } else {
@@ -114,7 +117,7 @@ private fun HomeList(
             val date = uiState.confDates[it]
             StandardChip(
                 label = dayFormatter.format(date.toJavaLocalDate()),
-                onClick = { daySelected(date) }
+                onClick = { daySelected(ConferenceDateKey(uiState.conference, date)) }
             )
         }
 
@@ -143,8 +146,9 @@ fun HomeListViewPreview() {
     ConfettiTheme {
         HomeListView(
             uiState = SessionsUiState.Success(
+                conference = "wearablecon2022",
                 now = sessionTime.toKotlinLocalDateTime(),
-                "WearableCon 2022",
+                conferenceName = "WearableCon 2022",
                 confDates = listOf(sessionTime.toLocalDate().toKotlinLocalDate()),
                 rooms = listOf(),
                 sessionsByStartTimeList = listOf(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
@@ -9,14 +9,17 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.ConfettiViewModel
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.wear.sessions.navigation.ConferenceDateKey
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun HomeRoute(
-    navigateToSession: (String) -> Unit,
-    navigateToDay: (LocalDate) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
+    navigateToDay: (ConferenceDateKey) -> Unit,
     navigateToSettings: () -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: ConfettiViewModel = getViewModel()
@@ -26,7 +29,7 @@ fun HomeRoute(
 
     HomeListView(
         uiState = uiState,
-        sessionSelected = navigateToSession,
+        sessionSelected = { navigateToSession(it) },
         daySelected = navigateToDay,
         onSettingsClick = navigateToSettings,
         onRefreshClick = {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
@@ -2,24 +2,59 @@
 
 package dev.johnoreilly.confetti.wear.home.navigation
 
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
 import dev.johnoreilly.confetti.wear.home.HomeRoute
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.wear.sessions.navigation.ConferenceDateKey
 import kotlinx.datetime.LocalDate
 
 object HomeDestination : ConfettiNavigationDestination {
-    override val route = "home_route"
+    const val conferenceArg = "conference"
+    override val route = "home_route/{$conferenceArg}"
     override val destination = "home_destination"
+
+    fun createNavigationRoute(conference: String): String {
+        val encodedConference = Uri.encode(conference)
+        return "home_route/$encodedConference"
+    }
+
+    fun fromNavArgs(entry: NavBackStackEntry): String {
+        val arguments = entry.arguments!!
+        return Uri.decode(arguments.getString(SessionDetailsDestination.conferenceArg))
+    }
+
+    fun fromNavArgs(savedStateHandle: SavedStateHandle): String {
+        return Uri.decode(savedStateHandle[SessionDetailsDestination.conferenceArg]!!)
+    }
 }
 
 fun NavGraphBuilder.homeGraph(
-    navigateToSession: (String) -> Unit,
-    navigateToDay: (LocalDate) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
+    navigateToDay: (ConferenceDateKey) -> Unit,
     navigateToSettings: () -> Unit,
 ) {
-    scrollable(route = HomeDestination.route) {
+    scrollable(
+        route = HomeDestination.route,
+        arguments = listOf(
+            navArgument(HomeDestination.conferenceArg) { type = NavType.StringType },
+        ),
+        deepLinks = listOf(
+            navDeepLink {
+                uriPattern =
+                    "confetti://confetti/home/{${HomeDestination.conferenceArg}}}"
+            }
+        )
+    ) {
         HomeRoute(
             navigateToSession = navigateToSession,
             navigateToDay = navigateToDay,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
@@ -36,18 +36,18 @@ fun SessionDetailsRoute(
     viewModel: SessionDetailsViewModel = getViewModel()
 ) {
     val session by viewModel.session.collectAsStateWithLifecycle()
-    val timeZone = remember { viewModel.timeZone }
+    val timezone = session?.second
     SessionDetailView(
-        session = session,
+        session = session?.first,
         columnState = columnState,
-        formatter = { viewModel.formatter.format(it, timeZone, "eeee HH:mm")})
+        formatter = { viewModel.formatter.format(it, timezone!!, "eeee HH:mm") })
 }
 
 @Composable
 fun SessionDetailView(
     session: SessionDetails?,
     columnState: ScalingLazyColumnState,
-    formatter: (Instant) -> String
+    formatter: (Instant) -> String,
 ) {
     val description = session.descriptionParagraphs()
 
@@ -55,7 +55,9 @@ fun SessionDetailView(
         session?.let { session ->
             item {
                 Row(
-                    modifier = Modifier.padding(horizontal = 20.dp).fillMaxWidth()
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp)
+                        .fillMaxWidth()
                 ) {
                     Text(
                         text = session.title,
@@ -108,7 +110,7 @@ fun SessionDetailsLongText() {
                 listOf()
             ),
             columnState = ScalingLazyColumnDefaults.belowTimeText().create(),
-            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") }
+            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") },
         )
     }
 }
@@ -135,7 +137,7 @@ fun SessionDetailsViewPreview() {
                 listOf()
             ),
             columnState = ScalingLazyColumnDefaults.belowTimeText().create(),
-            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") }
+            formatter = { AndroidDateService().format(it, TimeZone.UTC, "eeee HH:mm") },
         )
     }
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
@@ -17,34 +17,44 @@ import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsRoute
 
 object SessionDetailsDestination : ConfettiNavigationDestination {
     const val sessionIdArg = "sessionId"
-    override val route = "session_details_route/{$sessionIdArg}"
+    const val conferenceArg = "conference"
+    override val route = "session_details_route/{$conferenceArg}/{$sessionIdArg}"
     override val destination = "person_details_destination"
 
-    fun createNavigationRoute(sessionId: String): String {
-        val encodedId = Uri.encode(sessionId)
-        return "session_details_route/$encodedId"
+    fun createNavigationRoute(sessionKey: SessionDetailsKey): String {
+        val encodedId = Uri.encode(sessionKey.sessionId)
+        return "session_details_route/${sessionKey.conference}/$encodedId"
     }
 
-    fun fromNavArgs(entry: NavBackStackEntry): String {
-        val encodedId = entry.arguments?.getString(sessionIdArg)!!
-        return Uri.decode(encodedId)
+    fun fromNavArgs(entry: NavBackStackEntry): SessionDetailsKey {
+        val arguments = entry.arguments!!
+        return SessionDetailsKey(
+            arguments.getString(conferenceArg)!!,
+            Uri.decode(arguments.getString(sessionIdArg))
+        )
     }
 
-    fun fromNavArgs(savedStateHandle: SavedStateHandle): String {
-        val encodedId: String = savedStateHandle[sessionIdArg]!!
-        return Uri.decode(encodedId)
+    fun fromNavArgs(savedStateHandle: SavedStateHandle): SessionDetailsKey {
+        return SessionDetailsKey(
+            savedStateHandle[conferenceArg]!!,
+            Uri.decode(savedStateHandle[sessionIdArg]!!)
+        )
     }
 }
+
+data class SessionDetailsKey(val conference: String, val sessionId: String)
 
 fun NavGraphBuilder.sessionDetailsGraph() {
     scrollable(
         route = SessionDetailsDestination.route,
         arguments = listOf(
+            navArgument(SessionDetailsDestination.conferenceArg) { type = NavType.StringType },
             navArgument(SessionDetailsDestination.sessionIdArg) { type = NavType.StringType }
         ),
         deepLinks = listOf(
             navDeepLink {
-                uriPattern = "confetti://confetti/session/{${SessionDetailsDestination.sessionIdArg}}"
+                uriPattern =
+                    "confetti://confetti/session/{${SessionDetailsDestination.conferenceArg}}/{${SessionDetailsDestination.sessionIdArg}}"
             }
         )
     ) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
@@ -9,26 +9,32 @@ import androidx.navigation.navArgument
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.sessions.SessionsRoute
 import kotlinx.datetime.LocalDate
 
 object SessionsDestination : ConfettiNavigationDestination {
     const val dateArg = "date"
-    override val route = "sessions_route/{${dateArg}}"
+    const val conferenceArg = "conference"
+    override val route = "sessions_route/{$conferenceArg}/{${dateArg}}"
     override val destination = "sessions_destination"
 
-    fun createNavigationRoute(date: LocalDate): String {
-        return "sessions_route/$date"
+    fun createNavigationRoute(date: ConferenceDateKey): String {
+        return "sessions_route/${date.conference}/${date.date}"
     }
 
-    fun fromNavArgs(entry: NavBackStackEntry): LocalDate {
+    fun fromNavArgs(entry: NavBackStackEntry): ConferenceDateKey {
+        val arguments = entry.arguments!!
         val dateString = entry.arguments?.getString(dateArg)!!
-        return LocalDate.parse(dateString)
+        return ConferenceDateKey(arguments.getString(SessionDetailsDestination.conferenceArg)!!, LocalDate.parse(dateString))
     }
 }
 
+data class ConferenceDateKey(val conference: String, val date: LocalDate)
+
 fun NavGraphBuilder.sessionsGraph(
-    navigateToSession: (String) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
 ) {
     scrollable(
         route = SessionsDestination.route,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
@@ -15,13 +15,16 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.wear.sessions.navigation.ConferenceDateKey
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun SessionsRoute(
-    date: LocalDate,
-    navigateToSession: (String) -> Unit,
+    date: ConferenceDateKey,
+    navigateToSession: (SessionDetailsKey) -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: ConfettiViewModel = getViewModel()
 ) {
@@ -37,8 +40,9 @@ fun SessionsRoute(
 
 @Composable
 fun SessionView(
+    conference: String,
     session: SessionDetails,
-    sessionSelected: (sessionId: String) -> Unit,
+    sessionSelected: (SessionDetailsKey) -> Unit,
 ) {
     val speakers = session.speakers.joinToString(", ") { it.speakerDetails.name }
     val room = session.room
@@ -48,7 +52,7 @@ fun SessionView(
     } else if (room == null) {
         TitleCard(
             modifier = Modifier.fillMaxWidth(),
-            onClick = { sessionSelected(session.id) },
+            onClick = { sessionSelected(SessionDetailsKey(conference, session.id)) },
             title = { Text(session.title) }
         ) {
             if (speakers.isNotEmpty()) {
@@ -58,7 +62,7 @@ fun SessionView(
     } else {
         TitleCard(
             modifier = Modifier.fillMaxWidth(),
-            onClick = { sessionSelected(session.id) },
+            onClick = { sessionSelected(SessionDetailsKey(conference, session.id)) },
             title = { Text(room.name) }
         ) {
             Text(session.title)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
@@ -16,6 +16,8 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.wear.sessions.navigation.ConferenceDateKey
 import dev.johnoreilly.confetti.wear.ui.ConfettiTheme
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewDevices
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewFontSizes
@@ -30,9 +32,9 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun SessionListView(
-    date: LocalDate,
+    date: ConferenceDateKey,
     uiState: SessionsUiState,
-    sessionSelected: (sessionId: String) -> Unit,
+    sessionSelected: (sessionId: SessionDetailsKey) -> Unit,
     columnState: ScalingLazyColumnState
 ) {
     when (uiState) {
@@ -41,7 +43,7 @@ fun SessionListView(
         is SessionsUiState.Success -> {
             ReportDrawn()
 
-            val sessions = uiState.sessionsByStartTimeList[uiState.confDates.indexOf(date)]
+            val sessions = uiState.sessionsByStartTimeList[uiState.confDates.indexOf(date.date)]
             DaySessionList(date, sessions, sessionSelected, columnState)
         }
     }
@@ -49,9 +51,9 @@ fun SessionListView(
 
 @Composable
 private fun DaySessionList(
-    date: LocalDate,
+    date: ConferenceDateKey,
     sessions: Map<String, List<SessionDetails>>,
-    sessionSelected: (sessionId: String) -> Unit,
+    sessionSelected: (sessionId: SessionDetailsKey) -> Unit,
     columnState: ScalingLazyColumnState
 ) {
     // Monday
@@ -64,7 +66,7 @@ private fun DaySessionList(
             item {
                 ListHeader {
                     if (index == 0) {
-                        Text("${dayFormatter.format(date.toJavaLocalDate())} $time")
+                        Text("${dayFormatter.format(date.date.toJavaLocalDate())} $time")
                     } else {
                         Text(time)
                     }
@@ -72,7 +74,7 @@ private fun DaySessionList(
             }
 
             items(sessions) { session ->
-                SessionView(session, sessionSelected)
+                SessionView(date.conference, session, sessionSelected)
             }
         }
     }
@@ -88,10 +90,11 @@ fun SessionListViewPreview() {
     ConfettiTheme {
         val date = sessionTime.toLocalDate().toKotlinLocalDate()
         SessionListView(
-            date = date,
+            date = ConferenceDateKey("wearablecon2022", date),
             uiState = SessionsUiState.Success(
+                conference = "wearablecon2022",
                 now = sessionTime.toKotlinLocalDateTime(),
-                "WearableCon 2022",
+                conferenceName = "WearableCon 2022",
                 confDates = listOf(date),
                 rooms = listOf(),
                 sessionsByStartTimeList = listOf(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
@@ -25,7 +25,7 @@ fun ConfettiApp(navController: NavHostController) {
         navController.popBackStack()
     }
 
-    WearNavScaffold(startDestination = HomeDestination.route, navController = navController) {
+    WearNavScaffold(startDestination = ConferencesDestination.route, navController = navController) {
         conferencesGraph(
             navigateToConference = {
                 onNavigateToDestination(HomeDestination)


### PR DESCRIPTION
Early draft for discussion.

Changes
- Use non blocking settings API
- Use DataStore<Preferences> as the permanent settings
- Make conference a part of the navigation hierarchy

Context: I was looking at how to sync the Wear conference directly from the Mobile setting.  As part of that, I wanted to have it able to change immediately, and prompt to navigate the user across conferences.  This syncing can be put behind the DataStore API, so I wanted to use that API consistently.  

Before I finish off this, I wanted to check on early feedback, including whether to abandon and rethink the idea. Or split up.

But overall I think it's a nicer design for the app.  Allows linking directly into another conference, say from a push notification. And removes a lot of blocking logic during startup. 