### PR TITLE
Indicate lightning talks

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -53,6 +54,7 @@ import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.RoomDetails
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.isLightning
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.ui.ErrorView
 import dev.johnoreilly.confetti.ui.LoadingView
@@ -206,6 +208,19 @@ fun SessionGridRow(
                         )
                         Spacer(modifier = Modifier.weight(1f))
                         Speakers(session = session)
+                        if (session.isLightning()) {
+                            Surface(
+                                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                                shape = MaterialTheme.shapes.small,
+                                color = MaterialTheme.colorScheme.primaryContainer
+                            ) {
+                                Row(Modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
+                                    Icon(Icons.Default.Bolt, "lightning")
+                                    Spacer(Modifier.width(4.dp))
+                                    Text("Lightning / ${session.startsAt.time}-${session.endsAt.time}")
+                                }
+                            }
+                        }
                     }
                     Bookmark(
                         modifier = Modifier.align(Alignment.CenterEnd),

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
@@ -191,10 +191,10 @@ fun SessionGridRow(
                 Box(Modifier.fillMaxSize()) {
                     Column(
                         modifier = Modifier
-                            .padding(16.dp)
                             .clickable(onClick = {
                                 sessionSelected(SessionDetailsKey(conference, session.id))
-                            }),
+                            })
+                            .padding(16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text(

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -3,13 +3,14 @@
 package dev.johnoreilly.confetti.sessions
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
@@ -17,18 +18,15 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.Divider
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
@@ -42,14 +40,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import dev.johnoreilly.confetti.SessionsUiState
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.isLightning
 import dev.johnoreilly.confetti.sessionSpeakers
 import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.ui.ErrorView
@@ -59,7 +56,6 @@ import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.ui.component.ConfettiTab
 import dev.johnoreilly.confetti.ui.component.pagerTabIndicatorOffset
 import kotlinx.coroutines.launch
-import org.koin.androidx.compose.get
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -155,7 +151,6 @@ fun SessionListTabRow(pagerState: PagerState, uiState: SessionsUiState.Success) 
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionItemView(
     conference: String,
@@ -180,7 +175,7 @@ fun SessionItemView(
                 Text(text = session.title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold))
             }
 
-            session.room?.let {
+            session.room?.let { room ->
                 Row(
                     modifier = Modifier.padding(top = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -196,14 +191,26 @@ fun SessionItemView(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        it.name,
+                        room.name,
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.Gray
                     )
                 }
-
             }
 
+            if (session.isLightning()) {
+                Surface(
+                    modifier = Modifier.padding(top = 8.dp),
+                    shape = MaterialTheme.shapes.small,
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                ) {
+                    Row(Modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
+                        Icon(Icons.Default.Bolt, "lightning")
+                        Spacer(Modifier.width(4.dp))
+                        Text("Lightning / ${session.startsAt.time}-${session.endsAt.time}")
+                    }
+                }
+            }
         }
 
 

--- a/iosApp/iosApp/Sessions/SessionListView.swift
+++ b/iosApp/iosApp/Sessions/SessionListView.swift
@@ -79,6 +79,14 @@ struct SessionView: View {
                 Text(session.sessionSpeakers() ?? "").font(.subheadline)
                 Text(session.room?.name ?? "").font(.subheadline).foregroundColor(.gray)
             }
+            if session.isLightning() {
+                Text("Lightning / \(session.startsAt.time)-\(session.endsAt.time)")
+                    .colorInvert()
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.primary)
+                    .cornerRadius(8)
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/Model.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/Model.kt
@@ -2,8 +2,14 @@ package dev.johnoreilly.confetti
 
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 
 fun SessionDetails.isBreak() = this.type == "break"
+
+fun SessionDetails.isLightning() = endsAt.toInstant(TimeZone.UTC)
+    .minus(startsAt.toInstant(TimeZone.UTC))
+    .inWholeMinutes <= 15
 
 fun SessionDetails.sessionSpeakerLocation(): String {
     var text = if (speakers.isNotEmpty())


### PR DESCRIPTION
Partially addresses #533

Used `Icons.Default.Bolt` as a simple way to get something resembling what's in the website as discussed here https://kotlinlang.slack.com/archives/C051P2HUVKP/p1680724416100319. If we want the actual same icon as the website I wasn't sure how you'd like to bring that in so I didn't do it.

### Android
| Phone | Tablet |
| --- | --- |
| ![phone_lightning](https://user-images.githubusercontent.com/44558292/230522571-ced7f5f6-b233-4519-8161-77e9a160cd41.png) | ![tablet_lightning](https://user-images.githubusercontent.com/44558292/230522577-ec2dea6a-90d9-435d-9161-d997ce9a153b.png) |

Plus a little change in the modifier order so that the click interaction in the card spans across the entire card.

### iOS

| Light mode | Dark mode |
| --- | --- |
| ![simulator_screenshot_F711D0FC-AB8C-48AC-835B-7B8E7468D12D](https://user-images.githubusercontent.com/44558292/230530510-975a12dd-75ab-40b8-888c-7b5de610b840.png) | ![simulator_screenshot_2](https://user-images.githubusercontent.com/44558292/230530271-8f4b9c1d-689d-4be8-967c-8f28c2d5e870.png) |

### Room for improvement:
The iOS implementation probably can use some love, I've never really written SwiftUI code before 😅 Also didn't add the lightning as I wanted to hear which one you'd like to use there, as it may change for Android too.
Get opinions about the color decision of using `primaryContainer`, especially in the big screen where the primaryContainer isn't as nice as it is on the small screen which is on top of just the background color.