### PR TITLE
Opening sessions tab should show relevant talks for current date and hour

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -81,8 +81,14 @@ fun SessionListView(
             Column {
                 val initialPage by remember {
                     derivedStateOf {
-                        val indexOfNow = uiState.confDates.indexOf(uiState.now.date)
-                        if (indexOfNow == -1) 0 else indexOfNow
+                        val initialPage = uiState
+                            .confDates
+                            .withIndex()
+                            .minByOrNull { (_, sessionDate) ->
+                                abs(uiState.now.dayOfYear - sessionDate.dayOfYear)
+                            }
+
+                        initialPage?.index ?: 0
                     }
                 }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -69,14 +70,20 @@ fun SessionListView(
     onNavigateToSignIn: () -> Unit,
     user: User?
 ) {
-    val pagerState = rememberPagerState()
-
     when (uiState) {
         SessionsUiState.Error -> ErrorView(onRefresh)
         SessionsUiState.Loading -> LoadingView()
         is SessionsUiState.Success -> {
             val state = rememberPullRefreshState(refreshing, onRefresh)
             Column {
+                val initialPage by remember {
+                    derivedStateOf {
+                        val indexOfNow = uiState.confDates.indexOf(uiState.now.date)
+                        if (indexOfNow == -1) 0 else indexOfNow
+                    }
+                }
+
+                val pagerState = rememberPagerState(initialPage)
 
                 SessionListTabRow(pagerState, uiState)
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessions/SessionListView.kt
@@ -2,6 +2,7 @@
 
 package dev.johnoreilly.confetti.sessions
 
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -57,6 +59,7 @@ import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.ui.component.ConfettiTab
 import dev.johnoreilly.confetti.ui.component.pagerTabIndicatorOffset
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -91,14 +94,48 @@ fun SessionListView(
                     pageCount = uiState.formattedConfDates.size,
                     state = pagerState,
                 ) { page ->
-
                     val sessions = uiState.sessionsByStartTimeList[page]
+
+                    val initialItem by remember {
+                        derivedStateOf {
+                            // Retrieves the initial item matching an hour block, including the
+                            // aggregated index (ignores time grouping).
+                            val initialItem = sessions
+                                .values
+                                .flatten()
+                                .withIndex()
+                                .minByOrNull { (_, session) ->
+                                    abs(uiState.now.hour - session.startsAt.hour) +
+                                        abs(uiState.now.minute - session.startsAt.minute)
+                                }
+
+                            // Count the number of sticky headers until the initial item.
+                            val stickyHeader = sessions
+                                .entries
+                                .withIndex()
+                                .firstOrNull {
+                                    it.value.value.contains(initialItem?.value)
+                                }
+
+                            val stickyHeaderIndex = stickyHeader?.index ?: 0
+                            val initialItemIndex = initialItem?.index ?: 0
+
+                            // Sum the index of the initial item and the sticky headers.
+                            stickyHeaderIndex + initialItemIndex
+                        }
+                    }
+
+                    val listState = rememberLazyListState(
+                        initialFirstVisibleItemIndex = initialItem,
+                        initialFirstVisibleItemScrollOffset = initialItem,
+                    )
+
                     Box(
                         Modifier
                             .pullRefresh(state)
                             .clipToBounds()
                     ) {
-                        LazyColumn {
+                        LazyColumn(state = listState) {
                             sessions.forEach { (startTime, sessions) ->
                                 stickyHeader {
                                     ConfettiHeader(icon = Icons.Filled.AccessTime, text = startTime)
@@ -179,7 +216,10 @@ fun SessionItemView(
     Row(modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         Column(modifier = Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = session.title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold))
+                Text(
+                    text = session.title,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                )
             }
 
             session.room?.let { room ->

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SessionsViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
@@ -229,14 +230,15 @@ open class SessionsViewModel : KMMViewModel(), KoinComponent {
             dateService.format(date.atTime(0, 0), timeZone, "MMM dd, yyyy")
         }
         return SessionsUiState.Success(
-            conference!!,
-            dateService.now(),
-            conferenceName,
-            formattedConfDates,
-            sessionsByStartTimeList,
-            speakers,
-            rooms,
-            bookmarksData.bookmarks?.sessionIds.orEmpty().toSet(),
+            conference = conference!!,
+            now = dateService.now(),
+            conferenceName = conferenceName,
+            confDates = confDates,
+            formattedConfDates = formattedConfDates,
+            sessionsByStartTimeList = sessionsByStartTimeList,
+            speakers = speakers,
+            rooms = rooms,
+            bookmarks = bookmarksData.bookmarks?.sessionIds.orEmpty().toSet(),
         )
     }
 }
@@ -250,6 +252,7 @@ sealed interface SessionsUiState {
         val conference: String,
         val now: LocalDateTime,
         val conferenceName: String,
+        val confDates: List<LocalDate>,
         val formattedConfDates: List<String>,
         val sessionsByStartTimeList: List<Map<String, List<SessionDetails>>>,
         val speakers: List<SpeakerDetails>,


### PR DESCRIPTION
* Opens session tab in the current date.
* Opens session tab in the current "time slot" (closest hour to the current hour).

For the tests, I hard coded the current result for `now`: `LocalDateTime(year = 2023, month = 4, day = 14, hour = 11, minutes = 20)`, and opened the application.

| Before | After |
|---|---|
| ![Screenshot_1681149714](https://user-images.githubusercontent.com/4348197/230964027-2f2ab812-9d68-4fd2-ab75-fa26fc6fef7a.png) | ![Screenshot_1681149709](https://user-images.githubusercontent.com/4348197/230964061-7a329d01-4f8c-4ac4-a0b3-8524fea42369.png) |

