### PR TITLE
Google Signin: Change the oauth client id

### DIFF
--- a/androidApp/google-services.json
+++ b/androidApp/google-services.json
@@ -7,14 +7,22 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:977739339802:android:0683e4e695beadd4b799a3",
+        "mobilesdk_app_id": "1:977739339802:android:bd3d868c82b383ccb799a3",
         "android_client_info": {
           "package_name": "dev.johnoreilly.confetti"
         }
       },
       "oauth_client": [
         {
-          "client_id": "977739339802-rtlrklolvmvd87ldes0qdc48ifcn30rh.apps.googleusercontent.com",
+          "client_id": "977739339802-frqmbma0ggkrbv8l8bk827cbn39d1okr.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "dev.johnoreilly.confetti",
+            "certificate_hash": "62d40dc6870434ad7302e38b93ebf70aa9a2645f"
+          }
+        },
+        {
+          "client_id": "977739339802-403vj6tevit9ahsnru4pp18gd3ktr331.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
@@ -27,7 +35,7 @@
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "977739339802-rtlrklolvmvd87ldes0qdc48ifcn30rh.apps.googleusercontent.com",
+              "client_id": "977739339802-403vj6tevit9ahsnru4pp18gd3ktr331.apps.googleusercontent.com",
               "client_type": 3
             }
           ]

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/account/SignInView.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/account/SignInView.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.confetti.account
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -11,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -21,36 +23,40 @@ import org.koin.compose.koinInject
 
 @Composable
 fun SignInRoute(onBackClick: () -> Unit) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        var error: String? by remember { mutableStateOf(null) }
-        val launcher = rememberFirebaseAuthLauncher(
-            onAuthComplete = {
-                onBackClick()
-            },
-            onAuthError = {
-                it.printStackTrace()
-                error = "Something went wrong"
-            },
-            koinInject()
-        )
-
-        val context = LocalContext.current
-        Button(
-            modifier = Modifier.align(Alignment.Center),
-            onClick = {
-                val gso =
-                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                        .requestIdToken(context.getString(R.string.default_web_client_id))
-                        .requestEmail()
-                        .build()
-                val googleSignInClient = GoogleSignIn.getClient(context, gso)
-                launcher.launch(googleSignInClient.signInIntent)
-            }
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
         ) {
-            Text(text = stringResource(id = R.string.sign_in_google))
+            var error: String? by remember { mutableStateOf(null) }
+            val launcher = rememberFirebaseAuthLauncher(
+                onAuthComplete = {
+                    onBackClick()
+                },
+                onAuthError = {
+                    it.printStackTrace()
+                    error = "Something went wrong"
+                },
+                koinInject()
+            )
+
+            val context = LocalContext.current
+            Button(
+                onClick = {
+                    val gso =
+                        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                            .requestIdToken(context.getString(R.string.default_web_client_id))
+                            .requestEmail()
+                            .build()
+                    val googleSignInClient = GoogleSignIn.getClient(context, gso)
+                    launcher.launch(googleSignInClient.signInIntent)
+                }
+            ) {
+                Text(text = stringResource(id = R.string.sign_in_google))
+            }
+            if (error != null) {
+                Text(text = error!!, color = Color.Red)
+            }
         }
     }
 }

--- a/wearApp/google-services.json
+++ b/wearApp/google-services.json
@@ -7,14 +7,22 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:977739339802:android:0683e4e695beadd4b799a3",
+        "mobilesdk_app_id": "1:977739339802:android:bd3d868c82b383ccb799a3",
         "android_client_info": {
           "package_name": "dev.johnoreilly.confetti"
         }
       },
       "oauth_client": [
         {
-          "client_id": "977739339802-rtlrklolvmvd87ldes0qdc48ifcn30rh.apps.googleusercontent.com",
+          "client_id": "977739339802-frqmbma0ggkrbv8l8bk827cbn39d1okr.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "dev.johnoreilly.confetti",
+            "certificate_hash": "62d40dc6870434ad7302e38b93ebf70aa9a2645f"
+          }
+        },
+        {
+          "client_id": "977739339802-403vj6tevit9ahsnru4pp18gd3ktr331.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
@@ -27,7 +35,7 @@
         "appinvite_service": {
           "other_platform_oauth_client": [
             {
-              "client_id": "977739339802-rtlrklolvmvd87ldes0qdc48ifcn30rh.apps.googleusercontent.com",
+              "client_id": "977739339802-403vj6tevit9ahsnru4pp18gd3ktr331.apps.googleusercontent.com",
               "client_type": 3
             }
           ]


### PR DESCRIPTION
This somewhat makes Google signin work again. I'm not 100% sure what happened there.

The error that was happening was `ApiException: 12500`. From [stackoverflow](https://stackoverflow.com/questions/47632035/google-sign-in-error-12500), this can be a number of things from missing support email to wrong sha1

 I also put the Oauth consent screen back to "testing", which allows anyone to log in (with a warning)

From [doc](https://support.google.com/cloud/answer/10311615#publishing-status&zippy=%2Ctesting):

```
if your app requests a subset of the following: name, email address, and user profile (through the [userinfo.email, 
userinfo.profile, openid](https://developers.google.com/identity/protocols/oauth2/scopes#oauth2) scopes or their 
[OpenID Connect equivalents](https://developers.google.com/identity/protocols/oauth2/scopes#openid-connect)). 
For such requests, your users do not need to be in the trusted user list, they will not see a warning message, 
and their authorizations will not expire after 7 days.
```

This is our case, we request `userinfo.email` and `useringo.profile` only so I would say the "testing" mode allows is good enough for now? I'll try to hit the "publish" button once again after Android Makers see what this makes
