### PR TITLE
GraphQL: always send cache-control values

### DIFF
--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/CacheControlInstrumentation.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/CacheControlInstrumentation.kt
@@ -14,10 +14,10 @@ import net.mbonnin.bare.graphql.cast
 import java.util.concurrent.CompletableFuture
 
 class CacheControlInstrumentation : Instrumentation {
-    class MyState(val headers: MutableMap<String, String>) : InstrumentationState
+    class MyState(var maxAge: Int) : InstrumentationState
 
     override fun createState(parameters: InstrumentationCreateStateParameters?): InstrumentationState? {
-        return MyState(mutableMapOf())
+        return MyState(1800)
     }
 
     override fun beginField(
@@ -28,10 +28,7 @@ class CacheControlInstrumentation : Instrumentation {
         when {
              conference == "test" ||
                 parameters.field.name == "bookmarks" -> {
-                state.cast<MyState>().headers.put(
-                    "Cache-Control",
-                    "no-store"
-                )
+                state.cast<MyState>().maxAge = 0
             }
         }
         return super.beginField(parameters, state)!!
@@ -45,7 +42,7 @@ class CacheControlInstrumentation : Instrumentation {
 
         return CompletableFuture.completedFuture(
             executionResult.cast<ExecutionResultImpl>().transform {
-                it.addExtension("headers", state.cast<MyState>().headers)
+                it.addExtension("maxAge", state.cast<MyState>().maxAge)
             })
     }
 }

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
@@ -254,15 +254,18 @@ class DefaultApplication {
                 }
                 val headers = mutableMapOf<String, String>()
                 if (graphQLResponse is GraphQLResponse<*>) {
-                    headers.putAll(
-                        graphQLResponse.extensions?.get("headers")?.cast<Map<String, String>>()
-                            ?: emptyMap()
-                    )
+                    var maxAge = graphQLResponse.extensions?.get("maxAge")?.cast<Int>() ?: 0
                     if (!graphQLResponse.canBeCached()) {
-                        headers.put("Cache-Control", "no-store")
+                        maxAge = 0
                     }
 
-                    var newExtensions: Map<Any, Any?>? = graphQLResponse.extensions?.filterNot { it.key == "headers" }
+                    if (maxAge == 0) {
+                        headers.put("Cache-Control", "no-store")
+                    } else {
+                        headers.put("Cache-Control", "public, max-age=$maxAge")
+                    }
+
+                    var newExtensions: Map<Any, Any?>? = graphQLResponse.extensions?.filterNot { it.key == "maxAge" }
                     if (newExtensions?.isEmpty() == true) {
                         newExtensions = null
                     }


### PR DESCRIPTION
Turns out [the CDN wasn't looking at Cache-Control headers](https://console.cloud.google.com/net-services/cdn/backendService/edit/backend-graphql/loadbalancer1?project=confetti-349319):

<img width="529" alt="Screenshot 2023-03-20 at 00 18 26" src="https://user-images.githubusercontent.com/3974977/226218907-e5f31b8a-b22e-4c07-9465-77d2a6787b2c.png">

I've changed the header so that now the CDN always looks at the origin headers (option #2 above) and therefore we need to send something all the time. See https://github.com/joreilly/Confetti/issues/307