### PR TITLE
Fix session details time format

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -161,8 +161,8 @@ fun SessionDetailView(
 }
 
 private fun LocalDateTime.toTimeString(endsAt: LocalDateTime): String {
-    val startTimeFormatter = DateTimeFormatter.ofPattern("MMM d hh:mm")
-    val endTimeFormatter = DateTimeFormatter.ofPattern("hh:mm")
+    val startTimeFormatter = DateTimeFormatter.ofPattern("MMM d HH:mm")
+    val endTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     val startTimeDate = startTimeFormatter.format(this)
     val endsAtTime = endTimeFormatter.format(endsAt)
     return "$startTimeDate - $endsAtTime"


### PR DESCRIPTION
The formatting here was different from what's displayed for the session overview screen

For sessions starting 13:00 this was showing 01:00 in the details part but 13:00 in the overview part, so I changed it to match the overview.