### PR TITLE
Added -dontwarn for StaticLoggerBinder to proguard-rules

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -16,5 +16,8 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
 
+# Referenced by ktor
+-dontwarn org.slf4j.impl.StaticLoggerBinder
+
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }


### PR DESCRIPTION
It seems that we need to add the `StaticLoggerBinder` `-dontwarn` for Ktor.

More info:
- https://youtrack.jetbrains.com/issue/KTOR-5528
