### PR TITLE
Fix social icon tint when system ui is light, but app is dark

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/component/SocialIcon.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/component/SocialIcon.kt
@@ -1,13 +1,12 @@
 package dev.johnoreilly.confetti.ui.component
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import dev.johnoreilly.confetti.R
@@ -20,7 +19,7 @@ fun SocialIcon(
     contentDescription: String,
     onClick: () -> Unit
 ) {
-    val iconTint = (if (isSystemInDarkTheme()) Color.White else Color.Black).copy(alpha = 0.5f)
+    val iconTint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
     IconButton(onClick = onClick) {
         Icon(
             modifier = modifier

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/component/SocialIcon.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/component/SocialIcon.kt
@@ -2,14 +2,13 @@ package dev.johnoreilly.confetti.wear.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 
@@ -20,7 +19,7 @@ fun SocialIcon(
     contentDescription: String,
     onClick: () -> Unit
 ) {
-    val iconTint = (if (isSystemInDarkTheme()) Color.White else Color.Black).copy(alpha = 0.5f)
+    val iconTint = MaterialTheme.colors.onSurface.copy(alpha = 0.75f)
     Icon(
         modifier = modifier
             .size(24.dp)


### PR DESCRIPTION
Also made it a bit less transparent

<table>
<tr><td>Before</td><td>After</td></tr>

<tr>
<td>
<img src="https://user-images.githubusercontent.com/372852/229360889-3bf154c1-43cb-44c9-9052-c886ce65892d.png" width=300>
</td>
<td>
<img src="https://user-images.githubusercontent.com/372852/229361016-f0540fc9-f5f1-461c-987a-4ebae26e8504.png" width=300>
</td>
</tr>
</table>
