### PR TITLE
Add adaptive monochrome icon

### DIFF
--- a/shared/src/androidMain/res/drawable/ic_launcher_foreground.xml
+++ b/shared/src/androidMain/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,86 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="449"
+        android:viewportHeight="448">
+    <group
+            android:scaleX="0.67"
+            android:scaleY="0.6685078"
+            android:translateX="74.085"
+            android:translateY="74.25426">
+        <path
+                android:pathData="M115.63,337.28C52.76,274.41 52.76,172.47 115.63,109.6C165.85,59.38 242.45,48.37 304.28,80.84L306.15,81.83L268.04,152.17C236.81,135.25 197.72,140.64 172.2,166.16C140.57,197.8 140.57,249.08 172.2,280.72C197.86,306.37 237.19,311.65 268.44,294.49L269.38,293.96L308.83,363.56C246.34,398.99 167.15,388.8 115.63,337.28Z"
+                android:fillColor="#ffffff" />
+        <group>
+            <clip-path android:pathData="M115.63,337.28C52.76,274.41 52.76,172.47 115.63,109.6C165.85,59.38 242.45,48.37 304.28,80.84L306.15,81.83L268.04,152.17C236.81,135.25 197.72,140.64 172.2,166.16C140.57,197.8 140.57,249.08 172.2,280.72C197.86,306.37 237.19,311.65 268.44,294.49L269.38,293.96L308.83,363.56C246.34,398.99 167.15,388.8 115.63,337.28Z" />
+            <path
+                    android:pathData="M245.08,184.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#DB4437"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M150.08,414.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#DB4437"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M340.08,463.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#DB4437"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M191.08,221.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#DB4437"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M314.08,236.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#DB4437"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M154.08,148.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#F4B400"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M292.08,496.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#F4B400"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M228.08,132.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#F4B400"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M223.08,362.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#F4B400"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M300.08,358.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#0F9D58"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M211.08,450.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#0F9D58"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M103.08,354.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#0F9D58"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M99.08,278.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#0F9D58"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M287.08,155.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#4285F4"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M302.08,424.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#4285F4"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M185.08,324.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#4285F4"
+                    android:fillAlpha="0.75" />
+            <path
+                    android:pathData="M107.08,211.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                    android:fillColor="#4285F4"
+                    android:fillAlpha="0.75" />
+        </group>
+    </group>
+</vector>

--- a/shared/src/androidMain/res/drawable/ic_launcher_monochrome.xml
+++ b/shared/src/androidMain/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,61 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="449"
+        android:viewportHeight="448">
+    <group
+            android:scaleX="0.67"
+            android:scaleY="0.6685078"
+            android:translateX="74.085"
+            android:translateY="74.25426">
+        <clip-path android:pathData="M113.84,337.28C50.97,274.41 50.97,172.47 113.84,109.6C164.06,59.38 240.66,48.37 302.49,80.84L304.36,81.83L266.25,152.17C235.02,135.25 195.93,140.64 170.41,166.16C138.78,197.8 138.78,249.08 170.41,280.72C196.07,306.37 235.41,311.65 266.65,294.49L267.59,293.96L307.05,363.56C244.56,398.99 165.36,388.8 113.84,337.28Z" />
+        <path
+                android:pathData="M84.85,273.53l-48.81,-19.72l19.72,-48.81l48.81,19.72z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M183.56,324.26l-90.56,-36.59l36.59,-90.56l90.56,36.59z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M300.56,424.15l-90.56,-36.59l36.59,-90.56l90.56,36.59z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M98.68,362.26l-50.67,-20.47l20.47,-50.67l50.67,20.47z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M98.68,362.26l-50.67,-20.47l20.47,-50.67l50.67,20.47z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M278.34,152.35l-83.34,-33.67l33.67,-83.34l83.34,33.67z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M152.39,148.88l-7.53,-3.04l11.25,-27.84l7.53,3.04z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M140.25,329.77l-10.56,-4.27l3.53,-8.73l10.56,4.27z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M221.56,327.99l-15.03,-6.07l10.47,-25.92l15.03,6.07z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M196,389l-57.23,-23.12l15.71,-38.88l57.23,23.12z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M196,389l-22.07,-8.92l21.06,-52.13l22.07,8.92z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M123.36,371.28l-13.36,-5.4l12.28,-30.38l13.36,5.4z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M183.34,115.01l-54.72,-22.11l22.11,-54.72l54.72,22.11z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M104.86,211.58l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M213.72,218.7l-67.45,-27.25l27.25,-67.45l67.45,27.25z"
+                android:fillColor="#000000" />
+        <path
+                android:pathData="M151.02,182.27l-18.02,-7.28l7.28,-18.02l18.02,7.28z"
+                android:fillColor="#000000" />
+    </group>
+</vector>

--- a/shared/src/androidMain/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/shared/src/androidMain/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/shared/src/androidMain/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/shared/src/androidMain/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/shared/src/androidMain/res/values/ic_launcher_background.xml
+++ b/shared/src/androidMain/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#FFFFFF</color>
+</resources>


### PR DESCRIPTION
Took some creative liberty to add a monochrome version of the icon. I don't have a licence to sketch, so I can't open or modify the sketch file. I do have a figma source available.

<img width="545" alt="Screenshot 2023-04-20 at 12 53 53 pm" src="https://user-images.githubusercontent.com/13775137/233439013-b1373c84-be4e-437e-975b-a8930fa3369e.png">

This is how it looks 

Before:
<img src="https://user-images.githubusercontent.com/13775137/233439331-bdce864b-e7a8-4280-9696-b61c249c2e75.png" width="480"/>

After:
<img src="https://user-images.githubusercontent.com/13775137/233439386-e6697971-018b-41f5-a63f-be6c4488e375.png" width="480"/>

<img src="https://user-images.githubusercontent.com/13775137/233439639-896415a9-44d7-4238-a483-a2ad984bcef1.png" width="480"/>



