### PR TITLE
Backend: cache sessions

### DIFF
--- a/backend/service-graphql/src/main/resources/application.yml
+++ b/backend/service-graphql/src/main/resources/application.yml
@@ -1,2 +1,5 @@
 graphql:
   packages: "dev.johnoreilly.confetti.backend"
+
+  playground:
+    enabled: true


### PR DESCRIPTION
Since the addition of Speaker.session, we were querying Datastore separately for each session and that increase the `GetConferenceData` time a lot. Cache this information to make it faster. 

Also enable playground.