### PR TITLE
Auth rework

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.ui.ConfettiTheme
 import org.koin.androidx.compose.getViewModel
 
@@ -33,20 +34,19 @@ fun AccountIcon(
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
     onShowSettings: () -> Unit,
-    viewModel: AccountViewModel = getViewModel()
+    user: User?,
+    viewModel: AccountViewModel = getViewModel(),
 ) {
     val accountUiState = viewModel.uiState.collectAsState().value
     AccountIcon(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
-        onSignOut = {
-            viewModel.signOut()
-            onSignOut()
-        },
+        onSignOut = onSignOut,
         onShowSettings = onShowSettings,
         installOnWear = viewModel::installOnWear,
         updateWearTheme = viewModel::updateWearTheme,
-        uiState = accountUiState
+        uiState = accountUiState,
+        user = user,
     )
 }
 
@@ -59,9 +59,9 @@ private fun AccountIcon(
     updateWearTheme: () -> Unit,
     installOnWear: () -> Unit,
     uiState: UiState,
+    user: User?,
 ) {
     var showMenu by remember { mutableStateOf(false) }
-    val user = uiState.user
 
     IconButton(onClick = { showMenu = !showMenu }) {
         when {
@@ -153,10 +153,22 @@ private fun AccountIconPreview() {
                 onSwitchConference = {},
                 onSignIn = {},
                 onSignOut = {},
+                onShowSettings = {},
                 updateWearTheme = {},
                 installOnWear = {},
-                onShowSettings = {},
-                uiState = accountUiState
+                uiState = accountUiState,
+                user = object: User {
+                    override val name: String
+                        get() = "Foo"
+                    override val email: String?
+                        get() = "foo@bar.com"
+                    override val photoUrl: String?
+                        get() = null
+                    override val uid: String
+                        get() = "123"
+
+                    override suspend fun idToken(forceRefresh: Boolean): String? = null
+                }
             )
         }
     }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountIcon.kt
@@ -167,7 +167,7 @@ private fun AccountIconPreview() {
                     override val uid: String
                         get() = "123"
 
-                    override suspend fun idToken(forceRefresh: Boolean): String? = null
+                    override suspend fun token(forceRefresh: Boolean): String? = null
                 }
             )
         }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountViewModel.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/AccountViewModel.kt
@@ -11,21 +11,11 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class AccountViewModel(
-    val authentication: Authentication,
-    val apolloClientCache: ApolloClientCache,
     val wearSettingsSync: WearSettingsSync
 ) : ViewModel() {
 
-    val uiState: StateFlow<UiState> =
-        combine(authentication.currentUserFlow, wearSettingsSync.wearNodes) { user, wearNodes ->
-            UiState(user, wearNodes)
-        }
+    val uiState: StateFlow<UiState> = wearSettingsSync.wearNodes.map { UiState(it) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UiState())
-
-    fun signOut() {
-        apolloClientCache.clear()
-        authentication.signOut()
-    }
 
     fun installOnWear() {
         viewModelScope.launch {
@@ -43,7 +33,6 @@ class AccountViewModel(
 }
 
 data class UiState(
-    val user: User? = null,
     val wearNodes: List<AppHelperNodeStatus> = listOf()
 ) {
     val isInstalledOnWear: Boolean

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/SignInView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/SignInView.kt
@@ -28,7 +28,7 @@ fun SignInRoute(onBackClick: () -> Unit) {
     ) {
         var error: String? by remember { mutableStateOf(null) }
         val launcher = rememberFirebaseAuthLauncher(
-            onAuthComplete = { _ ->
+            onAuthComplete = {
                 onBackClick()
             },
             onAuthError = {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/authIntent.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/authIntent.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun rememberFirebaseAuthLauncher(
-    onAuthComplete: (User) -> Unit,
+    onAuthComplete: () -> Unit,
     onAuthError: (Exception) -> Unit,
     authentication: Authentication,
 ): ManagedActivityResultLauncher<Intent, ActivityResult> {
@@ -26,7 +26,8 @@ fun rememberFirebaseAuthLauncher(
         try {
             val idToken = task.getResult(ApiException::class.java)!!.idToken!!
             scope.launch {
-                onAuthComplete(authentication.signIn(idToken))
+                authentication.signIn(idToken)
+                onAuthComplete()
             }
         } catch (e: Exception) {
             onAuthError(e)

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
@@ -9,14 +9,13 @@ import dev.johnoreilly.confetti.AppViewModel
 import dev.johnoreilly.confetti.ConferenceRefresh
 import dev.johnoreilly.confetti.ConferencesViewModel
 import dev.johnoreilly.confetti.ConfettiRepository
+import dev.johnoreilly.confetti.SearchViewModel
 import dev.johnoreilly.confetti.SessionDetailsViewModel
 import dev.johnoreilly.confetti.SessionsViewModel
 import dev.johnoreilly.confetti.SpeakerDetailsViewModel
 import dev.johnoreilly.confetti.SpeakersViewModel
-import dev.johnoreilly.confetti.TokenProvider
 import dev.johnoreilly.confetti.account.AccountViewModel
 import dev.johnoreilly.confetti.auth.Authentication
-import dev.johnoreilly.confetti.SearchViewModel
 import dev.johnoreilly.confetti.settings.SettingsViewModel
 import dev.johnoreilly.confetti.wear.WearSettingsSync
 import dev.johnoreilly.confetti.work.WorkManagerConferenceRefresh
@@ -25,6 +24,7 @@ import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import dev.johnoreilly.confetti.auth.DefaultAuthentication
 
 val appModule = module {
     viewModelOf(::SessionsViewModel)
@@ -48,8 +48,7 @@ val appModule = module {
     single<ConferenceRefresh> { WorkManagerConferenceRefresh(get()) }
 
     singleOf(::WorkManagerConferenceRefresh) { bind<ConferenceRefresh>() }
-    singleOf(::Authentication)
-    single { TokenProvider { forceRefresh -> get<Authentication>().idToken(forceRefresh) } }
+    singleOf(::DefaultAuthentication) { bind<Authentication>() }
 
     single<PhoneDataLayerAppHelper> {
         PhoneDataLayerAppHelper(androidContext(), get())

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchRoute.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchRoute.kt
@@ -5,10 +5,13 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.johnoreilly.confetti.SearchViewModel
+import dev.johnoreilly.confetti.auth.Authentication
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
 import dev.johnoreilly.confetti.ui.ConfettiAppState
 import org.koin.androidx.compose.getViewModel
+import org.koin.compose.koinInject
 
 @Composable
 fun SearchRoute(
@@ -21,8 +24,9 @@ fun SearchRoute(
     onSignOut: () -> Unit,
 ) {
     val viewModel = getViewModel<SearchViewModel>()
+    val user by koinInject<Authentication>().currentUser.collectAsStateWithLifecycle()
     SideEffect {
-        viewModel.configure(conference)
+        viewModel.configure(conference, user?.uid, user)
     }
     val search by viewModel
         .search

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -92,7 +92,8 @@ fun SearchView(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-    ) { _, user ->
+    ) {
+        val user = it.user
         Column {
             SearchTextField(
                 modifier = Modifier

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.johnoreilly.confetti.R
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
@@ -91,7 +92,7 @@ fun SearchView(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-    ) {
+    ) { _, user ->
         Column {
             SearchTextField(
                 modifier = Modifier
@@ -112,6 +113,7 @@ fun SearchView(
                         addBookmark = addBookmark,
                         removeBookmark = removeBookmark,
                         onSignIn = onSignIn,
+                        user = user
                     )
                     speakerItems(
                         conference = conference,
@@ -122,6 +124,7 @@ fun SearchView(
             }
         }
     }
+
 }
 
 private fun LazyListScope.speakerItems(
@@ -152,6 +155,7 @@ private fun LazyListScope.sessionItems(
     addBookmark: (sessionId: String) -> Unit,
     removeBookmark: (sessionId: String) -> Unit,
     onSignIn: () -> Unit,
+    user: User?
 ) {
     // Shows header if and only if there are session results.
     if (sessions.isNotEmpty()) {
@@ -168,6 +172,7 @@ private fun LazyListScope.sessionItems(
             addBookmark = { sessionId -> addBookmark(sessionId) },
             removeBookmark = { sessionId -> removeBookmark(sessionId) },
             onNavigateToSignIn = onSignIn,
+            user = user,
         )
     }
 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.auth.Authentication
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isBreak
 import dev.johnoreilly.confetti.sessionSpeakerLocation
@@ -63,7 +64,8 @@ fun SessionListView(
     addBookmark: (sessionId: String) -> Unit,
     removeBookmark: (sessionId: String) -> Unit,
     onRefresh: () -> Unit,
-    onNavigateToSignIn: () -> Unit
+    onNavigateToSignIn: () -> Unit,
+    user: User?
 ) {
     val pagerState = rememberPagerState()
 
@@ -115,7 +117,8 @@ fun SessionListView(
                                         isBookmarked = uiState.bookmarks.contains(session.id),
                                         addBookmark = addBookmark,
                                         removeBookmark = removeBookmark,
-                                        onNavigateToSignIn = onNavigateToSignIn
+                                        onNavigateToSignIn = onNavigateToSignIn,
+                                        user,
                                     )
                                 }
                             }
@@ -169,6 +172,7 @@ fun SessionItemView(
     addBookmark: (String) -> Unit,
     removeBookmark: (String) -> Unit,
     onNavigateToSignIn: () -> Unit = {},
+    user: User?,
 ) {
 
     var modifier = Modifier.fillMaxSize()
@@ -197,8 +201,6 @@ fun SessionItemView(
         }
 
 
-        val authentication = get<Authentication>()
-        val user by remember { mutableStateOf(authentication.currentUser()) }
         var showDialog by remember { mutableStateOf(false) }
 
         if (isBookmarked) {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionsRoute.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionsRoute.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package dev.johnoreilly.confetti.sessions
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,7 +19,7 @@ import kotlinx.coroutines.launch
 import org.koin.androidx.compose.getViewModel
 
 @Composable
-fun SessionsView(
+fun SessionsRoute(
     conference: String,
     appState: ConfettiAppState,
     navigateToSession: (SessionDetailsKey) -> Unit,
@@ -35,9 +32,9 @@ fun SessionsView(
     }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var refreshing by remember { mutableStateOf(false) }
-    val refreshScope = rememberCoroutineScope()
+    val scope = rememberCoroutineScope()
     fun refresh() {
-        refreshScope.launch {
+        scope.launch {
             refreshing = true
             viewModel.refresh()
             refreshing = false
@@ -51,7 +48,7 @@ fun SessionsView(
         onSwitchConference = onSwitchConferenceSelected,
         onSignIn = navigateToSignIn,
         onSignOut = onSignOut,
-    ) {
+    ) { snackbarHostState, user ->
         if (appState.isExpandedScreen) {
             SessionListGridView(
                 uiState = uiState,
@@ -67,6 +64,7 @@ fun SessionsView(
                 removeBookmark = { viewModel.removeBookmark(it) },
                 onRefresh = ::refresh,
                 onNavigateToSignIn = navigateToSignIn,
+                user
             )
         }
 
@@ -74,7 +72,7 @@ fun SessionsView(
             .collectAsStateWithLifecycle(initialValue = 0)
         LaunchedEffect(addErrorCount) {
             if (addErrorCount > 0) {
-                it.showSnackbar(
+                snackbarHostState.showSnackbar(
                     message = "Error while adding bookmark",
                     duration = SnackbarDuration.Short,
                 )
@@ -85,7 +83,7 @@ fun SessionsView(
             .collectAsStateWithLifecycle(initialValue = 0)
         LaunchedEffect(removeErrorCount) {
             if (removeErrorCount > 0) {
-                it.showSnackbar(
+                snackbarHostState.showSnackbar(
                     message = "Error while removing bookmark",
                     duration = SnackbarDuration.Short,
                 )

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionsRoute.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionsRoute.kt
@@ -27,28 +27,32 @@ fun SessionsRoute(
     onSignOut: () -> Unit,
     onSwitchConferenceSelected: () -> Unit,
 ) {
-    val viewModel: SessionsViewModel = getViewModel<SessionsViewModel>().apply {
-        configure(conference)
-    }
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var refreshing by remember { mutableStateOf(false) }
-    val scope = rememberCoroutineScope()
-    fun refresh() {
-        scope.launch {
-            refreshing = true
-            viewModel.refresh()
-            refreshing = false
-        }
-    }
-
     ConfettiScaffold(
         conference = conference,
-        title = (uiState as? SessionsUiState.Success)?.conferenceName,
         appState = appState,
         onSwitchConference = onSwitchConferenceSelected,
         onSignIn = navigateToSignIn,
         onSignOut = onSignOut,
-    ) { snackbarHostState, user ->
+    ) {
+        val snackbarHostState = it.snackbarHostState
+        val user = it.user
+
+        val viewModel: SessionsViewModel = getViewModel<SessionsViewModel>().apply {
+            configure(conference, user?.uid, user)
+        }
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        var refreshing by remember { mutableStateOf(false) }
+        val scope = rememberCoroutineScope()
+        fun refresh() {
+            scope.launch {
+                refreshing = true
+                viewModel.refresh()
+                refreshing = false
+            }
+        }
+
+        it.title.value = (uiState as? SessionsUiState.Success)?.conferenceName
+
         if (appState.isExpandedScreen) {
             SessionListGridView(
                 uiState = uiState,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/navigation/SessionsDestination.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/navigation/SessionsDestination.kt
@@ -8,7 +8,7 @@ import androidx.navigation.navArgument
 import dev.johnoreilly.confetti.navigation.urlDecoded
 import dev.johnoreilly.confetti.navigation.urlEncoded
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
-import dev.johnoreilly.confetti.sessions.SessionsView
+import dev.johnoreilly.confetti.sessions.SessionsRoute
 import dev.johnoreilly.confetti.ui.ConfettiAppState
 
 private const val base = "sessions"
@@ -39,7 +39,7 @@ fun NavGraphBuilder.sessionsGraph(
             }
         )
     ) { backStackEntry ->
-        SessionsView(
+        SessionsRoute(
             conference = SessionsKey(backStackEntry).conference,
             appState = appState,
             navigateToSession = navigateToSession,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
@@ -59,7 +59,7 @@ fun SpeakersRoute(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-    ) {
+    ) { _, _ ->
         when (val uiState1 = uiState) {
             is SpeakersUiState.Success -> {
                 if (appState.isExpandedScreen) {
@@ -75,7 +75,6 @@ fun SpeakersRoute(
             }
         }
     }
-
 }
 
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
@@ -59,7 +59,7 @@ fun SpeakersRoute(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-    ) { _, _ ->
+    ) {
         when (val uiState1 = uiState) {
             is SpeakersUiState.Success -> {
                 if (appState.isExpandedScreen) {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -24,8 +24,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -39,18 +41,23 @@ import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.settings.SettingsDialog
 import org.koin.compose.koinInject
 
+class ScaffoldState(
+    val title: MutableState<String?>,
+    val snackbarHostState: SnackbarHostState,
+    val user: User?
+)
 /**
  * A wrapper for some content view that handles the different layouts (mobile/tablet, etc...)
  */
 @Composable
 fun ConfettiScaffold(
-    title: String?,
+    title: String? = null,
     conference: String,
     appState: ConfettiAppState,
     onSwitchConference: () -> Unit,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
-    content: @Composable (SnackbarHostState, User?) -> Unit,
+    content: @Composable (ScaffoldState) -> Unit,
 ) {
     val authentication = koinInject<Authentication>()
     fun signOut() {
@@ -59,8 +66,10 @@ fun ConfettiScaffold(
     }
     val user by authentication.currentUser.collectAsStateWithLifecycle()
 
+    val titleState = remember(title) { mutableStateOf(title) }
+
     ConfettiScaffold(
-        title = title,
+        title = titleState.value,
         conference = conference,
         appState = appState,
         onSwitchConference = onSwitchConference,
@@ -68,7 +77,7 @@ fun ConfettiScaffold(
         onSignOut = ::signOut,
         user = user
         ) {
-        content(it, user)
+        content(ScaffoldState(titleState, it, user))
     }
 }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -24,18 +24,54 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.johnoreilly.confetti.account.AccountIcon
+import dev.johnoreilly.confetti.auth.Authentication
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.settings.SettingsDialog
+import org.koin.compose.koinInject
 
 /**
  * A wrapper for some content view that handles the different layouts (mobile/tablet, etc...)
  */
+@Composable
+fun ConfettiScaffold(
+    title: String?,
+    conference: String,
+    appState: ConfettiAppState,
+    onSwitchConference: () -> Unit,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    content: @Composable (SnackbarHostState, User?) -> Unit,
+) {
+    val authentication = koinInject<Authentication>()
+    fun signOut() {
+        authentication.signOut()
+        onSignOut()
+    }
+    val user by authentication.currentUser.collectAsStateWithLifecycle()
+
+    ConfettiScaffold(
+        title = title,
+        conference = conference,
+        appState = appState,
+        onSwitchConference = onSwitchConference,
+        onSignIn = onSignIn,
+        onSignOut = ::signOut,
+        user = user
+        ) {
+        content(it, user)
+    }
+}
+
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +82,7 @@ fun ConfettiScaffold(
     onSwitchConference: () -> Unit,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
+    user: User?,
     content: @Composable (SnackbarHostState) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -94,6 +131,7 @@ fun ConfettiScaffold(
                             onSignIn = onSignIn,
                             onSignOut = onSignOut,
                             onShowSettings = { appState.setShowSettingsDialog(true) },
+                            user = user
                         )
                     },
                     scrollBehavior = scrollBehavior,

--- a/iosApp/ConfettiTests/ConfettiTests.swift
+++ b/iosApp/ConfettiTests/ConfettiTests.swift
@@ -24,7 +24,7 @@ final class ConfettiTests: XCTestCase {
     
     func testGetSessions() async throws {
         let viewModel = SessionsViewModel()
-        viewModel.configure(conference: "test")
+        viewModel.configure(conference: "test", uid: nil, tokenProvider: nil)
         
         let sessionsUIStateSequence = asyncSequence(for: viewModel.uiStateFlow)
         let uiState = try await sessionsUIStateSequence.first(where: { $0 is SessionsUiStateSuccess })

--- a/iosApp/iosApp/ConfettiApp.swift
+++ b/iosApp/iosApp/ConfettiApp.swift
@@ -115,7 +115,7 @@ struct SessionsView: View {
                 ProgressView()
             }
         }.onAppear {
-            viewModel.configure(conference: conference)
+            viewModel.configure(conference: conference, uid: nil, tokenProvider: nil)
         }
     }
 }

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -82,4 +82,4 @@ actual fun platformModule() = module {
 
 val Context.settingsStore by preferencesDataStore("settings")
 
-actual fun getDatabaseName(conference: String) = "$conference.db"
+actual fun getDatabaseName(conference: String, uid: String?) = "$conference$uid.db"

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -1,15 +1,23 @@
 package dev.johnoreilly.confetti
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.ExecutionContext
+import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
+import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import dev.johnoreilly.confetti.di.getDatabaseName
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
@@ -19,51 +27,58 @@ interface TokenProvider {
     suspend fun token(forceRefresh: Boolean): String?
 }
 
-/**
- * A factory function which creates an anonymous instance for [TokenProvider] where [getToken] is
- * used when [TokenProvider.token] is invoked.
- */
-inline fun TokenProvider(
-    crossinline getToken: suspend (forceRefresh: Boolean) -> String?,
-): TokenProvider =
-    object : TokenProvider {
-        override suspend fun token(forceRefresh: Boolean): String? = getToken(forceRefresh)
-    }
+
+class TokenProviderContext(val tokenProvider: TokenProvider): ExecutionContext.Element{
+    override val key: ExecutionContext.Key<*>
+        get() = Key
+    companion object Key: ExecutionContext.Key<TokenProviderContext>
+}
 
 class ApolloClientCache : KoinComponent {
     val _clients = mutableMapOf<String, ApolloClient>()
     val mutex = Mutex(false)
-    private val tokenProvider = get<TokenProvider>()
 
-    private val httpInterceptor = object : HttpInterceptor {
-        override suspend fun intercept(
-            request: HttpRequest,
-            chain: HttpInterceptorChain
-        ): HttpResponse {
-            val token = tokenProvider.token(false)
+    private val tokenProviderInterceptor = object : ApolloInterceptor {
+        override fun <D : Operation.Data> intercept(
+            request: ApolloRequest<D>,
+            chain: ApolloInterceptorChain
+        ): Flow<ApolloResponse<D>> {
+            val tokenProvider = request.executionContext[TokenProviderContext]?.tokenProvider
+            if (tokenProvider == null) {
+                return chain.proceed(request)
+            }
+            val token = runBlocking {
+                tokenProvider.token(false)
+            }
             if (token == null) {
                 return chain.proceed(request)
             }
-            val newRequest =
-                request.newBuilder().addHeader("Authorization", "Bearer $token").build()
+            val newRequest = request.newBuilder().addHttpHeader("Authorization", "Bearer $token").build()
             return chain.proceed(newRequest)
         }
-
     }
 
+    suspend fun getClient(conference: String, uid: String?): ApolloClient {
+        return mutex.withLock {
+            _clients.getOrPut("$conference-$uid") {
+                clientFor(conference, uid, true)
+            }
+        }
+    }
     suspend fun getClient(conference: String): ApolloClient {
         return mutex.withLock {
             _clients.getOrPut(conference) {
-                clientFor(conference, conference != "all")
+                clientFor(conference, "none", conference != "all")
             }
         }
     }
 
     private fun clientFor(
         conference: String,
+        uid: String?,
         writeToCacheAsynchronously: Boolean
     ): ApolloClient {
-        val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(getDatabaseName(conference))
+        val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(getDatabaseName(conference, uid))
         val memoryFirstThenSqlCacheFactory = MemoryCacheFactory(10 * 1024 * 1024)
             .chain(sqlNormalizedCacheFactory)
 
@@ -71,12 +86,12 @@ class ApolloClientCache : KoinComponent {
             .serverUrl("https://confetti-app.dev/graphql")
             .addHttpHeader("conference", conference)
             .ignorePartialData(true)
-            .addHttpInterceptor(httpInterceptor)
             .normalizedCache(
                 memoryFirstThenSqlCacheFactory,
                 writeToCacheAsynchronously = writeToCacheAsynchronously
             )
             .autoPersistedQueries()
+            .addInterceptor(tokenProviderInterceptor)
             .build()
     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -30,7 +30,6 @@ fun commonModule() = module {
     singleOf(::ConfettiRepository)
     singleOf(::AppSettings)
     singleOf(::ApolloClientCache)
-    single { TokenProvider { null } }
 }
 
-expect fun getDatabaseName(conference: String): String
+expect fun getDatabaseName(conference: String, uid: String?): String

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -26,4 +26,4 @@ actual fun platformModule() = module {
     }
 }
 
-actual fun getDatabaseName(conference: String) = "$conference.db"
+actual fun getDatabaseName(conference: String, uid: String?) = "$conference$uid.db"

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -29,4 +29,4 @@ actual fun platformModule() = module {
     }
 }
 
-actual fun getDatabaseName(conference: String) = "jdbc:sqlite:$conference.db"
+actual fun getDatabaseName(conference: String, uid: String?) = "jdbc:sqlite:$conference$uid.db"

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SearchViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SearchViewModel.kt
@@ -77,8 +77,8 @@ class SearchViewModel(
             }
     }
 
-    fun configure(conference: String) {
-        sessionsViewModel.configure(conference)
+    fun configure(conference: String, uid: String?, tokenProvider: TokenProvider?) {
+        sessionsViewModel.configure(conference, uid, tokenProvider)
         speakersViewModel.configure(conference)
     }
 

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
@@ -10,15 +10,19 @@ import dev.johnoreilly.confetti.fragment.RoomDetails
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.utils.DateService
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -29,28 +33,27 @@ import kotlinx.datetime.atTime
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+data class ResponseData(
+    val bookmarksResponse: ApolloResponse<GetBookmarksQuery.Data>,
+    val sessionsResponse: ApolloResponse<GetConferenceDataQuery.Data>,
+)
+
 open class SessionsViewModel : KMMViewModel(), KoinComponent {
     private val repository: ConfettiRepository by inject()
     private val dateService: DateService by inject()
     private var addErrorCount = 1
     private var removeErrorCount = 1
 
-    private lateinit var conference: String
-    private val responseDatas = Channel<ResponseData>()
-    private var started: Boolean = false
+    private var conference: String? = null
+    private var uid: String? = null
+    private var tokenProvider: TokenProvider? = null
 
-    private fun maybeStart() {
-        if (!started) {
-            started = true
-            viewModelScope.coroutineScope.launch {
-                refresh(true)
-            }
-        }
-    }
+    private val responseDatas = Channel<ResponseData?>()
+
 
     fun addBookmark(sessionId: String) {
         viewModelScope.coroutineScope.launch {
-            val success = repository.addBookmark(conference, sessionId)
+            val success = repository.addBookmark(conference!!, uid, tokenProvider, sessionId)
             if (!success) {
                 addErrorChannel.send(addErrorCount++)
             }
@@ -59,11 +62,126 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
 
     fun removeBookmark(sessionId: String) {
         viewModelScope.coroutineScope.launch {
-            val success = repository.removeBookmark(conference, sessionId)
+            val success = repository.removeBookmark(conference!!, uid, tokenProvider, sessionId)
             if (!success) {
                 removeErrorChannel.send(removeErrorCount++)
             }
         }
+    }
+
+    val addErrorChannel = Channel<Int>()
+    val removeErrorChannel = Channel<Int>()
+
+    // exposed like this so it can be bound to in SwiftUI code
+    @NativeCoroutinesState
+    val searchQuery = MutableStateFlow("")
+
+    @NativeCoroutinesState
+    val uiState: StateFlow<SessionsUiState> = responseDatas.receiveAsFlow()
+        .uiState()
+        .combine(searchQuery) { uiState, search ->
+            filterSessions(uiState, search)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SessionsUiState.Loading)
+
+    // FIXME: can we pass that as a parameter somehow
+    fun configure(conference: String, uid: String?, tokenProvider: TokenProvider?) {
+        val hasChanged = this.conference != conference || this.uid != uid
+        this.conference = conference
+        this.uid = uid
+        this.tokenProvider = tokenProvider
+
+        refresh(showLoading = hasChanged, forceRefresh = false)
+    }
+
+    private var job: Job? = null
+
+    /**
+     * @param showLoading whether to show a loading state (if user or conference changed)
+     * @param forceRefresh whether to force a network refresh (pull-to-refresh)
+     */
+    fun refresh(showLoading: Boolean, forceRefresh: Boolean) {
+        job?.cancel()
+        job = viewModelScope.coroutineScope.launch {
+            responseData(showLoading, forceRefresh).collect {
+                responseDatas.send(it)
+            }
+        }
+    }
+
+    suspend fun refresh() = refresh(false, true)
+
+    fun onSearch(searchString: String) {
+        searchQuery.value = searchString
+    }
+
+    private fun filterSessions(uiState: SessionsUiState, filter: String): SessionsUiState {
+        return if (filter.isNotBlank() && uiState is SessionsUiState.Success) {
+            val newSessions = uiState.sessionsByStartTimeList.map { outerMap ->
+                outerMap.mapValues { (_, value) ->
+                    value.filter { session ->
+                        filterSessionDetails(session, filter)
+                    }
+                }.filterValues { it.isNotEmpty() }
+            }
+            uiState.copy(sessionsByStartTimeList = newSessions)
+        } else {
+            uiState
+        }
+    }
+
+    private fun filterSessionDetails(details: SessionDetails, filter: String): Boolean {
+        val ignoreCase = true
+        return details.title.contains(filter, ignoreCase) ||
+            details.sessionDescription.orEmpty().contains(filter, ignoreCase) ||
+            details.room?.name?.contains(filter, ignoreCase) == true ||
+            details.speakers.any { speaker ->
+                speaker.speakerDetails.name.contains(filter, ignoreCase)
+            }
+    }
+
+    private fun responseData(showLoading: Boolean, forceRefresh: Boolean): Flow<ResponseData?> = flow {
+        if (showLoading) {
+            emit(null)
+        }
+        val fetchPolicy = if (forceRefresh) {
+            FetchPolicy.NetworkOnly
+        } else {
+            FetchPolicy.CacheFirst
+        }
+
+        // get initial data
+        coroutineScope {
+            val bookmarksResponse = async {
+                repository.bookmarks(conference!!, uid, tokenProvider, fetchPolicy)
+            }
+            val sessionsResponse = async {
+                repository.conferenceData(conference!!, fetchPolicy)
+            }
+
+            ResponseData(bookmarksResponse.await(), sessionsResponse.await())
+        }.also {
+            emit(it)
+        }
+    }
+
+    fun Flow<ResponseData?>.uiState() = flatMapLatest { responseData ->
+        if (responseData == null) {
+            flowOf(SessionsUiState.Loading)
+        } else {
+            val bookmarksData = responseData.bookmarksResponse.data
+            repository.watchBookmarks(conference!!, uid, tokenProvider, bookmarksData)
+                .map { responseData.copy(bookmarksResponse = it) }
+                .onStart {
+                    emit(responseData)
+                }.map {
+                    uiStates(it)
+                }
+        }
+    }
+
+    private fun getSessionTime(session: SessionDetails, timeZone: TimeZone): String {
+        return dateService.format(session.startsAt, timeZone, "HH:mm")
     }
 
     private fun uiStates(
@@ -103,7 +221,7 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
             dateService.format(date.atTime(0, 0), timeZone, "MMM dd, yyyy")
         }
         return SessionsUiState.Success(
-            conference,
+            conference!!,
             dateService.now(),
             conferenceName,
             formattedConfDates,
@@ -113,101 +231,9 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
             bookmarksData.bookmarks?.sessionIds.orEmpty().toSet(),
         )
     }
-
-    data class ResponseData(
-        val bookmarksResponse: ApolloResponse<GetBookmarksQuery.Data>,
-        val sessionsResponse: ApolloResponse<GetConferenceDataQuery.Data>,
-    )
-
-    val addErrorChannel = Channel<Int>()
-    val removeErrorChannel = Channel<Int>()
-
-    // exposed like this so it can be bound to in SwiftUI code
-    @NativeCoroutinesState
-    val searchQuery = MutableStateFlow("")
-
-    @NativeCoroutinesState
-    val uiState: StateFlow<SessionsUiState> = responseDatas.receiveAsFlow()
-        .flatMapLatest { refreshData ->
-            val bookmarksData = refreshData.bookmarksResponse.data
-            repository.watchBookmarks(conference, bookmarksData)
-                .map { refreshData.copy(bookmarksResponse = it) }
-                .onStart {
-                    emit(refreshData)
-                }.map {
-                    uiStates(it)
-                }
-        }.combine(searchQuery) { uiState, search ->
-            filterSessions(uiState, search)
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SessionsUiState.Loading)
-
-
-    // FIXME: can we pass that as a parameter somehow
-    fun configure(conference: String) {
-        this.conference = conference
-        maybeStart()
-    }
-
-    suspend fun refresh() = refresh(false)
-
-    fun onSearch(searchString: String) {
-        searchQuery.value = searchString
-    }
-
-    private fun filterSessions(uiState: SessionsUiState, filter: String): SessionsUiState {
-        return if (filter.isNotBlank() && uiState is SessionsUiState.Success) {
-            val newSessions = uiState.sessionsByStartTimeList.map { outerMap ->
-                outerMap.mapValues { (_, value) ->
-                    value.filter { session ->
-                        filterSessionDetails(session, filter)
-                    }
-                }.filterValues { it.isNotEmpty() }
-            }
-            uiState.copy(sessionsByStartTimeList = newSessions)
-        } else {
-            uiState
-        }
-    }
-
-    private fun filterSessionDetails(details: SessionDetails, filter: String): Boolean {
-        val ignoreCase = true
-        return details.title.contains(filter, ignoreCase) ||
-            details.sessionDescription.orEmpty().contains(filter, ignoreCase) ||
-            details.room?.name?.contains(filter, ignoreCase) == true ||
-            details.speakers.any { speaker ->
-                speaker.speakerDetails.name.contains(filter, ignoreCase)
-            }
-    }
-
-    private suspend fun refresh(initial: Boolean) {
-        val fetchPolicy = if (initial) {
-            FetchPolicy.CacheFirst
-        } else {
-            FetchPolicy.NetworkOnly
-        }
-
-        coroutineScope {
-            val bookmarksResponse = async {
-                repository.bookmarks(conference, fetchPolicy)
-            }
-            val sessionsResponse = async {
-                repository.conferenceData(conference, fetchPolicy)
-            }
-
-            responseDatas.send(
-                ResponseData(
-                    bookmarksResponse = bookmarksResponse.await(),
-                    sessionsResponse = sessionsResponse.await()
-                )
-            )
-        }
-    }
-
-    private fun getSessionTime(session: SessionDetails, timeZone: TimeZone): String {
-        return dateService.format(session.startsAt, timeZone, "HH:mm")
-    }
 }
+
+
 
 sealed interface SessionsUiState {
     object Loading : SessionsUiState

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
@@ -109,7 +109,7 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
         }
     }
 
-    suspend fun refresh() = refresh(false, true)
+    suspend fun refresh() = refresh(showLoading = false, forceRefresh = true)
 
     fun onSearch(searchString: String) {
         searchQuery.value = searchString

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/auth/Authentication.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/auth/Authentication.kt
@@ -4,6 +4,7 @@ import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.GoogleAuthProvider
 import dev.gitlive.firebase.auth.auth
+import dev.johnoreilly.confetti.TokenProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -11,12 +12,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.runBlocking
 
-interface User {
+interface User: TokenProvider {
     val name: String
     val email: String?
     val photoUrl: String?
     val uid: String
-    suspend fun idToken(forceRefresh: Boolean): String?
 }
 
 interface Authentication {
@@ -48,7 +48,7 @@ class DefaultUser(
     override val uid: String,
     private val user_: FirebaseUser?
 ): User {
-    override suspend fun idToken(forceRefresh: Boolean): String? {
+    override suspend fun token(forceRefresh: Boolean): String? {
         return user_?.getIdToken(forceRefresh)
     }
 }

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/auth/Authentication.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/auth/Authentication.kt
@@ -4,49 +4,72 @@ import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.GoogleAuthProvider
 import dev.gitlive.firebase.auth.auth
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.runBlocking
 
-class User(
-    val name: String,
-    val email: String?,
-    val photoUrl: String?,
-)
-
-private fun FirebaseUser.toUser(): User {
-    return User(
-        displayName ?: "",
-        email ,
-        photoURL.toString()
-    )
+interface User {
+    val name: String
+    val email: String?
+    val photoUrl: String?
+    val uid: String
+    suspend fun idToken(forceRefresh: Boolean): String?
 }
 
-class Authentication {
-    suspend fun idToken(forceRefresh: Boolean = false): String? {
-        return Firebase.auth.currentUser?.getIdToken(forceRefresh)
-    }
-
-    fun currentUser(): User? {
-        return Firebase.auth.currentUser?.toUser()
-    }
-
-    val currentUserFlow: Flow<User?> = Firebase.auth.authStateChanged.map {it?.toUser() }
-        .onStart {
-            emit(currentUser())
-        }
+interface Authentication {
+    /**
+     * A state flow that returns the current user
+     */
+    val currentUser: StateFlow<User?>
 
     /**
-     * @throws
+     * Sign in to firebase. A successful call returns [SignInSuccess] and triggers the emission
+     * of a new [currentUser]
      */
-    suspend fun signIn(idToken: String): User {
+    suspend fun signIn(idToken: String): SignInResult
+
+    /**
+     * Sign out of firebase. triggers the emission of a new [currentUser]
+     */
+    fun signOut()
+}
+
+sealed interface SignInResult
+object SignInSuccess : SignInResult
+class SignInError(val e: Exception) : SignInResult
+
+class DefaultUser(
+    override val name: String,
+    override val email: String?,
+    override val photoUrl: String?,
+    override val uid: String,
+    private val user_: FirebaseUser?
+): User {
+    override suspend fun idToken(forceRefresh: Boolean): String? {
+        return user_?.getIdToken(forceRefresh)
+    }
+}
+
+class DefaultAuthentication(
+    val coroutineScope: CoroutineScope
+) : Authentication {
+    override val currentUser: StateFlow<User?> = Firebase.auth.authStateChanged.map { it?.toUser() }
+        .stateIn(coroutineScope, SharingStarted.Eagerly, Firebase.auth.currentUser?.toUser())
+
+    override suspend fun signIn(idToken: String): SignInResult {
         val credential = GoogleAuthProvider.credential(idToken, null)
-        val authResult = Firebase.auth.signInWithCredential(credential)
-        return authResult.user!!.toUser()
+        return try {
+            Firebase.auth.signInWithCredential(credential)
+            SignInSuccess
+        } catch (e: Exception) {
+            SignInError(e)
+        }
     }
 
-    fun signOut() {
+    override fun signOut() {
         // The underlying function is only blocking on JS so it should be OK to block here
         runBlocking {
             Firebase.auth.signOut()
@@ -54,3 +77,12 @@ class Authentication {
     }
 }
 
+private fun FirebaseUser.toUser(): User {
+    return DefaultUser(
+        name = displayName ?: "",
+        email = email,
+        photoUrl = photoURL.toString(),
+        uid = uid,
+        user_ = this
+    )
+}


### PR DESCRIPTION
Follow up from https://github.com/joreilly/Confetti/pull/449

This turns `User` and `Authentication` into interfaces that we can fake for tests/previews. Also fixes #450

@oas004 @yschimke let me know what you think, it passes `uid` and `tokenProvider` all the way down to the repository so now we have an `uid` parameter everywhere in addition to `conference` (but not in deeplinks). It's a bit verbose (Compose loves long lists of arguments) but at least it's correct and the bookmark state is now in-sync with the AccountIcon. 