### PR TITLE
Fix session screen having some unnecessary bottom padding

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
@@ -13,12 +13,17 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowColumn
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -87,7 +92,9 @@ fun SessionListGridView(
 
                     Row(
                         Modifier
-                            .padding(bottom = 60.dp)
+                            .windowInsetsPadding(
+                                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
+                            )
                             .horizontalScroll(rememberScrollState())
                     ) {
                         val sessionsByStartTime = uiState.sessionsByStartTimeList[page]

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiScaffold.kt
@@ -1,22 +1,20 @@
-@file:OptIn(
-    ExperimentalAnimationApi::class, ExperimentalMaterial3Api::class,
-    ExperimentalComposeUiApi::class
-)
+@file:OptIn(ExperimentalMaterial3Api::class)
 
 package dev.johnoreilly.confetti.ui
 
 import android.annotation.SuppressLint
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -28,8 +26,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -41,7 +37,6 @@ import dev.johnoreilly.confetti.auth.Authentication
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.settings.SettingsDialog
 import dev.johnoreilly.confetti.wear.WearSettingsSync
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 class ScaffoldState(
@@ -182,10 +177,20 @@ fun ConfettiScaffold(
                     .padding(innerPadding)
                     .fillMaxHeight()
             ) {
-                Box(modifier = Modifier.weight(1f)) {
+                val shouldShowBottomBar = appState.shouldShowBottomBar
+                // If the bottom bar is shown, we must properly inform our content() that the
+                // navigation bar insets have been consumed already.
+                val consumedInsetsModifier = if (shouldShowBottomBar) {
+                    Modifier.consumeWindowInsets(NavigationBarDefaults.windowInsets)
+                } else {
+                    Modifier
+                }
+                Box(modifier = Modifier
+                    .weight(1f)
+                    .then(consumedInsetsModifier)) {
                     content(snackbarHostState)
                 }
-                if (appState.shouldShowBottomBar) {
+                if (shouldShowBottomBar) {
                     ConfettiBottomBar(
                         conference = conference,
                         onNavigateToDestination = appState::navigateToTopLevelDestination,


### PR DESCRIPTION
Make use of window insets instead, to specifically only pad that much for cases like tablets, while still making sure that in phone form factors the insets are not applied two times.

How it looked like before:
![landscape_too_much_bottom_padding](https://user-images.githubusercontent.com/44558292/230506944-edb0902e-1f92-4104-a494-e12b9929cb27.png)

Changing from padding(80) to using insets initially changes it to this (Got some red border to indicate where the content should be):
That extra spacing is from the window insets for the navigation bar being applied again
![before_consuming_the_bottom_bar_paddings](https://user-images.githubusercontent.com/44558292/230506979-dc7dd0b0-366c-474f-8f00-4316293836e0.png)

The `consumedInsetsModifier` I added makes sure that we inform the content that the insets are already consumed. This does not happen automatically in this case since `ConfettiBottomBar` and `content()` are two separate items, and the way that the inset modifiers work is that they inform items that are children of wherever they are applied. Since now they're not inside each other but in a column side by side, we need to do this ourselves.

And finally we get this result:
| Phone | Tablet |
| --- | --- |
| ![after_fix](https://user-images.githubusercontent.com/44558292/230507608-99886edc-0089-43ca-b4d3-80364ac7aaaa.png) | ![after_fix_tablet](https://user-images.githubusercontent.com/44558292/230507617-6e8b5b7f-f996-41e7-899f-d27b5fcf4c86.png) |

