### PR TITLE
Try to reduce AppEngine costs a bit

### DIFF
--- a/backend/service-graphql/src/main/appengine/app.yaml
+++ b/backend/service-graphql/src/main/appengine/app.yaml
@@ -1,12 +1,8 @@
 service: graphql
 runtime: java17
-instance_class: F2
+instance_class: F1
 
 entrypoint: java -Xmx64m -jar service-graphql.jar
-
-automatic_scaling:
-  min_instances: 1
-  max_instances: 10
 
 inbound_services:
   - warmup


### PR DESCRIPTION
This means there will not always be an instance ready to server requests which means cold requests can have several seconds of latency but it's probably fine