### PR TITLE
Add past/upcoming filters to bookmarks

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksRoute.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksRoute.kt
@@ -28,8 +28,11 @@ fun BookmarksRoute(
     val loading by viewModel
         .loading
         .collectAsStateWithLifecycle(initialValue = true)
-    val sessions by viewModel
-        .sessions
+    val pastSessions by viewModel
+        .pastSessions
+        .collectAsStateWithLifecycle(initialValue = emptyList())
+    val upcomingSessions by viewModel
+        .upcomingSessions
         .collectAsStateWithLifecycle(initialValue = emptyList())
     val bookmarks by viewModel
         .bookmarks
@@ -41,7 +44,8 @@ fun BookmarksRoute(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-        sessions = sessions,
+        pastSessions = pastSessions,
+        upcomingSessions = upcomingSessions,
         bookmarks = bookmarks,
         addBookmark = viewModel::addBookmark,
         removeBookmark = viewModel::removeBookmark,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksView.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalFoundationApi::class)
 
 package dev.johnoreilly.confetti.bookmarks
 
@@ -6,21 +6,31 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import dev.johnoreilly.confetti.R
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.sessions.SessionItemView
 import dev.johnoreilly.confetti.ui.ConfettiAppState
 import dev.johnoreilly.confetti.ui.ConfettiScaffold
 import dev.johnoreilly.confetti.ui.LoadingView
+import dev.johnoreilly.confetti.ui.component.ConfettiTab
+import kotlinx.coroutines.launch
 
 @Composable
 fun BookmarksView(
     conference: String,
     appState: ConfettiAppState,
-    sessions: List<SessionDetails>,
+    pastSessions: List<SessionDetails>,
+    upcomingSessions: List<SessionDetails>,
     navigateToSession: (SessionDetailsKey) -> Unit,
     onSwitchConference: () -> Unit,
     onSignIn: () -> Unit,
@@ -37,27 +47,118 @@ fun BookmarksView(
         onSwitchConference = onSwitchConference,
         onSignIn = onSignIn,
         onSignOut = onSignOut,
-    ) {
-        val user = it.user
+    ) { state ->
+        val user = state.user
         Column {
 
             if (loading) {
                 LoadingView()
             } else {
-                LazyColumn {
-                    items(sessions) { session ->
-                        SessionItemView(
-                            conference = conference,
-                            session = session,
-                            sessionSelected = navigateToSession,
-                            isBookmarked = bookmarks.contains(session.id),
-                            addBookmark = { sessionId -> addBookmark(sessionId) },
-                            removeBookmark = { sessionId -> removeBookmark(sessionId) },
-                            onNavigateToSignIn = onSignIn,
-                            user = user,
-                        )
-                    }
-                }
+                BookmarksContent(
+                    pastSessions = pastSessions,
+                    upcomingSessions = upcomingSessions,
+                    conference = conference,
+                    navigateToSession = navigateToSession,
+                    bookmarks = bookmarks,
+                    addBookmark = addBookmark,
+                    removeBookmark = removeBookmark,
+                    onSignIn = onSignIn,
+                    user = user,
+                )
+
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookmarksContent(
+    pastSessions: List<SessionDetails>,
+    upcomingSessions: List<SessionDetails>,
+    conference: String,
+    navigateToSession: (SessionDetailsKey) -> Unit,
+    bookmarks: Set<String>,
+    addBookmark: (sessionId: String) -> Unit,
+    removeBookmark: (sessionId: String) -> Unit,
+    onSignIn: () -> Unit,
+    user: User?
+) {
+    Column {
+        val pagerState = rememberPagerState(initialPage = 1)
+        BookmarksTabRow(pagerState = pagerState)
+        BookmarksHorizontalPager(
+            pagerState = pagerState,
+            pastSessions = pastSessions,
+            upcomingSessions = upcomingSessions,
+            conference = conference,
+            navigateToSession = navigateToSession,
+            bookmarks = bookmarks,
+            addBookmark = addBookmark,
+            removeBookmark = removeBookmark,
+            onSignIn = onSignIn,
+            user = user,
+        )
+    }
+}
+
+private enum class BookmarksTab(val title: String) {
+    Past(title = "Past"),
+    Upcoming(title = "Upcoming")
+}
+
+@Composable
+private fun BookmarksTabRow(pagerState: PagerState) {
+    TabRow(selectedTabIndex = pagerState.currentPage) {
+        for ((index, tab) in BookmarksTab.values().withIndex()) {
+            val tabScope = rememberCoroutineScope()
+
+            ConfettiTab(
+                selected = pagerState.currentPage == index,
+                onClick = {
+                    tabScope.launch { pagerState.animateScrollToPage(index) }
+                },
+                text = { Text(text = tab.title) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun BookmarksHorizontalPager(
+    pagerState: PagerState,
+    pastSessions: List<SessionDetails>,
+    upcomingSessions: List<SessionDetails>,
+    conference: String,
+    navigateToSession: (SessionDetailsKey) -> Unit,
+    bookmarks: Set<String>,
+    addBookmark: (sessionId: String) -> Unit,
+    removeBookmark: (sessionId: String) -> Unit,
+    onSignIn: () -> Unit,
+    user: User?
+) {
+    HorizontalPager(
+        pageCount = BookmarksTab.values().size,
+        state = pagerState,
+    ) { page ->
+        val displayedSessions =
+            if (page == BookmarksTab.Past.ordinal) {
+                pastSessions
+            } else {
+                upcomingSessions
+            }
+
+        LazyColumn {
+            items(displayedSessions) { session ->
+                SessionItemView(
+                    conference = conference,
+                    session = session,
+                    sessionSelected = navigateToSession,
+                    isBookmarked = bookmarks.contains(session.id),
+                    addBookmark = { sessionId -> addBookmark(sessionId) },
+                    removeBookmark = { sessionId -> removeBookmark(sessionId) },
+                    onNavigateToSignIn = onSignIn,
+                    user = user,
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/DateService.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/DateService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 interface DateService {
     fun format(localDateTime: LocalDateTime, timeZone: TimeZone, format: String): String
@@ -15,7 +16,7 @@ interface DateService {
     fun now(): LocalDateTime
 }
 
-fun DateService.createCurrentLocalDateTimeFlow(delay: Duration): Flow<LocalDateTime> =
+fun DateService.createCurrentLocalDateTimeFlow(delay: Duration = 5.minutes): Flow<LocalDateTime> =
     flow {
         emit(now())
         while (currentCoroutineContext().isActive) {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/DateService.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/DateService.kt
@@ -1,11 +1,25 @@
 package dev.johnoreilly.confetti.utils
 
-import kotlinx.datetime.Instant
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
+import kotlin.time.Duration
 
 interface DateService {
     fun format(localDateTime: LocalDateTime, timeZone: TimeZone, format: String): String
 
     fun now(): LocalDateTime
 }
+
+fun DateService.createCurrentLocalDateTimeFlow(delay: Duration): Flow<LocalDateTime> =
+    flow {
+        emit(now())
+        while (currentCoroutineContext().isActive) {
+            emit(now())
+            delay(delay)
+        }
+    }

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/BookmarksViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/BookmarksViewModel.kt
@@ -38,7 +38,7 @@ class BookmarksViewModel(
         }
 
     private val currentDateTimeFlow = dateService
-        .createCurrentLocalDateTimeFlow(delay = 15.minutes)
+        .createCurrentLocalDateTimeFlow()
 
     val pastSessions = sessions
         .combine(currentDateTimeFlow) { sessions, now ->


### PR DESCRIPTION
* Add past/upcoming tabs to bookmarks.
* Filter automatically based on the current time, refreshed every 5 minutes - it seemed reasonable, but we can fine-tune it as we wish.

Issues: the tab text color is different between sessions and bookmarks, we will need to fix it.

| Past | Upcoming |
|---|---|
| ![Screenshot_1680445258](https://user-images.githubusercontent.com/4348197/229360188-2f22175c-6020-4fb5-8eed-5f0c792a6e96.png) | ![Screenshot_1680445261](https://user-images.githubusercontent.com/4348197/229360198-7f1f5e0c-107a-497b-8a3d-56454047036e.png) |