### PR TITLE
Adjust bookmark icon interaction background

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/Bookmark.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/Bookmark.kt
@@ -1,11 +1,11 @@
 package dev.johnoreilly.confetti.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,20 +18,22 @@ fun Bookmark(
     onBookmarkChange: (Boolean) -> Unit,
 ) {
 
-    val iconModifier = modifier
-        .clickable { onBookmarkChange(!isBookmarked) }
-        .padding(8.dp)
+    val iconModifier = modifier.padding(8.dp)
 
-    if (isBookmarked) {
-        Icon(
-            imageVector = Icons.Outlined.Bookmark,
-            contentDescription = "remove bookmark",
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = iconModifier)
-    } else {
-        Icon(
-            imageVector = Icons.Outlined.BookmarkAdd,
-            contentDescription = "add bookmark",
-            modifier = iconModifier)
+    IconButton(onClick = { onBookmarkChange(!isBookmarked) }) {
+        if (isBookmarked) {
+            Icon(
+                imageVector = Icons.Outlined.Bookmark,
+                contentDescription = "remove bookmark",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = iconModifier
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Outlined.BookmarkAdd,
+                contentDescription = "add bookmark",
+                modifier = iconModifier
+            )
+        }
     }
 }


### PR DESCRIPTION
A minor UI detail that bothered me. When interacting with the bookmark icon the background is a grey rectangle. For other icons like account or share action it's a circle. The difference is that the other buttons use an `IconButton` (with a nested `Icon`) while the `Bookmark` composable only uses an icon.

### Changes
Wrapped the icon(s) in the Bookmark composable with an IconButton similar to the other occurences

| Before | After |
|---|---|
| ![bookmark-before-list](https://user-images.githubusercontent.com/1376279/234096549-a8f65020-c7f6-4b9b-81b0-5601c67717f1.png) | ![bookmark-after-list](https://user-images.githubusercontent.com/1376279/234096584-3e503bf9-c527-4b24-a357-ad6a7b554e53.png) |
| ![bookmark-before-details](https://user-images.githubusercontent.com/1376279/234096800-c1d84d81-4511-4678-b28e-cf47cd76f23b.png) | ![bookmark-after-details](https://user-images.githubusercontent.com/1376279/234096866-a66f05fa-eb6a-4577-944e-6111fc75bd51.png) |

