### PR TITLE
Add Apollo Sandbox and GraphQL playground as alternate IDEs

### DIFF
--- a/landing-page/public/index.html
+++ b/landing-page/public/index.html
@@ -3,7 +3,7 @@
 
 	<head>
 		<meta charset="utf-8">
-		<title>SIMPLE - Landing Page</title>
+		<title>Confetti 🎊</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=Edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="keywords" content="">

--- a/landing-page/public/playground/index.html
+++ b/landing-page/public/playground/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset=utf-8/>
+    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <title>Confetti Playground</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+    <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+
+<body>
+<div id="root">
+    <style>
+      body {
+        background-color: rgb(23, 42, 58);
+        font-family: Open Sans, sans-serif;
+        height: 90vh;
+      }
+
+      #root {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .loading {
+        font-size: 32px;
+        font-weight: 200;
+        color: rgba(255, 255, 255, .6);
+        margin-left: 20px;
+      }
+
+      img {
+        width: 78px;
+        height: 78px;
+      }
+
+      .title {
+        font-weight: 400;
+      }
+    </style>
+    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    <div class="loading"> Loading
+        <span class="title">GraphQL Playground</span>
+    </div>
+</div>
+<script>window.addEventListener('load', function (event) {
+      GraphQLPlayground.init(document.getElementById('root'), {
+        endpoint: "https://confetti-app.dev/graphql"
+      })
+    })</script>
+</body>
+
+</html>

--- a/landing-page/public/sandbox/index.html
+++ b/landing-page/public/sandbox/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" style="display:table;width:100%;height:100%;">
+
+<head>
+    <meta charset="utf-8">
+    <title>Coneftti sandbox</title>
+</head>
+
+<body style="height: 100%; display:table-cell;">
+<div style="width: 100%; height: 100%;" id='embedded-sandbox'></div>
+<script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
+<script>
+  new window.EmbeddedSandbox({
+    target: '#embedded-sandbox',
+    initialEndpoint: 'https://confetti-app.dev/graphql',
+  });
+</script>
+</body>
+
+</html>
+


### PR DESCRIPTION
This way you can choose your GraphQL IDE of choice

## https://confetti-app.dev/graphiql
<img width="1799" alt="Screenshot 2023-03-19 at 23 27 58" src="https://user-images.githubusercontent.com/3974977/226213855-91865499-b5f3-42da-a41e-a3c7d72a7bf2.png">

## https://confetti-app.dev/playground
<img width="1799" alt="Screenshot 2023-03-19 at 23 27 44" src="https://user-images.githubusercontent.com/3974977/226213858-a73bae04-fe33-49f4-ad47-4e2a0e5446b6.png">

## https://confetti-app.dev/sandbox
![Screenshot 2023-03-19 at 18 45 15](https://user-images.githubusercontent.com/3974977/226213863-348d8f2b-02f2-49cd-8fcf-39478985b9aa.png)
