### PR TITLE
Use Koin's Constructor DSL

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
@@ -1,6 +1,5 @@
 package dev.johnoreilly.confetti.di
 
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.AppViewModel
 import dev.johnoreilly.confetti.ConferenceRefresh
 import dev.johnoreilly.confetti.ConferencesViewModel
@@ -11,26 +10,21 @@ import dev.johnoreilly.confetti.account.Authentication
 import dev.johnoreilly.confetti.sessiondetails.SessionDetailsViewModel
 import dev.johnoreilly.confetti.speakerdetails.SpeakerDetailsViewModel
 import dev.johnoreilly.confetti.work.WorkManagerConferenceRefresh
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 
 val appModule = module {
-    viewModel { SessionsViewModel() }
-    viewModel { AppViewModel() }
-    viewModel { ConferencesViewModel() }
-    viewModel { SpeakersViewModel() }
-    viewModel { SessionDetailsViewModel(get(), get()) }
-    viewModel { SpeakerDetailsViewModel(get(), get()) }
-    single<ConferenceRefresh> { WorkManagerConferenceRefresh(get()) }
+    viewModelOf(::SessionsViewModel)
+    viewModelOf(::AppViewModel)
+    viewModelOf(::ConferencesViewModel)
+    viewModelOf(::SpeakersViewModel)
+    viewModelOf(::SessionDetailsViewModel)
+    viewModelOf(::SpeakerDetailsViewModel)
 
-    single {
-        Authentication()
-    }
-    single<TokenProvider> {
-        object : TokenProvider {
-            override suspend fun token(forceRefresh: Boolean): String? {
-                return get<Authentication>().idToken(forceRefresh)
-            }
-        }
-    }
+    singleOf(::WorkManagerConferenceRefresh).withOptions { bind<ConferenceRefresh>() }
+    singleOf(::Authentication)
+    single { TokenProvider { forceRefresh -> get<Authentication>().idToken(forceRefresh) } }
 }

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -23,11 +23,15 @@ import dev.johnoreilly.confetti.work.RefreshWorker
 import okhttp3.OkHttpClient
 import okhttp3.logging.LoggingEventListener
 import org.koin.android.ext.koin.androidContext
-import org.koin.androidx.workmanager.dsl.worker
+import org.koin.androidx.workmanager.dsl.workerOf
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.new
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
-    single<DateService> { AndroidDateService() }
+    singleOf(::AndroidDateService).withOptions { bind<DateService>() }
     single<OkHttpClient> {
         OkHttpClient.Builder()
             .apply {
@@ -52,11 +56,9 @@ actual fun platformModule() = module {
         }
     }
     single { androidContext().settingsStore }
-    single<FlowSettings> { DataStoreSettings(get()) }
-    single {
-        get<FlowSettings>().toBlockingObservableSettings()
-    }
-    worker { RefreshWorker(get(), get(), get(), get()) }
+    single<FlowSettings> { new(::DataStoreSettings) }
+    single { get<FlowSettings>().toBlockingObservableSettings() }
+    workerOf(::RefreshWorker)
     single { WorkManager.getInstance(androidContext()) }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -19,6 +19,17 @@ interface TokenProvider {
     suspend fun token(forceRefresh: Boolean): String?
 }
 
+/**
+ * A factory function which creates an anonymous instance for [TokenProvider] where [getToken] is
+ * used when [TokenProvider.token] is invoked.
+ */
+inline fun TokenProvider(
+    crossinline getToken: suspend (forceRefresh: Boolean) -> String?,
+): TokenProvider =
+    object : TokenProvider {
+        override suspend fun token(forceRefresh: Boolean): String? = getToken(forceRefresh)
+    }
+
 class ApolloClientCache : KoinComponent {
     val _clients = mutableMapOf<String, ApolloClient>()
     val mutex = Mutex(false)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -9,6 +9,7 @@ import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.TokenProvider
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.module
 
@@ -16,7 +17,7 @@ expect fun platformModule(): Module
 
 fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
     startKoin {
-        modules(commonModule(), platformModule())
+        modules(commonModule())
         appDeclaration()
     }
 
@@ -24,16 +25,12 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
 fun initKoin() = initKoin() {}
 
 fun commonModule() = module {
-    single { ConfettiRepository() }
-    single { AppSettings(get()) }
-    single { ApolloClientCache() }
-    single<TokenProvider> {
-        object : TokenProvider {
-            override suspend fun token(forceRefresh: Boolean): String? {
-                return null
-            }
-        }
-    }
+    includes(platformModule())
+
+    singleOf(::ConfettiRepository)
+    singleOf(::AppSettings)
+    singleOf(::ApolloClientCache)
+    single { TokenProvider { null } }
 }
 
 expect fun getDatabaseName(conference: String): String

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -3,17 +3,17 @@
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.NSUserDefaultsSettings
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.coroutines.toFlowSettings
-import dev.johnoreilly.confetti.ConferenceRefresh
-import dev.johnoreilly.confetti.JobConferenceRefresh
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.utils.IosDateService
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 import platform.Foundation.NSUserDefaults
 
@@ -21,7 +21,7 @@ actual fun platformModule() = module {
     single<ObservableSettings> { NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults) }
     single { get<ObservableSettings>().toFlowSettings() }
     single<NormalizedCacheFactory> { SqlNormalizedCacheFactory("confetti.db") }
-    single<DateService> { IosDateService() }
+    singleOf(::IosDateService).withOptions { bind<DateService>() }
     factory {
         ApolloClient.Builder()
     }

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -11,13 +11,16 @@ import com.russhwolf.settings.coroutines.toFlowSettings
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.utils.JvmDateService
 import okhttp3.OkHttpClient
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 import java.util.prefs.Preferences
 
 actual fun platformModule() = module {
     single<ObservableSettings> { PreferencesSettings(Preferences.userRoot()) }
     single { get<ObservableSettings>().toFlowSettings() }
-    single<DateService> { JvmDateService() }
+    singleOf(::JvmDateService).withOptions { bind<DateService>() }
     single<OkHttpClient> {
         OkHttpClient.Builder()
             .build()

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -3,10 +3,10 @@
 package dev.johnoreilly.confetti.wear.di
 
 import android.content.Context
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.horologist.auth.data.ExperimentalHorologistAuthDataApi
+import com.google.android.horologist.auth.data.googlesignin.GoogleSignInEventListener
 import com.google.android.horologist.auth.ui.ExperimentalHorologistAuthUiApi
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel
@@ -20,21 +20,24 @@ import dev.johnoreilly.confetti.wear.settings.SettingsViewModel
 import dev.johnoreilly.confetti.wear.auth.ConfettiGoogleSignOutViewModel
 import dev.johnoreilly.confetti.wear.speakerdetails.SpeakerDetailsViewModel
 import dev.johnoreilly.confetti.work.WorkManagerConferenceRefresh
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 
 @OptIn(ExperimentalHorologistAuthDataApi::class, ExperimentalHorologistAuthUiApi::class)
 val appModule = module {
-    viewModel { SessionDetailsViewModel(get(), get(), get()) }
-    viewModel { SpeakerDetailsViewModel(get(), get()) }
-    viewModel { ConferencesViewModel(get(), get(), get()) }
-    viewModel { SessionsViewModel(get(), get()) }
-    viewModel { HomeViewModel(get(), get(), get()) }
-    viewModel { SettingsViewModel(get(), get()) }
-    viewModel { GoogleSignInViewModel(get(), get<GoogleSignInAuthUserRepository>()) }
-    viewModel { SignInPromptViewModel(get()) }
-    viewModel { ConfettiGoogleSignOutViewModel(get()) }
+    viewModelOf(::SessionDetailsViewModel)
+    viewModelOf(::SpeakerDetailsViewModel)
+    viewModelOf(::ConferencesViewModel)
+    viewModelOf(::SessionsViewModel)
+    viewModelOf(::HomeViewModel)
+    viewModelOf(::SettingsViewModel)
+    viewModelOf(::SignInPromptViewModel)
+    viewModelOf(::ConfettiGoogleSignOutViewModel)
+    viewModelOf(::GoogleSignInViewModel)
     single { GoogleSignIn.getClient(get<Context>(), GoogleSignInOptions.DEFAULT_SIGN_IN) }
-    single { GoogleSignInAuthUserRepository(get(), get()) }
-    single<ConferenceRefresh> { WorkManagerConferenceRefresh(get()) }
+    singleOf(::GoogleSignInAuthUserRepository).withOptions { bind<GoogleSignInEventListener>() }
+    singleOf(::WorkManagerConferenceRefresh).withOptions { bind<ConferenceRefresh>() }
 }


### PR DESCRIPTION
Koin's constructor DSL reduces boilerplate by:
1. Removing the need to directly call `get()` for each parameter;
2. Allowing classes to evolve and change their constructor without requiring them to change their binding manually;
3. The previous two points reduce the chance of human error, as there is less code to update once a class's constructor changes.

For more details about the Constructor DSL, please refer to: https://insert-koin.io/docs/reference/koin-core/dsl-update