### PR TITLE
Use the OSS snapshot repository only for Apollo

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,10 +2,6 @@
 pluginManagement {
     listOf(repositories, dependencyResolutionManagement.repositories).forEach {
         it.apply {
-            // For Apollo Kotlin snapshots
-            maven {
-                url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            }
             mavenCentral()
             google()
             maven("https://androidx.dev/storage/compose-compiler/repository")
@@ -17,6 +13,16 @@ pluginManagement {
                 url = uri("https://jitpack.io")
                 content {
                     includeGroup("com.github.QuickBirdEng.kotlin-snapshot-testing")
+                }
+            }
+            exclusiveContent {
+                forRepository {
+                    maven {
+                        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    }
+                }
+                filter {
+                    includeGroup("com.apollographql.apollo3")
                 }
             }
         }


### PR DESCRIPTION
Avoid resolving other dependencies in SNAPSHOTs as it's not very reliable (see https://github.com/joreilly/Confetti/actions/runs/4484732035/jobs/7885536636?pr=383) and not reproducible.