### PR TITLE
Split up Sessions Screen ViewModel.

### DIFF
--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -20,6 +20,20 @@ query GetConferenceData($first: Int! = 1000, $after: String = null) {
     }
 }
 
+query GetSessions($first: Int! = 1000, $after: String = null) {
+    sessions(first: $first, after: $after) {
+        nodes {
+            ...SessionDetails
+        }
+        pageInfo {
+            endCursor
+        }
+    }
+    config {
+        timezone
+    }
+}
+
 query GetSession($id: String!){
 	session(id: $id) {
 	    ...SessionDetails

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -128,7 +128,12 @@ class ConfettiRepository(
         }
     }
 
-    suspend fun sessionDetails(conference: String, sessionId: String): Flow<ApolloResponse<GetSessionQuery.Data>> {
-        return apolloClientCache.getClient(conference).query(GetSessionQuery(sessionId)).toFlow()
-    }
+    suspend fun sessionDetails(
+        conference: String,
+        sessionId: String
+    ): Flow<ApolloResponse<GetSessionQuery.Data>> =
+        apolloClientCache.getClient(conference).query(GetSessionQuery(sessionId)).toFlow()
+
+    suspend fun sessions(conference: String): Flow<ApolloResponse<GetSessionsQuery.Data>> =
+        apolloClientCache.getClient(conference).query(GetSessionsQuery()).toFlow()
 }

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/navigation/ConferenceDayKey.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/navigation/ConferenceDayKey.kt
@@ -1,0 +1,5 @@
+package dev.johnoreilly.confetti.navigation
+
+import kotlinx.datetime.LocalDate
+
+data class ConferenceDayKey(val conference: String, val date: LocalDate)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
@@ -17,9 +17,9 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.analytics.AnalyticsLogger
 import dev.johnoreilly.confetti.analytics.NavigationHelper.logNavigationEvent
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.conferences.ConferencesRoute
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.ui.ConfettiApp
 import dev.johnoreilly.confetti.wear.ui.ConfettiTheme
 import kotlinx.coroutines.runBlocking

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/homeView.kt
@@ -9,15 +9,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.ConfettiViewModel
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import kotlinx.coroutines.launch
-import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun HomeRoute(
     navigateToSession: (SessionDetailsKey) -> Unit,
-    navigateToDay: (LocalDate) -> Unit,
+    navigateToDay: (ConferenceDayKey) -> Unit,
     navigateToSettings: () -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: ConfettiViewModel = getViewModel()
@@ -30,7 +30,7 @@ fun HomeRoute(
         sessionSelected = {
             navigateToSession(SessionDetailsKey(viewModel.savedConference.value, it))
         },
-        daySelected = navigateToDay,
+        daySelected = { navigateToDay(ConferenceDayKey(viewModel.savedConference.value, it)) },
         onSettingsClick = navigateToSettings,
         onRefreshClick = {
             refreshScope.launch {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/navigation/homeDestination.kt
@@ -5,10 +5,10 @@ package dev.johnoreilly.confetti.wear.home.navigation
 import androidx.navigation.NavGraphBuilder
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.home.HomeRoute
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
-import kotlinx.datetime.LocalDate
 
 object HomeDestination : ConfettiNavigationDestination {
     override val route = "home_route"
@@ -17,7 +17,7 @@ object HomeDestination : ConfettiNavigationDestination {
 
 fun NavGraphBuilder.homeGraph(
     navigateToSession: (SessionDetailsKey) -> Unit,
-    navigateToDay: (LocalDate) -> Unit,
+    navigateToDay: (ConferenceDayKey) -> Unit,
     navigateToSettings: () -> Unit,
 ) {
     scrollable(route = HomeDestination.route) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsViewModel.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsViewModel.kt
@@ -4,19 +4,16 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.johnoreilly.confetti.ConfettiRepository
-import dev.johnoreilly.confetti.analytics.AnalyticsLogger
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 
 class SessionDetailsViewModel(
@@ -31,7 +28,7 @@ class SessionDetailsViewModel(
     val session: StateFlow<SessionDetails?> = flow {
         val resultsFlow = repository.sessionDetails(sessionId.conference, sessionId.sessionId)
 
-        emitAll(resultsFlow.map {  it.data?.session?.sessionDetails })
+        emitAll(resultsFlow.map {  it?.data?.session?.sessionDetails })
     }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/navigation/SessionDetailsDestination.kt
@@ -11,6 +11,7 @@ import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
 import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsRoute
 
@@ -41,8 +42,6 @@ object SessionDetailsDestination : ConfettiNavigationDestination {
         )
     }
 }
-
-data class SessionDetailsKey(val conference: String, val sessionId: String)
 
 fun NavGraphBuilder.sessionDetailsGraph() {
     scrollable(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsViewModel.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsViewModel.kt
@@ -1,0 +1,40 @@
+package dev.johnoreilly.confetti.wear.sessions
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.johnoreilly.confetti.ConfettiRepository
+import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
+import dev.johnoreilly.confetti.wear.sessions.navigation.SessionsDestination
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+class SessionsViewModel(
+    savedStateHandle: SavedStateHandle,
+    repository: ConfettiRepository,
+) : ViewModel() {
+    private val conferenceDay: ConferenceDayKey =
+        SessionsDestination.fromNavArgs(savedStateHandle)
+
+    val session: StateFlow<List<SessionDetails>?> = flow {
+        val resultsFlow = repository.sessions(conferenceDay.conference)
+
+        val sessions = resultsFlow
+            .map {
+                val timeZone = TimeZone.of(it.dataAssertNoErrors.config.timezone!!)
+                val sessionList = it.dataAssertNoErrors.sessions.nodes.map { it.sessionDetails }
+                sessionList.filter {
+                    it.startInstant.toLocalDateTime(timeZone).date == conferenceDay.date
+                }
+            }
+        emitAll(sessions)
+    }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/navigation/sessionsDestination.kt
@@ -2,29 +2,42 @@
 
 package dev.johnoreilly.confetti.wear.sessions.navigation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import com.google.android.horologist.compose.navscaffold.scrollable
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
+import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
 import dev.johnoreilly.confetti.wear.sessions.SessionsRoute
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toLocalDate
 
 object SessionsDestination : ConfettiNavigationDestination {
     const val dateArg = "date"
-    override val route = "sessions_route/{${dateArg}}"
+    const val conferenceArg = "conference"
+    override val route = "sessions_route/{$conferenceArg}/{${dateArg}}"
     override val destination = "sessions_destination"
 
-    fun createNavigationRoute(date: LocalDate): String {
-        return "sessions_route/$date"
+    fun createNavigationRoute(date: ConferenceDayKey): String {
+        return "sessions_route/${date.conference}/${date.date}"
     }
 
-    fun fromNavArgs(entry: NavBackStackEntry): LocalDate {
+    fun fromNavArgs(entry: NavBackStackEntry): ConferenceDayKey {
+        val arguments = entry.arguments!!
         val dateString = entry.arguments?.getString(dateArg)!!
-        return LocalDate.parse(dateString)
+        return ConferenceDayKey(arguments.getString(SessionDetailsDestination.conferenceArg)!!, LocalDate.parse(dateString))
+    }
+
+    fun fromNavArgs(savedStateHandle: SavedStateHandle): ConferenceDayKey {
+        return ConferenceDayKey(
+            savedStateHandle[SessionsDestination.conferenceArg]!!,
+            savedStateHandle.get<String>(SessionsDestination.dateArg)!!.toLocalDate()
+        )
     }
 }
 

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionView.kt
@@ -15,13 +15,13 @@ import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistC
 import dev.johnoreilly.confetti.ConfettiViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isBreak
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
-import kotlinx.datetime.LocalDate
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
+import dev.johnoreilly.confetti.navigation.SessionDetailsKey
 import org.koin.androidx.compose.getViewModel
 
 @Composable
 fun SessionsRoute(
-    date: LocalDate,
+    date: ConferenceDayKey,
     navigateToSession: (SessionDetailsKey) -> Unit,
     columnState: ScalingLazyColumnState,
     viewModel: ConfettiViewModel = getViewModel()

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/sessionsListView.kt
@@ -3,7 +3,6 @@
 package dev.johnoreilly.confetti.wear.sessions
 
 import androidx.activity.compose.ReportDrawn
-import androidx.activity.compose.ReportDrawnAfter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.wear.compose.material.CircularProgressIndicator
@@ -16,10 +15,10 @@ import com.google.android.horologist.compose.layout.ScalingLazyColumnState
 import com.google.android.horologist.compose.navscaffold.ExperimentalHorologistComposeLayoutApi
 import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.navigation.ConferenceDayKey
 import dev.johnoreilly.confetti.wear.ui.ConfettiTheme
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewDevices
 import dev.johnoreilly.confetti.wear.ui.previews.WearPreviewFontSizes
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
@@ -30,7 +29,7 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun SessionListView(
-    date: LocalDate,
+    date: ConferenceDayKey,
     uiState: SessionsUiState,
     sessionSelected: (sessionId: String) -> Unit,
     columnState: ScalingLazyColumnState
@@ -41,7 +40,7 @@ fun SessionListView(
         is SessionsUiState.Success -> {
             ReportDrawn()
 
-            val sessions = uiState.sessionsByStartTimeList[uiState.confDates.indexOf(date)]
+            val sessions = uiState.sessionsByStartTimeList[uiState.confDates.indexOf(date.date)]
             DaySessionList(date, sessions, sessionSelected, columnState)
         }
     }
@@ -49,7 +48,7 @@ fun SessionListView(
 
 @Composable
 private fun DaySessionList(
-    date: LocalDate,
+    date: ConferenceDayKey,
     sessions: Map<String, List<SessionDetails>>,
     sessionSelected: (sessionId: String) -> Unit,
     columnState: ScalingLazyColumnState
@@ -64,7 +63,7 @@ private fun DaySessionList(
             item {
                 ListHeader {
                     if (index == 0) {
-                        Text("${dayFormatter.format(date.toJavaLocalDate())} $time")
+                        Text("${dayFormatter.format(date.date.toJavaLocalDate())} $time")
                     } else {
                         Text(time)
                     }
@@ -88,7 +87,7 @@ fun SessionListViewPreview() {
     ConfettiTheme {
         val date = sessionTime.toLocalDate().toKotlinLocalDate()
         SessionListView(
-            date = date,
+            date = ConferenceDayKey("wearconf", date),
             uiState = SessionsUiState.Success(
                 now = sessionTime.toKotlinLocalDateTime(),
                 "WearableCon 2022",

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
@@ -9,7 +9,6 @@ import dev.johnoreilly.confetti.wear.home.navigation.HomeDestination
 import dev.johnoreilly.confetti.wear.home.navigation.homeGraph
 import dev.johnoreilly.confetti.wear.navigation.ConfettiNavigationDestination
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsDestination
-import dev.johnoreilly.confetti.wear.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.wear.sessiondetails.navigation.sessionDetailsGraph
 import dev.johnoreilly.confetti.wear.sessions.navigation.SessionsDestination
 import dev.johnoreilly.confetti.wear.sessions.navigation.sessionsGraph


### PR DESCRIPTION
Step 2.

I suspect caching for this won't make sense until I stop using ConfettiViewModel with it's uber query, and change to a refresh that queries Sessions, Rooms and Speakers in matching queries.

But pulling a thread and seeing where it goes.