### PR TITLE
Make AccountIcon composable less stateful

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
@@ -46,9 +46,7 @@ fun AccountIcon(
         onShowSettings = onShowSettings,
         installOnWear = viewModel::installOnWear,
         updateWearTheme = viewModel::updateWearTheme,
-        user = accountUiState.user,
-        showInstallOnWear = accountUiState.showInstallOnWear,
-        isInstalledOnWear = accountUiState.isInstalledOnWear
+        uiState = accountUiState
     )
 }
 
@@ -57,14 +55,13 @@ private fun AccountIcon(
     onSwitchConference: () -> Unit,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
+    onShowSettings: () -> Unit,
     updateWearTheme: () -> Unit,
     installOnWear: () -> Unit,
-    onShowSettings: () -> Unit,
-    user: User?,
-    showInstallOnWear: Boolean,
-    isInstalledOnWear: Boolean
+    uiState: UiState,
 ) {
     var showMenu by remember { mutableStateOf(false) }
+    val user = uiState.user
 
     IconButton(onClick = { showMenu = !showMenu }) {
         when {
@@ -124,7 +121,7 @@ private fun AccountIcon(
                 onShowSettings()
             }
         )
-        if (showInstallOnWear) {
+        if (uiState.showInstallOnWear) {
             DropdownMenuItem(
                 text = { Text("Install on Wear") },
                 onClick = {
@@ -133,7 +130,7 @@ private fun AccountIcon(
                 }
             )
         }
-        if (isInstalledOnWear) {
+        if (uiState.isInstalledOnWear) {
             DropdownMenuItem(
                 text = { Text("Update Wear Theme") },
                 onClick = {
@@ -149,6 +146,7 @@ private fun AccountIcon(
 @Preview(uiMode = UI_MODE_NIGHT_NO, name = "light theme")
 @Composable
 private fun AccountIconPreview() {
+    val accountUiState = UiState()
     ConfettiTheme {
         Surface {
             AccountIcon(
@@ -157,10 +155,8 @@ private fun AccountIconPreview() {
                 onSignOut = {},
                 updateWearTheme = {},
                 installOnWear = {},
-                user = null,
-                showInstallOnWear = false,
-                isInstalledOnWear = false,
-                onShowSettings = {}
+                onShowSettings = {},
+                uiState = accountUiState
             )
         }
     }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti.account
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
@@ -8,8 +10,10 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -17,9 +21,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import dev.johnoreilly.confetti.ui.ConfettiTheme
 import org.koin.androidx.compose.getViewModel
 
 @Composable
@@ -30,10 +35,36 @@ fun AccountIcon(
     onShowSettings: () -> Unit,
     viewModel: AccountViewModel = getViewModel()
 ) {
-    var showMenu by remember { mutableStateOf(false) }
+    val accountUiState = viewModel.uiState.collectAsState().value
+    AccountIcon(
+        onSwitchConference = onSwitchConference,
+        onSignIn = onSignIn,
+        onSignOut = {
+            viewModel.signOut()
+            onSignOut()
+        },
+        onShowSettings = onShowSettings,
+        installOnWear = viewModel::installOnWear,
+        updateWearTheme = viewModel::updateWearTheme,
+        user = accountUiState.user,
+        showInstallOnWear = accountUiState.showInstallOnWear,
+        isInstalledOnWear = accountUiState.isInstalledOnWear
+    )
+}
 
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val user = uiState.user
+@Composable
+private fun AccountIcon(
+    onSwitchConference: () -> Unit,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    updateWearTheme: () -> Unit,
+    installOnWear: () -> Unit,
+    onShowSettings: () -> Unit,
+    user: User?,
+    showInstallOnWear: Boolean,
+    isInstalledOnWear: Boolean
+) {
+    var showMenu by remember { mutableStateOf(false) }
 
     IconButton(onClick = { showMenu = !showMenu }) {
         when {
@@ -47,9 +78,11 @@ fun AccountIcon(
                         .clip(androidx.compose.foundation.shape.CircleShape)
                 )
             }
+
             user != null -> {
                 Icon(Icons.Filled.AccountCircle, contentDescription = "menu")
             }
+
             else -> {
                 Icon(Icons.Outlined.AccountCircle, contentDescription = "menu")
             }
@@ -65,7 +98,6 @@ fun AccountIcon(
                 text = { Text("Sign out") },
                 onClick = {
                     onSignOut()
-                    viewModel.signOut()
                     showMenu = false
                 }
             )
@@ -92,22 +124,43 @@ fun AccountIcon(
                 onShowSettings()
             }
         )
-        if (uiState.showInstallOnWear) {
+        if (showInstallOnWear) {
             DropdownMenuItem(
                 text = { Text("Install on Wear") },
                 onClick = {
                     showMenu = false
-                    viewModel.installOnWear()
+                    installOnWear()
                 }
             )
         }
-        if (uiState.isInstalledOnWear) {
+        if (isInstalledOnWear) {
             DropdownMenuItem(
                 text = { Text("Update Wear Theme") },
                 onClick = {
                     showMenu = false
-                    viewModel.updateWearTheme()
+                    updateWearTheme()
                 }
+            )
+        }
+    }
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_YES, name = "night theme")
+@Preview(uiMode = UI_MODE_NIGHT_NO, name = "light theme")
+@Composable
+private fun AccountIconPreview() {
+    ConfettiTheme {
+        Surface {
+            AccountIcon(
+                onSwitchConference = {},
+                onSignIn = {},
+                onSignOut = {},
+                updateWearTheme = {},
+                installOnWear = {},
+                user = null,
+                showInstallOnWear = false,
+                isInstalledOnWear = false,
+                onShowSettings = {}
             )
         }
     }


### PR DESCRIPTION
Firstly, thanks for a super cool and inspiring project! 👏  A lot of cool stuff to learn for me here! :) 

In this PR I have moved the ViewModel one level up from the `AccountIcon` in an effort to try to make the `AccountIcon` composable more stateless so that it is easier to make preview functions for it.

I was not 100% sure which approach was the best for this.  I was first thinking to just pass the UIState object as a parameter. Then I thought that it might be even easier to mock if I just pass the boolean types and the user object. 

I also added a preview for light and dark theme with a background so that it was a bit easier to see.

resolves #375 