### PR TITLE
Split up SessionDetail ViewModel to use specific query.

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.sessiondetails.SessionDetailsViewModel
 import dev.johnoreilly.confetti.speakerdetails.SpeakerDetailsViewModel
@@ -10,5 +11,9 @@ val appModule = module {
     viewModel { ConfettiViewModel() }
     viewModel { SessionDetailsViewModel(get(), get()) }
     viewModel { SpeakerDetailsViewModel(get(), get()) }
-
+    single {
+        // Assume an online first strategy for Mobile
+        // But use Cache for initial results
+        FetchPolicy.CacheAndNetwork
+    }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
                 api(libs.koin.core)
 
                 api(libs.apollo.runtime)
-                implementation(libs.bundles.apollo)
+                api(libs.bundles.apollo)
             }
         }
         val commonTest by getting {

--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -14,6 +14,7 @@ query GetConferenceData($first: Int! = 1000, $after: String = null) {
         ...RoomDetails
     }
     config {
+        id
         name
         timezone
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -1,0 +1,42 @@
+package dev.johnoreilly.confetti
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.normalizedCache
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import dev.johnoreilly.confetti.di.getDatabaseName
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+class ApolloClientCache : KoinComponent {
+    val _clients = mutableMapOf<String, ApolloClient>()
+    val mutex = Mutex(false)
+
+    suspend fun getClient(conference: String): ApolloClient {
+        return mutex.withLock {
+            _clients.getOrPut(conference) {
+                clientFor(conference, conference != "all")
+            }
+        }
+    }
+
+    private fun clientFor(
+        conference: String,
+        writeToCacheAsynchronously: Boolean
+    ): ApolloClient {
+        val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(getDatabaseName(conference))
+        val memoryFirstThenSqlCacheFactory = MemoryCacheFactory(10 * 1024 * 1024)
+            .chain(sqlNormalizedCacheFactory)
+
+        return get<ApolloClient.Builder>()
+            .serverUrl("https://graphql-dot-confetti-349319.uw.r.appspot.com/graphql?conference=$conference")
+            //.serverUrl("http://10.0.2.2:8080/graphql?conference=graphqlsummit2022")
+            .normalizedCache(
+                memoryFirstThenSqlCacheFactory,
+                writeToCacheAsynchronously = writeToCacheAsynchronously
+            )
+            .build()
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.di
 
+import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.ConfettiRepository
 import org.koin.core.context.startKoin
@@ -19,8 +20,9 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
 fun initKoin() = initKoin() {}
 
 fun commonModule() = module {
-    single { ConfettiRepository() }
+    single { ConfettiRepository(get()) }
     single { AppSettings(get()) }
+    single { ApolloClientCache() }
 }
 
 expect fun getDatabaseName(conference: String): String

--- a/shared/src/jvmMain/kotlin/Main.kt
+++ b/shared/src/jvmMain/kotlin/Main.kt
@@ -1,5 +1,7 @@
+package dev.johnoreilly.confetti
+
 import dev.johnoreilly.confetti.di.initKoin
-import dev.johnoreilly.confetti.ConfettiRepository
+import kotlinx.coroutines.flow.first
 
 suspend fun main() {
     val koin = initKoin().koin
@@ -7,9 +9,8 @@ suspend fun main() {
     repo.setConference("droidconlondon2022")
 
     println("Sessions")
-    repo.sessions.collect { sessions ->
-        sessions.forEach { session ->
-            println("${session.startInstant} ${session.title}")
-        }
+    val sessions = repo.sessions.first()
+    sessions.forEach { session ->
+        println("${session.startInstant} ${session.title}")
     }
 }

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -3,6 +3,7 @@
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.network.okHttpClient
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
@@ -24,6 +25,11 @@ actual fun platformModule() = module {
     }
     factory {
         ApolloClient.Builder().okHttpClient(get())
+    }
+    single {
+        // Assume an online first strategy for Desktop
+        // But use Cache for initial results
+        FetchPolicy.CacheAndNetwork
     }
 }
 

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
@@ -1,0 +1,13 @@
+package dev.johnoreilly.confetti
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class MainTest {
+    @Test
+    fun test() {
+        runBlocking {
+            main()
+        }
+    }
+}

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/navigation/SessionDetailsKey.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/navigation/SessionDetailsKey.kt
@@ -1,0 +1,3 @@
+package dev.johnoreilly.confetti.navigation
+
+data class SessionDetailsKey(val conference: String, val sessionId: String)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
@@ -19,6 +19,7 @@ import dev.johnoreilly.confetti.analytics.AnalyticsLogger
 import dev.johnoreilly.confetti.analytics.NavigationHelper.logNavigationEvent
 import dev.johnoreilly.confetti.wear.conferences.ConferencesRoute
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.ui.ConfettiApp
 import dev.johnoreilly.confetti.wear.ui.ConfettiTheme
 import org.koin.android.ext.android.inject
@@ -53,14 +54,21 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(Unit) {
                 val sessionId = intent.getAndRemoveKey("session")
 
+                val conference = repository.getConference()
+
                 if (sessionId != null && !showLandingScreen) {
-                    navController.navigate(SessionDetailsDestination.createNavigationRoute(sessionId))
+                    navController.navigate(
+                        SessionDetailsDestination.createNavigationRoute(
+                            SessionDetailsKey(conference, sessionId)
+                        )
+                    )
                 }
             }
 
             LaunchedEffect(Unit) {
                 navController.currentBackStackEntryFlow.collect { navEntry ->
-                    analyticsLogger.logNavigationEvent(repository.getConference(), navEntry)
+                    val conference = repository.getConference()
+                    analyticsLogger.logNavigationEvent(conference, navEntry)
                 }
             }
         }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.wear.di
 
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -8,4 +9,9 @@ import org.koin.dsl.module
 val appModule = module {
     viewModel { ConfettiViewModel() }
     viewModel { SessionDetailsViewModel(get(), get(), get()) }
+    single {
+        // Assume an offline first strategy for Wear
+        // Eventually use the mobile to drive updates
+        FetchPolicy.CacheFirst
+    }
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
@@ -9,13 +9,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.ConfettiViewModel
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun HomeRoute(
-    navigateToSession: (String) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
     navigateToDay: (LocalDate) -> Unit,
     navigateToSettings: () -> Unit,
     columnState: ScalingLazyColumnState,
@@ -26,7 +27,9 @@ fun HomeRoute(
 
     HomeListView(
         uiState = uiState,
-        sessionSelected = navigateToSession,
+        sessionSelected = {
+            navigateToSession(SessionDetailsKey(viewModel.savedConference.value, it))
+        },
         daySelected = navigateToDay,
         onSettingsClick = navigateToSettings,
         onRefreshClick = {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
@@ -7,6 +7,7 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
 import com.google.android.horologist.compose.navscaffold.scrollable
 import dev.johnoreilly.confetti.wear.home.HomeRoute
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import kotlinx.datetime.LocalDate
 
 object HomeDestination : ConfettiNavigationDestination {
@@ -15,7 +16,7 @@ object HomeDestination : ConfettiNavigationDestination {
 }
 
 fun NavGraphBuilder.homeGraph(
-    navigateToSession: (String) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
     navigateToDay: (LocalDate) -> Unit,
     navigateToSettings: () -> Unit,
 ) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
@@ -17,34 +17,44 @@ import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsRoute
 
 object SessionDetailsDestination : ConfettiNavigationDestination {
     const val sessionIdArg = "sessionId"
-    override val route = "session_details_route/{$sessionIdArg}"
+    const val conferenceArg = "conference"
+    override val route = "session_details_route/{$conferenceArg}/{$sessionIdArg}"
     override val destination = "person_details_destination"
 
-    fun createNavigationRoute(sessionId: String): String {
-        val encodedId = Uri.encode(sessionId)
-        return "session_details_route/$encodedId"
+    fun createNavigationRoute(sessionKey: SessionDetailsKey): String {
+        val encodedId = Uri.encode(sessionKey.sessionId)
+        return "session_details_route/${sessionKey.conference}/$encodedId"
     }
 
-    fun fromNavArgs(entry: NavBackStackEntry): String {
-        val encodedId = entry.arguments?.getString(sessionIdArg)!!
-        return Uri.decode(encodedId)
+    fun fromNavArgs(entry: NavBackStackEntry): SessionDetailsKey {
+        val arguments = entry.arguments!!
+        return SessionDetailsKey(
+            arguments.getString(conferenceArg)!!,
+            Uri.decode(arguments.getString(sessionIdArg))
+        )
     }
 
-    fun fromNavArgs(savedStateHandle: SavedStateHandle): String {
-        val encodedId: String = savedStateHandle[sessionIdArg]!!
-        return Uri.decode(encodedId)
+    fun fromNavArgs(savedStateHandle: SavedStateHandle): SessionDetailsKey {
+        return SessionDetailsKey(
+            savedStateHandle[conferenceArg]!!,
+            Uri.decode(savedStateHandle[sessionIdArg]!!)
+        )
     }
 }
+
+data class SessionDetailsKey(val conference: String, val sessionId: String)
 
 fun NavGraphBuilder.sessionDetailsGraph() {
     scrollable(
         route = SessionDetailsDestination.route,
         arguments = listOf(
+            navArgument(SessionDetailsDestination.conferenceArg) { type = NavType.StringType },
             navArgument(SessionDetailsDestination.sessionIdArg) { type = NavType.StringType }
         ),
         deepLinks = listOf(
             navDeepLink {
-                uriPattern = "confetti://confetti/session/{${SessionDetailsDestination.sessionIdArg}}"
+                uriPattern =
+                    "confetti://confetti/session/{${SessionDetailsDestination.conferenceArg}}/{${SessionDetailsDestination.sessionIdArg}}"
             }
         )
     ) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
@@ -9,6 +9,7 @@ import androidx.navigation.navArgument
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.sessions.SessionsRoute
 import kotlinx.datetime.LocalDate
 
@@ -28,7 +29,7 @@ object SessionsDestination : ConfettiNavigationDestination {
 }
 
 fun NavGraphBuilder.sessionsGraph(
-    navigateToSession: (String) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
 ) {
     scrollable(
         route = SessionsDestination.route,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
@@ -15,13 +15,14 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun SessionsRoute(
     date: LocalDate,
-    navigateToSession: (String) -> Unit,
+    navigateToSession: (SessionDetailsKey) -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: ConfettiViewModel = getViewModel()
 ) {
@@ -30,7 +31,9 @@ fun SessionsRoute(
     SessionListView(
         date = date,
         uiState = uiState,
-        sessionSelected = navigateToSession,
+        sessionSelected = {
+            navigateToSession(SessionDetailsKey(viewModel.savedConference.value, it))
+        },
         columnState = columnState
     )
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
@@ -9,6 +9,7 @@ import dev.johnoreilly.confetti.wear.home.navigation.HomeDestination
 import dev.johnoreilly.confetti.wear.home.navigation.homeGraph
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.sessionDetailsGraph
 import dev.johnoreilly.confetti.wear.sessions.navigation.SessionsDestination
 import dev.johnoreilly.confetti.wear.sessions.navigation.sessionsGraph
@@ -16,7 +17,9 @@ import dev.johnoreilly.confetti.wear.settings.navigation.SettingsDestination
 import dev.johnoreilly.confetti.wear.settings.navigation.settingsGraph
 
 @Composable
-fun ConfettiApp(navController: NavHostController) {
+fun ConfettiApp(
+    navController: NavHostController
+) {
     fun onNavigateToDestination(destination: ConfettiNavigationDestination, route: String? = null) {
         navController.navigate(route ?: destination.route)
     }


### PR DESCRIPTION
Splitting up ConfettiViewModel, use targetted specific queries.

This isn't very simple yet. Plan

1) Demonstrate this approach incrementally on Wear
a) SessionDetails (this)
b) Session
c) Conference Day
d) Conference

2) Apply to android also

3) Delete ConfettiViewModel, ensure clean navigation with conference in all paths.

Need to land after https://github.com/joreilly/Confetti/pull/255