### PR TITLE
Improve ripple on speaker view on session details

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -96,15 +96,17 @@ fun SessionDetailView(
         }
     ) {
         Column(modifier = Modifier.padding(it)) {
+            val horizontalPadding = 16.dp
             session?.let { session ->
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(vertical = 8.dp)
                         .verticalScroll(state = scrollState)
                 ) {
 
                     Text(
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
                         text = session.title,
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.titleLarge
@@ -113,6 +115,7 @@ fun SessionDetailView(
                     Spacer(modifier = Modifier.size(16.dp))
 
                     Text(
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
                         text = session.startsAt.toTimeString(session.endsAt),
                         color = MaterialTheme.colorScheme.onSurface,
                         style = MaterialTheme.typography.labelLarge
@@ -120,6 +123,7 @@ fun SessionDetailView(
 
                     session.room?.name?.let { roomName ->
                         Text(
+                            modifier = Modifier.padding(horizontal = horizontalPadding),
                             text = roomName,
                             color = MaterialTheme.colorScheme.onSurface,
                             style = MaterialTheme.typography.labelLarge
@@ -129,13 +133,14 @@ fun SessionDetailView(
                     Spacer(modifier = Modifier.size(16.dp))
 
                     Text(
+                        modifier = Modifier.padding(horizontal = horizontalPadding),
                         text = session.sessionDescription ?: "",
                         style = MaterialTheme.typography.bodyMedium
                     )
 
                     if (session.tags.isNotEmpty()) {
                         Spacer(modifier = Modifier.size(16.dp))
-                        FlowRow {
+                        FlowRow(modifier = Modifier.padding(horizontal = horizontalPadding)) {
                             session.tags.distinct().forEach { tag ->
                                 Box(Modifier.padding(bottom = 8.dp)) {
                                     Chip(tag)

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionSpeakerInfo.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionSpeakerInfo.kt
@@ -37,7 +37,8 @@ fun SessionSpeakerInfo(
             .clickable(role = Role.Button) {
                 onSpeakerClick(speaker.id)
             }
-            .padding(top = 16.dp, bottom = 8.dp),
+            .padding(top = 16.dp, bottom = 8.dp)
+            .padding(horizontal = 16.dp)
     ) {
         Row {
             AsyncImage(


### PR DESCRIPTION
Following up on comment from @marcellogalhardo (https://github.com/joreilly/Confetti/pull/511#issuecomment-1497821209).  Trying to improve the ripple effect so that it is going all the way to the sides horizontally. This was to remove the pointy square feeling.

Now it looks like this:


https://user-images.githubusercontent.com/54936943/230162005-2179d00c-2f56-4bbe-8f9e-7a65e409c049.mp4

