### PR TITLE
Add desugaring dependency to androidTest project

### DIFF
--- a/androidTest/build.gradle.kts
+++ b/androidTest/build.gradle.kts
@@ -36,4 +36,6 @@ dependencies {
     implementation(libs.compose.ui.test.junit4)
     implementation(libs.koin.test)
     implementation(libs.okio)
+
+    coreLibraryDesugaring(libs.desugar)
 }


### PR DESCRIPTION
Gradle was failing with an error without this, when called from the Apollo Kotlin IJ plugin. Not sure why we don't get any Gradle failure elsewhere 😅