### PR TITLE
Improve Search experience

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -122,7 +122,6 @@ fun ConfettiScaffold(
                                     onValueChange = onSearch,
                                     onCloseSearch = {
                                         isSearching = false
-                                        onSearch("")
                                     }
                                 )
                             },
@@ -185,10 +184,18 @@ private fun SearchTextField(
     modifier: Modifier = Modifier,
     value: String = "",
     onValueChange: (String) -> Unit,
-    onCloseSearch: () -> Unit,
+    onCloseSearch: () -> Unit = {},
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
+
+    val closeSearch = remember {
+        {
+            keyboardController?.hide()
+            onValueChange("")
+            onCloseSearch()
+        }
+    }
 
     DisposableEffect(Unit) {
         focusRequester.requestFocus()
@@ -196,8 +203,8 @@ private fun SearchTextField(
     }
 
     BackHandler {
-        // Closes search if the user presses back.
-        onCloseSearch()
+        // Closes search if the user presses back before closing the app.
+        closeSearch()
     }
 
     TextField(
@@ -212,7 +219,7 @@ private fun SearchTextField(
         placeholder = { Text("Search") },
         leadingIcon = { Icon(Icons.Filled.Search, "Search") },
         trailingIcon = {
-            IconButton(onClick = { onCloseSearch() }) {
+            IconButton(onClick = { closeSearch() }) {
                 Icon(
                     Icons.Filled.Close,
                     contentDescription = "Close Search"

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -6,6 +6,7 @@
 package dev.johnoreilly.confetti.ui
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box
@@ -192,6 +193,11 @@ private fun SearchTextField(
     DisposableEffect(Unit) {
         focusRequester.requestFocus()
         onDispose { onValueChange("") }
+    }
+
+    BackHandler {
+        // Closes search if the user presses back.
+        onCloseSearch()
     }
 
     TextField(

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
@@ -167,7 +167,7 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
                     value.filter { session ->
                         filterSessionDetails(session, filter)
                     }
-                }
+                }.filterValues { it.isNotEmpty() }
             }
             uiState.copy(sessionsByStartTimeList = newSessions)
         } else {


### PR DESCRIPTION
* ~Search is now always visible.~
* Search removes any empty dates, they are unnecessary clusters.
* Pressing back now closes the search, before closing the app.
* Account action moved to the right side of the top bar.

~@joreilly + @martinbonnin I'm not sure how much I like the new search compared with the previous one (and there is no animation now), but it will make it easier to include a filter action in the future (on the right side of the account).~

EDIT: I have dropped the new Search UI for now, we can discuss it separately.
