### PR TITLE
Fixed speakers' photo url

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/auto/speakers/SpeakersScreen.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/auto/speakers/SpeakersScreen.kt
@@ -79,7 +79,7 @@ class SpeakersScreen(
                     }.setImage(
                         if (image == null) {
                             lifecycleScope.launch {
-                                images.add(AutoImage(speaker.id, fetchImage(carContext, speaker.id, speaker.name)))
+                                images.add(AutoImage(speaker.id, fetchImage(carContext, speaker.id, speaker.photoUrl ?: "")))
                                 invalidate()
                             }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/auto/speakers/details/SpeakerDetailsScreen.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/auto/speakers/details/SpeakerDetailsScreen.kt
@@ -41,7 +41,7 @@ class SpeakerDetailsScreen(
                 )
             } else {
                 lifecycleScope.launch {
-                    speakerImage = fetchImage(carContext, speaker.id, speaker.name)
+                    speakerImage = fetchImage(carContext, speaker.id, speaker.photoUrl ?: " ")
                     invalidate()
                 }
 


### PR DESCRIPTION
Was wrongly setting the name instead of the `photoUrl`. 

Due to cache, it kept working, only on a new install I was able to replicate this.