### PR TITLE
Going under navigation bar in the top level screens that now show navigation rail instead

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/bookmarks/BookmarksView.kt
@@ -4,6 +4,11 @@ package dev.johnoreilly.confetti.bookmarks
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
@@ -147,7 +152,10 @@ private fun BookmarksHorizontalPager(
                 upcomingSessions
             }
 
-        LazyColumn {
+        LazyColumn(
+            contentPadding = WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
+                .asPaddingValues()
+        ) {
             items(displayedSessions) { session ->
                 SessionItemView(
                     conference = conference,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -8,10 +8,15 @@ package dev.johnoreilly.confetti.search
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imeNestedScroll
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
@@ -102,6 +107,9 @@ fun SearchView(
             } else if (search.isNotBlank()) {
                 LazyColumn(
                     modifier = Modifier.imeNestedScroll(),
+                    contentPadding = WindowInsets.safeDrawing
+                        .only(WindowInsetsSides.Bottom)
+                        .asPaddingValues()
                 ) {
                     sessionItems(
                         conference = conference,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListGridView.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowColumn
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -23,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -64,6 +65,7 @@ import dev.johnoreilly.confetti.sessiondetails.navigation.SessionDetailsKey
 import dev.johnoreilly.confetti.ui.ErrorView
 import dev.johnoreilly.confetti.ui.LoadingView
 import dev.johnoreilly.confetti.ui.SignInDialog
+import dev.johnoreilly.confetti.utils.plus
 
 @Composable
 fun SessionListGridView(
@@ -92,13 +94,7 @@ fun SessionListGridView(
                     state = pagerState,
                 ) { page ->
 
-                    Row(
-                        Modifier
-                            .windowInsetsPadding(
-                                WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
-                            )
-                            .horizontalScroll(rememberScrollState())
-                    ) {
+                    Row(Modifier.horizontalScroll(rememberScrollState())) {
                         val sessionsByStartTime = uiState.sessionsByStartTimeList[page]
 
                         val rooms = uiState.rooms.filter { room ->
@@ -129,8 +125,11 @@ fun SessionListGridView(
 
                             LazyColumn(
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(end = 16.dp)
+                                    .fillMaxWidth(),
+                                contentPadding = PaddingValues(end = 16.dp).plus(
+                                    WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)
+                                        .asPaddingValues()
+                                )
                             ) {
                                 sessionsByStartTime.forEach {
                                     item {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/speakers/SpeakerView.kt
@@ -37,6 +37,7 @@ import dev.johnoreilly.confetti.ui.ConfettiAppState
 import dev.johnoreilly.confetti.ui.ConfettiScaffold
 import dev.johnoreilly.confetti.ui.ErrorView
 import dev.johnoreilly.confetti.ui.LoadingView
+import dev.johnoreilly.confetti.utils.plus
 import org.koin.androidx.compose.getViewModel
 
 
@@ -86,11 +87,10 @@ fun SpeakerGridView(
     navigateToSpeaker: (SpeakerDetailsKey) -> Unit
 ) {
     LazyVerticalGrid(
-        modifier = Modifier.padding(16.dp),
         columns = GridCells.Adaptive(200.dp),
-
-        // content padding
-        contentPadding = PaddingValues(8.dp),
+        contentPadding = PaddingValues(16.dp).plus(
+            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom).asPaddingValues()
+        ),
         content = {
             items(speakers) { speaker ->
                 Column(

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/utils/PaddingValuesExt.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/utils/PaddingValuesExt.kt
@@ -1,0 +1,19 @@
+package dev.johnoreilly.confetti.utils
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+
+operator fun PaddingValues.plus(that: PaddingValues): PaddingValues = object : PaddingValues {
+    override fun calculateBottomPadding(): Dp =
+        this@plus.calculateBottomPadding() + that.calculateBottomPadding()
+
+    override fun calculateLeftPadding(layoutDirection: LayoutDirection): Dp =
+        this@plus.calculateLeftPadding(layoutDirection) + that.calculateLeftPadding(layoutDirection)
+
+    override fun calculateRightPadding(layoutDirection: LayoutDirection): Dp =
+        this@plus.calculateRightPadding(layoutDirection) + that.calculateRightPadding(layoutDirection)
+
+    override fun calculateTopPadding(): Dp =
+        this@plus.calculateTopPadding() + that.calculateTopPadding()
+}


### PR DESCRIPTION
These were adding some padding which is unnecessary. Winning a tiny bit more screen real estate 😊

### Sessions
| Before | After |
| --- | --- |
| ![before_insets](https://user-images.githubusercontent.com/44558292/230598912-cd784c15-e88e-4bb1-8177-1864107347bf.png) | ![after_insets](https://user-images.githubusercontent.com/44558292/230598921-cb8ff90f-3969-4be7-a835-e8df2d02bf27.png) |


### Speakers
| Before | After |
| --- | --- |
| ![before_speakers](https://user-images.githubusercontent.com/44558292/230598944-abefb6f8-0bd9-4496-8dd5-47c36d6cb418.png) | ![after_speakers](https://user-images.githubusercontent.com/44558292/230598951-b8d42201-3ec1-4132-bc40-083f63cae0f8.png) |


#### The following two were going under, but just were not adding the necessary spacing after the last item:

### Search
| Before | After |
| --- | --- |
| ![before_search_max_scroll](https://user-images.githubusercontent.com/44558292/230599006-f5a1f58e-f120-491d-b9db-961a38db8d87.png) | ![after_search_max_scroll](https://user-images.githubusercontent.com/44558292/230599034-c66fcdbf-cf48-45c7-8111-ce94dc852337.png) |

### Bookmarks
| Before | After |
| --- | --- |
| ![before_bookmarks](https://user-images.githubusercontent.com/44558292/230599060-cf088b36-75e0-41c2-af1a-e96eb9dc0069.png) | ![after_bookmarks](https://user-images.githubusercontent.com/44558292/230599070-6d2c1a5a-5448-4d6b-a68a-5bf7d377b7c5.png) |
