### PR TITLE
Fix Keyboard and Improve Section Headers

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -36,7 +36,9 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.MicExternalOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
@@ -167,7 +168,7 @@ private fun LazyListScope.sessionItems(
     // Shows header if and only if there are session results.
     if (sessions.isNotEmpty()) {
         stickyHeader {
-            HeaderView(Icons.Filled.MicExternalOn, "Sessions")
+            HeaderView(Icons.Filled.Event, "Sessions")
         }
     }
     items(sessions) { session ->
@@ -200,13 +201,12 @@ private fun HeaderView(
             .fillMaxWidth(),
     ) {
         Column {
+            Divider()
             Row(
                 modifier = Modifier
                     .padding(
-                        start = 16.dp,
-                        end = 16.dp,
-                        top = 16.dp,
-                        bottom = 8.dp
+                        horizontal = 16.dp,
+                        vertical = 8.dp,
                     ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -1,14 +1,17 @@
 @file:OptIn(
     ExperimentalMaterial3Api::class, ExperimentalMaterial3Api::class,
-    ExperimentalFoundationApi::class
+    ExperimentalFoundationApi::class, ExperimentalLayoutApi::class
 )
 
 package dev.johnoreilly.confetti.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imeNestedScroll
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -86,6 +89,7 @@ fun SearchView(
     loading: Boolean,
 ) {
     ConfettiScaffold(
+        modifier = Modifier.imePadding(),
         title = stringResource(R.string.search),
         conference = conference,
         appState = appState,
@@ -105,7 +109,9 @@ fun SearchView(
             if (loading) {
                 LoadingView()
             } else if (search.isNotBlank()) {
-                LazyColumn {
+                LazyColumn(
+                    modifier = Modifier.imeNestedScroll(),
+                ) {
                     sessionItems(
                         conference = conference,
                         sessions = sessions,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -8,7 +8,6 @@ package dev.johnoreilly.confetti.search
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.imePadding
@@ -21,14 +20,11 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Event
-import androidx.compose.material.icons.filled.MicExternalOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -36,13 +32,11 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -50,9 +44,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.auth.User
@@ -66,9 +58,7 @@ import dev.johnoreilly.confetti.ui.ConfettiAppState
 import dev.johnoreilly.confetti.ui.ConfettiScaffold
 import dev.johnoreilly.confetti.ui.ConfettiTypography
 import dev.johnoreilly.confetti.ui.LoadingView
-import dev.johnoreilly.confetti.ui.component.BackgroundTheme
-import dev.johnoreilly.confetti.ui.component.ConfettiBackground
-import dev.johnoreilly.confetti.ui.component.LocalBackgroundTheme
+import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.utils.rememberRunnable
 
 @Composable
@@ -143,7 +133,7 @@ private fun LazyListScope.speakerItems(
     // Shows header if and only if there are speaker results.
     if (speakers.isNotEmpty()) {
         stickyHeader {
-            HeaderView(Icons.Filled.Person, "Speakers")
+            ConfettiHeader(icon = Icons.Filled.Person, text = "Speakers")
         }
     }
     items(speakers) { speaker ->
@@ -168,7 +158,7 @@ private fun LazyListScope.sessionItems(
     // Shows header if and only if there are session results.
     if (sessions.isNotEmpty()) {
         stickyHeader {
-            HeaderView(Icons.Filled.Event, "Sessions")
+            ConfettiHeader(icon = Icons.Filled.Event, text = "Sessions")
         }
     }
     items(sessions) { session ->
@@ -182,48 +172,6 @@ private fun LazyListScope.sessionItems(
             onNavigateToSignIn = onSignIn,
             user = user,
         )
-    }
-}
-
-@Composable
-private fun HeaderView(
-    icon: ImageVector,
-    text: String,
-) {
-    val tonalElevation = LocalBackgroundTheme.current.tonalElevation
-    ConfettiBackground(
-        tonalElevation = if (tonalElevation == Dp.Unspecified) {
-            BackgroundTheme.DEFAULT_TONAL_ELEVATION
-        } else {
-            tonalElevation
-        },
-        modifier = Modifier
-            .fillMaxWidth(),
-    ) {
-        Column {
-            Divider()
-            Row(
-                modifier = Modifier
-                    .padding(
-                        horizontal = 16.dp,
-                        vertical = 8.dp,
-                    ),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    modifier = Modifier
-                        .padding(end = 8.dp),
-                    imageVector = icon,
-                    contentDescription = null,
-                )
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-            Divider()
-        }
     }
 }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -99,23 +99,6 @@ fun SessionListView(
                             sessions.forEach { (startTime, sessions) ->
                                 stickyHeader {
                                     ConfettiHeader(icon = Icons.Filled.AccessTime, text = startTime)
-//                                    Column(
-//                                        Modifier
-//                                            .background(MaterialTheme.colorScheme.surface)
-//                                            .padding(
-//                                                start = 16.dp,
-//                                                end = 16.dp,
-//                                                top = 16.dp,
-//                                                bottom = 8.dp
-//                                            )
-//                                    ) {
-//                                        Text(
-//                                            startTime,
-//                                            fontWeight = FontWeight.Bold,
-//                                            color = MaterialTheme.colorScheme.primary
-//                                        )
-//                                        Divider()
-//                                    }
                                 }
 
                                 items(sessions) { session ->

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
@@ -53,6 +55,7 @@ import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.ui.ErrorView
 import dev.johnoreilly.confetti.ui.LoadingView
 import dev.johnoreilly.confetti.ui.SignInDialog
+import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.ui.component.ConfettiTab
 import dev.johnoreilly.confetti.ui.component.pagerTabIndicatorOffset
 import kotlinx.coroutines.launch
@@ -95,23 +98,24 @@ fun SessionListView(
                         LazyColumn {
                             sessions.forEach { (startTime, sessions) ->
                                 stickyHeader {
-                                    Column(
-                                        Modifier
-                                            .background(MaterialTheme.colorScheme.surface)
-                                            .padding(
-                                                start = 16.dp,
-                                                end = 16.dp,
-                                                top = 16.dp,
-                                                bottom = 8.dp
-                                            )
-                                    ) {
-                                        Text(
-                                            startTime,
-                                            fontWeight = FontWeight.Bold,
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
-                                        Divider()
-                                    }
+                                    ConfettiHeader(icon = Icons.Filled.AccessTime, text = startTime)
+//                                    Column(
+//                                        Modifier
+//                                            .background(MaterialTheme.colorScheme.surface)
+//                                            .padding(
+//                                                start = 16.dp,
+//                                                end = 16.dp,
+//                                                top = 16.dp,
+//                                                bottom = 8.dp
+//                                            )
+//                                    ) {
+//                                        Text(
+//                                            startTime,
+//                                            fontWeight = FontWeight.Bold,
+//                                            color = MaterialTheme.colorScheme.primary
+//                                        )
+//                                        Divider()
+//                                    }
                                 }
 
                                 items(sessions) { session ->

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/speakerdetails/SpeakerDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/speakerdetails/SpeakerDetailsView.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +33,7 @@ import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
 import dev.johnoreilly.confetti.ui.ErrorView
 import dev.johnoreilly.confetti.ui.LoadingView
+import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.ui.component.SocialIcon
 import org.koin.androidx.compose.getViewModel
 
@@ -91,13 +95,17 @@ fun SpeakerDetailsView(
                 )
             )
         },
-    ) { padding ->
-        Column(modifier = Modifier.padding(padding)) {
+    ) { innerPadding ->
+        val contentPaddings = remember { PaddingValues(horizontal = 16.dp, vertical = 8.dp) }
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(state = scrollState),
+            ) {
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .verticalScroll(state = scrollState),
+                    .padding(contentPaddings),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 speaker.tagline?.let { city ->
@@ -127,6 +135,7 @@ fun SpeakerDetailsView(
                 )
 
                 Spacer(modifier = Modifier.size(16.dp))
+
                 Row(
                     Modifier.padding(top = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -142,11 +151,16 @@ fun SpeakerDetailsView(
                         )
                     }
                 }
-
-                Spacer(modifier = Modifier.size(16.dp))
-
-                SpeakerTalks(conference, speaker.sessions, navigateToSession)
             }
+
+            Spacer(modifier = Modifier.size(16.dp))
+
+            SpeakerTalks(
+                modifier = Modifier.padding(contentPaddings),
+                conference = conference,
+                sessions = speaker.sessions,
+                navigateToSession = navigateToSession,
+            )
         }
     }
 }
@@ -156,22 +170,27 @@ fun SpeakerTalks(
     conference: String,
     sessions: List<SpeakerDetails.Session>,
     navigateToSession: (SessionDetailsKey) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(Modifier.fillMaxWidth()) {
-        Text("Sessions", style = MaterialTheme.typography.headlineSmall)
-        Divider()
+
+        ConfettiHeader(icon = Icons.Filled.Event, text = "Sessions")
+
         Spacer(modifier = Modifier.size(8.dp))
-        sessions.forEach { session ->
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        navigateToSession(SessionDetailsKey(conference, session.id))
-                    }
-                    .padding(vertical = 8.dp)) {
-                Text(session.title, style = MaterialTheme.typography.bodyLarge)
+
+        Column(modifier) {
+            sessions.forEach { session ->
+                Row(
+                    Modifier
+                        .padding()
+                        .fillMaxWidth()
+                        .clickable {
+                            navigateToSession(SessionDetailsKey(conference, session.id))
+                        }
+                        .padding(vertical = 8.dp)) {
+                    Text(session.title, style = MaterialTheme.typography.bodyLarge)
+                }
             }
         }
     }
 }
-

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiBottomBar.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiBottomBar.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti.ui
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -17,27 +19,31 @@ internal fun ConfettiBottomBar(
     onNavigateToDestination: (String) -> Unit,
     currentDestination: NavDestination?
 ) {
-    NavigationBar(
-        contentColor = ConfettiNavigationDefaults.navigationContentColor(),
-    ) {
-        TopLevelDestination.values.forEach { destination ->
-            val route = destination.route(conference)
+    Column {
+        Divider()
+        NavigationBar(
+            contentColor = ConfettiNavigationDefaults.navigationContentColor(),
+            tonalElevation = 0.dp,
+        ) {
+            TopLevelDestination.values.forEach { destination ->
+                val route = destination.route(conference)
 
-            val selected =
-                currentDestination?.hierarchy?.any { it.route == destination.routePattern } == true
-            NavigationBarItem(
-                selected = selected,
-                onClick = { onNavigateToDestination(route) },
-                icon = {
-                    val icon = if (selected) {
-                        destination.selectedIcon
-                    } else {
-                        destination.unselectedIcon
-                    }
-                    Icon(icon, contentDescription = stringResource(destination.iconTextId))
-                },
-                label = { Text(stringResource(destination.iconTextId)) }
-            )
+                val selected =
+                    currentDestination?.hierarchy?.any { it.route == destination.routePattern } == true
+                NavigationBarItem(
+                    selected = selected,
+                    onClick = { onNavigateToDestination(route) },
+                    icon = {
+                        val icon = if (selected) {
+                            destination.selectedIcon
+                        } else {
+                            destination.unselectedIcon
+                        }
+                        Icon(icon, contentDescription = stringResource(destination.iconTextId))
+                    },
+                    label = { Text(stringResource(destination.iconTextId)) }
+                )
+            }
         }
     }
 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiBottomBar.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiBottomBar.kt
@@ -19,7 +19,6 @@ internal fun ConfettiBottomBar(
 ) {
     NavigationBar(
         contentColor = ConfettiNavigationDefaults.navigationContentColor(),
-        tonalElevation = 0.dp,
     ) {
         TopLevelDestination.values.forEach { destination ->
             val route = destination.route(conference)

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -51,6 +51,7 @@ class ScaffoldState(
  */
 @Composable
 fun ConfettiScaffold(
+    modifier: Modifier = Modifier,
     title: String? = null,
     conference: String,
     appState: ConfettiAppState,
@@ -69,6 +70,7 @@ fun ConfettiScaffold(
     val titleState = remember(title) { mutableStateOf(title) }
 
     ConfettiScaffold(
+        modifier = modifier,
         title = titleState.value,
         conference = conference,
         appState = appState,
@@ -85,6 +87,7 @@ fun ConfettiScaffold(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConfettiScaffold(
+    modifier: Modifier = Modifier,
     title: String?,
     conference: String,
     appState: ConfettiAppState,
@@ -104,7 +107,7 @@ fun ConfettiScaffold(
         )
     }
 
-    Row {
+    Row(modifier = modifier) {
         // The default behaviour is to keep top bar always visible.
         var scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         if (appState.shouldShowNavRail) {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/component/ConfettiHeader.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/component/ConfettiHeader.kt
@@ -1,0 +1,62 @@
+package dev.johnoreilly.confetti.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ConfettiHeader(
+    text: String,
+    icon: ImageVector? = null,
+    modifier: Modifier = Modifier,
+) {
+    val tonalElevation = LocalBackgroundTheme.current.tonalElevation
+    ConfettiBackground(
+        tonalElevation = if (tonalElevation == Dp.Unspecified) {
+            BackgroundTheme.DEFAULT_TONAL_ELEVATION
+        } else {
+            tonalElevation
+        },
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
+        Column {
+            Divider()
+            Row(
+                modifier = Modifier
+                    .padding(
+                        horizontal = 16.dp,
+                        vertical = 8.dp,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                icon?.let { icon ->
+                    Icon(
+                        modifier = Modifier
+                            .padding(end = 8.dp),
+                        imageVector = icon,
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            Divider()
+        }
+    }
+}


### PR DESCRIPTION
* Fixes the keyboard covering part of the UI.
* Automatically opens the keyboard when scrolling down the screen.
* Creates unified `ConfettiHeader` to be used across all screens.
* Fixes icon from sessions: now we use the event icon.

| Schedule | Speaker Details | Search |
|---|---|---|
|  ![Screenshot_1680381885](https://user-images.githubusercontent.com/4348197/229313658-4060a13f-f5d1-4fbc-9c8e-3d4efbb67fc7.png) | ![Screenshot_1680382510](https://user-images.githubusercontent.com/4348197/229313674-f37de9e0-bf9c-45d8-92c0-679e65c6153a.png) | ![Screenshot_1680382546](https://user-images.githubusercontent.com/4348197/229313684-669bfd1a-329a-4d05-acdd-0bd9876621dc.png) |

Scrollable Keyboard Animation:

[keyboard_ime_anim.webm](https://user-images.githubusercontent.com/4348197/229313704-39c45511-31cb-4a93-a6d1-4bddfaef4929.webm)
