### PR TITLE
Add navigation from session details to speaker details

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -37,22 +37,40 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.johnoreilly.confetti.SessionDetailsViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
 import dev.johnoreilly.confetti.utils.format
 import org.koin.androidx.compose.getViewModel
 import java.time.format.DateTimeFormatter
 
 @Composable
-fun SessionDetailsRoute(conference: String, sessionId: String, onBackClick: () -> Unit) {
+fun SessionDetailsRoute(
+    conference: String,
+    sessionId: String,
+    onBackClick: () -> Unit,
+    onSpeakerClick: (key: SpeakerDetailsKey) -> Unit
+) {
     val viewModel: SessionDetailsViewModel = getViewModel<SessionDetailsViewModel>().apply {
         configure(conference, sessionId)
     }
     val session by viewModel.session.collectAsStateWithLifecycle()
     val share = rememberShareDetails(session)
-    SessionDetailView(session, onBackClick, share)
+    SessionDetailView(
+        session = session,
+        popBack = onBackClick,
+        share = share,
+        onSpeakerClick = { speakerId ->
+            onSpeakerClick(SpeakerDetailsKey(conference = conference, speakerId = speakerId))
+        }
+    )
 }
 
 @Composable
-fun SessionDetailView(session: SessionDetails?, popBack: () -> Unit, share: () -> Unit) {
+fun SessionDetailView(
+    session: SessionDetails?,
+    popBack: () -> Unit,
+    share: () -> Unit,
+    onSpeakerClick: (speakerId: String) -> Unit
+) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current
 
@@ -114,7 +132,8 @@ fun SessionDetailView(session: SessionDetails?, popBack: () -> Unit, share: () -
                             onSocialLinkClick = { socialItem, _ ->
                                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(socialItem.url))
                                 context.startActivity(intent)
-                            }
+                            },
+                            onSpeakerClick = onSpeakerClick
                         )
                     }
                 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionSpeakerInfo.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionSpeakerInfo.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.sessiondetails
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -27,6 +29,7 @@ import dev.johnoreilly.confetti.ui.component.SocialIcon
 fun SessionSpeakerInfo(
     modifier: Modifier = Modifier,
     speaker: SpeakerDetails,
+    onSpeakerClick: (speakerId: String) -> Unit,
     onSocialLinkClick: (SpeakerDetails.Social, SpeakerDetails) -> Unit
 ) {
     Column(modifier.padding(top = 16.dp, bottom = 8.dp)) {
@@ -34,7 +37,10 @@ fun SessionSpeakerInfo(
             AsyncImage(
                 modifier = Modifier
                     .size(64.dp)
-                    .clip(CircleShape),
+                    .clip(CircleShape)
+                    .clickable(role = Role.Button) {
+                        onSpeakerClick(speaker.id)
+                    },
                 placeholder = painterResource(R.drawable.ic_person_black_24dp),
                 error = painterResource(R.drawable.ic_person_black_24dp),
                 model = ImageRequest.Builder(LocalContext.current)

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/navigation/SessionDetailsDestination.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/navigation/SessionDetailsDestination.kt
@@ -8,6 +8,7 @@ import androidx.navigation.navArgument
 import dev.johnoreilly.confetti.navigation.urlDecoded
 import dev.johnoreilly.confetti.navigation.urlEncoded
 import dev.johnoreilly.confetti.sessiondetails.SessionDetailsRoute
+import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
 
 private const val base = "session_details"
 private const val sessionIdArg = "sessionIdArg"
@@ -29,12 +30,15 @@ class SessionDetailsKey(val conference: String, val sessionId: String) {
     val route: String = "$base/${conference.urlEncoded()}/${sessionId.urlEncoded()}"
 }
 
-fun NavGraphBuilder.sessionDetailsGraph(onBackClick: () -> Unit) {
+fun NavGraphBuilder.sessionDetailsGraph(
+    onBackClick: () -> Unit,
+    navigateToSpeakerDetails: (SpeakerDetailsKey) -> Unit
+) {
     composable(
         route = pattern,
         arguments = arguments
     ) {
         val key = SessionDetailsKey(it)
-        SessionDetailsRoute(key.conference, key.sessionId, onBackClick)
+        SessionDetailsRoute(key.conference, key.sessionId, onBackClick, navigateToSpeakerDetails)
     }
 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiApp.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiApp.kt
@@ -64,7 +64,12 @@ fun ConfettiApp(
             onSignOut = ::onSignOut,
             onSwitchConferenceSelected = ::onSwitchConference
         )
-        sessionDetailsGraph(appState::onBackClick)
+        sessionDetailsGraph(
+            appState::onBackClick,
+            navigateToSpeakerDetails = { key ->
+                appState.navigate(key.route)
+            }
+        )
         speakersGraph(
             appState = appState,
             navigateToSpeaker = { appState.navigate(it.route) },


### PR DESCRIPTION
In this PR I have added navigation to the speaker details of the speaker who is clicked on in the session details. 
This should resolve #492 

In the issue it says that if you click the image it should navigate. Does that make sense? Or should it be if you click the speaker detail section?


https://user-images.githubusercontent.com/54936943/229589890-81689668-af12-4902-aab4-c2db38c73942.mp4

