### PR TITLE
Add `ConfettiHeader` to speakers section in Session Details

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/search/SearchView.kt
@@ -141,7 +141,10 @@ private fun LazyListScope.speakerItems(
     // Shows header if and only if there are speaker results.
     if (speakers.isNotEmpty()) {
         stickyHeader {
-            ConfettiHeader(icon = Icons.Filled.Person, text = "Speakers")
+            ConfettiHeader(
+                icon = Icons.Filled.Person,
+                text = stringResource(R.string.speakers),
+            )
         }
     }
     items(speakers) { speaker ->
@@ -166,7 +169,10 @@ private fun LazyListScope.sessionItems(
     // Shows header if and only if there are session results.
     if (sessions.isNotEmpty()) {
         stickyHeader {
-            ConfettiHeader(icon = Icons.Filled.Event, text = "Sessions")
+            ConfettiHeader(
+                icon = Icons.Filled.Event,
+                text = stringResource(R.string.sessions),
+            )
         }
     }
     items(sessions) { session ->

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -34,10 +34,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.SessionDetailsViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
@@ -155,7 +157,7 @@ fun SessionDetailView(
                     }
 
                     ConfettiHeader(
-                        text = "Speakers",
+                        text = stringResource(R.string.speakers),
                         icon = Icons.Filled.Person,
                     )
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/sessiondetails/SessionDetailsView.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,6 +41,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.johnoreilly.confetti.SessionDetailsViewModel
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.speakerdetails.navigation.SpeakerDetailsKey
+import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.utils.format
 import kotlinx.datetime.LocalDateTime
 import org.koin.androidx.compose.getViewModel
@@ -149,9 +151,16 @@ fun SessionDetailView(
                                 }
                             }
                         }
+                        Spacer(modifier = Modifier.size(16.dp))
                     }
 
+                    ConfettiHeader(
+                        text = "Speakers",
+                        icon = Icons.Filled.Person,
+                    )
+
                     Spacer(modifier = Modifier.size(16.dp))
+
                     session.speakers.forEach { speaker ->
                         SessionSpeakerInfo(speaker = speaker.speakerDetails,
                             onSocialLinkClick = { socialItem, _ ->


### PR DESCRIPTION
* Add `ConfettiHeader` to Speakers section inside Session Details.
* Improves UI and makes it consistent with other screens.
* Replace hardcoded Strings with `R.string` variants.

![Screenshot_1681160789](https://user-images.githubusercontent.com/4348197/230999556-9054477e-54c1-44c1-81eb-0928c50215dd.png)
