### PR TITLE
Show time and room in session details

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -39,6 +39,7 @@ import dev.johnoreilly.confetti.SessionDetailsViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
 import dev.johnoreilly.confetti.utils.format
+import kotlinx.datetime.LocalDateTime
 import org.koin.androidx.compose.getViewModel
 import java.time.format.DateTimeFormatter
 
@@ -110,6 +111,23 @@ fun SessionDetailView(
                     )
 
                     Spacer(modifier = Modifier.size(16.dp))
+
+                    Text(
+                        text = session.startsAt.toTimeString(),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        style = MaterialTheme.typography.labelLarge
+                    )
+
+                    session.room?.name?.let { roomName ->
+                        Text(
+                            text = roomName,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.size(16.dp))
+
                     Text(
                         text = session.sessionDescription ?: "",
                         style = MaterialTheme.typography.bodyMedium
@@ -142,6 +160,11 @@ fun SessionDetailView(
     }
 }
 
+private fun LocalDateTime.toTimeString(): String {
+    val timeFormatter = DateTimeFormatter.ofPattern("hh:mm")
+    return timeFormatter.format(this)
+}
+
 
 @Composable
 fun Chip(name: String) {
@@ -169,7 +192,6 @@ private fun rememberShareDetails(details: SessionDetails?): () -> Unit {
         if (details == null) return@remember {}
 
         val dateFormatter = DateTimeFormatter.ofPattern("dd/MM")
-        val timeFormatter = DateTimeFormatter.ofPattern("hh:mm")
 
         val sendIntent = Intent().apply {
             action = Intent.ACTION_SEND
@@ -177,8 +199,8 @@ private fun rememberShareDetails(details: SessionDetails?): () -> Unit {
 
             val room = details.room?.name ?: "Unknown"
             val date = dateFormatter.format(details.startsAt)
-            val startsAt = timeFormatter.format(details.startsAt)
-            val endsAt = timeFormatter.format(details.endsAt)
+            val startsAt = details.startsAt.toTimeString()
+            val endsAt = details.endsAt.toTimeString()
             val schedule = "$date $startsAt-$endsAt"
             val speakers = details
                 .speakers

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -113,7 +113,7 @@ fun SessionDetailView(
                     Spacer(modifier = Modifier.size(16.dp))
 
                     Text(
-                        text = session.startsAt.toTimeString(),
+                        text = session.startsAt.toTimeString(session.endsAt),
                         color = MaterialTheme.colorScheme.onSurface,
                         style = MaterialTheme.typography.labelLarge
                     )
@@ -160,9 +160,12 @@ fun SessionDetailView(
     }
 }
 
-private fun LocalDateTime.toTimeString(): String {
-    val timeFormatter = DateTimeFormatter.ofPattern("hh:mm")
-    return timeFormatter.format(this)
+private fun LocalDateTime.toTimeString(endsAt: LocalDateTime): String {
+    val startTimeFormatter = DateTimeFormatter.ofPattern("MMM d hh:mm")
+    val endTimeFormatter = DateTimeFormatter.ofPattern("hh:mm")
+    val startTimeDate = startTimeFormatter.format(this)
+    val endsAtTime = endTimeFormatter.format(endsAt)
+    return "$startTimeDate - $endsAtTime"
 }
 
 
@@ -192,6 +195,7 @@ private fun rememberShareDetails(details: SessionDetails?): () -> Unit {
         if (details == null) return@remember {}
 
         val dateFormatter = DateTimeFormatter.ofPattern("dd/MM")
+        val timeFormatter = DateTimeFormatter.ofPattern("hh:mm")
 
         val sendIntent = Intent().apply {
             action = Intent.ACTION_SEND
@@ -199,8 +203,8 @@ private fun rememberShareDetails(details: SessionDetails?): () -> Unit {
 
             val room = details.room?.name ?: "Unknown"
             val date = dateFormatter.format(details.startsAt)
-            val startsAt = details.startsAt.toTimeString()
-            val endsAt = details.endsAt.toTimeString()
+            val startsAt = timeFormatter.format(details.startsAt)
+            val endsAt = timeFormatter.format(details.endsAt)
             val schedule = "$date $startsAt-$endsAt"
             val speakers = details
                 .speakers


### PR DESCRIPTION
Added the time and room for to be displayed in the session details. 

This should resolve #487 

I used `labelLarge` for these texts. Not quite sure if that is correct. According to M3 docs, you can use that for small texts in text bodys like captions (https://m3.material.io/styles/typography/applying-type#af6eb002-9cbb-4b64-bce6-1315d2252364). I can change it up if that is preferred. Maybe it's a bit small. Here is how it looks

Android Phone

![image](https://user-images.githubusercontent.com/54936943/229933564-f2d505c7-0453-4f25-8caf-208a3ce1e9d8.png)

Android Tablet
![image](https://user-images.githubusercontent.com/54936943/229933617-254624a9-ff40-4d43-8c89-82bc237a88f4.png)
