### PR TITLE
Simplify ConfettiRepository

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import okio.IOException
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/shared/src/jvmMain/kotlin/Main.kt
+++ b/shared/src/jvmMain/kotlin/Main.kt
@@ -12,9 +12,6 @@ fun main(args: Array<String>) = runBlocking {
     val clientCache = koin.get<ApolloClientCache>()
 
     repo.setConference("droidconlondon2022")
-    launch {
-        repo.initOnce()
-    }
 
     println("Sessions")
     val sessions = repo.sessions.first()

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -60,21 +60,10 @@ open class ConfettiViewModel : KMMViewModel(), KoinComponent {
     val speakers = repository.speakers
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
-
-    @NativeCoroutinesState
-    val savedConference = MutableStateFlow(viewModelScope,
-        runBlocking {
-            // TODO refactor to avoid needing this so early
-            repository.getConference()
-        }
-    )
-
     fun setConference(conference: String) {
         viewModelScope.coroutineScope.launch {
             repository.setConference(conference)
-            savedConference.value = conference
         }
-        conferenceRefresher.refresh(conference)
     }
 
     fun clearConference() {

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -23,11 +23,15 @@ open class ConfettiViewModel : KMMViewModel(), KoinComponent {
     private val dateService: DateService by inject()
 
     fun addBookmark(sessionId: String) {
-        repository.addBookmark(sessionId)
+        viewModelScope.coroutineScope.launch {
+            repository.addBookmark(sessionId)
+        }
     }
 
     fun removeBookmark(sessionId: String) {
-        repository.removeBookmark(sessionId)
+        viewModelScope.coroutineScope.launch {
+            repository.removeBookmark(sessionId)
+        }
     }
 
     private val conferenceRefresher: ConferenceRefresh by inject()

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -33,12 +33,6 @@ open class ConfettiViewModel : KMMViewModel(), KoinComponent {
         emptyList()
     )
 
-    init {
-        viewModelScope.coroutineScope.launch {
-            repository.initOnce()
-        }
-    }
-
     @NativeCoroutinesState
     val uiState: StateFlow<SessionsUiState> =
         combine(

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -1,7 +1,6 @@
 package dev.johnoreilly.confetti
 
 import com.rickclephas.kmm.viewmodel.KMMViewModel
-import com.rickclephas.kmm.viewmodel.MutableStateFlow
 import com.rickclephas.kmm.viewmodel.coroutineScope
 import com.rickclephas.kmm.viewmodel.stateIn
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
@@ -13,7 +12,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import org.koin.core.component.KoinComponent

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/ConfettiViewModel.kt
@@ -58,6 +58,11 @@ open class ConfettiViewModel : KMMViewModel(), KoinComponent {
     val speakers = repository.speakers
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
+
+    @NativeCoroutinesState
+    val savedConference = repository.getConferenceFlow()
+        .stateIn(viewModelScope, started = SharingStarted.Lazily, "")
+
     fun setConference(conference: String) {
         viewModelScope.coroutineScope.launch {
             repository.setConference(conference)

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/JobConferenceRefresh.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/JobConferenceRefresh.kt
@@ -17,7 +17,7 @@ class JobConferenceRefresh(
 
         if (conference.isNotEmpty()) {
             refreshJob = coroutineScope.launch {
-                confettiRepository.refresh(networkOnly = false)
+                confettiRepository.refresh(conference, networkOnly = false)
             }
         }
     }


### PR DESCRIPTION
Remove state from ConfettiRepository.

It does cause a delay after switching conference, while refresh is happening.