### PR TITLE
Do not use the real network in JVM tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo3:apollo-no
 apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime" }
 apollo-annotations = { module = "com.apollographql.apollo3:apollo-annotations", version.ref = "apollo" }
 apollo-tooling = { module = "com.apollographql.apollo3:apollo-tooling", version.ref = "apollo" }
+apollo-testing = { module = "com.apollographql.apollo3:apollo-testing-support" }
 atomicfu = "org.jetbrains.kotlinx:atomicfu:0.20.2"
 bare-graphQL = "net.mbonnin.bare-graphql:bare-graphql:0.0.2"
 car-app = "androidx.car.app:app:1.3.0-rc01"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.swing)
                 implementation(libs.okhttp)
                 implementation(libs.okhttp.coroutines)
+                implementation(libs.apollo.testing)
             }
         }
     }

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -52,7 +52,9 @@ actual fun platformModule() = module {
             .build()
     }
     factory<ApolloClient.Builder> {
-        ApolloClient.Builder().okHttpClient(get())
+        ApolloClient.Builder()
+            .serverUrl("https://confetti-app.dev/graphql")
+            .okHttpClient(get())
     }
     single<ImageLoader> {
         ImageLoader.Builder(androidContext())

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -108,8 +108,6 @@ class ApolloClientCache : KoinComponent {
             .chain(sqlNormalizedCacheFactory)
 
         return get<ApolloClient.Builder>()
-            // .serverUrl("http://10.0.2.2:8080/graphql")
-            .serverUrl("https://confetti-app.dev/graphql")
             .addHttpHeader("conference", conference)
             .normalizedCache(
                 memoryFirstThenSqlCacheFactory,

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -23,6 +23,7 @@ actual fun platformModule() = module {
     singleOf(::IosDateService){ bind<DateService>() }
     factory {
         ApolloClient.Builder()
+            .serverUrl("https://confetti-app.dev/graphql")
     }
 }
 

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -1,15 +1,26 @@
-@file:OptIn(ExperimentalSettingsApi::class)
+@file:OptIn(ExperimentalSettingsApi::class, ApolloExperimental::class)
 
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.DefaultFakeResolver
+import com.apollographql.apollo3.api.FakeResolverContext
 import com.apollographql.apollo3.network.okHttpClient
+import com.apollographql.apollo3.testing.MapTestNetworkTransport
+import com.benasher44.uuid.uuid4
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.PreferencesSettings
 import com.russhwolf.settings.coroutines.toFlowSettings
+import dev.johnoreilly.confetti.GetSessionsQuery
+import dev.johnoreilly.confetti.schema.__Schema
+import dev.johnoreilly.confetti.type.LocalDateTime
+import dev.johnoreilly.confetti.type.__CustomScalarAdapters
 import dev.johnoreilly.confetti.utils.DateService
 import dev.johnoreilly.confetti.utils.JvmDateService
+import kotlinx.datetime.LocalDate
 import okhttp3.OkHttpClient
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
@@ -25,7 +36,21 @@ actual fun platformModule() = module {
             .build()
     }
     factory {
-        ApolloClient.Builder().okHttpClient(get())
+        ApolloClient.Builder()
+            .networkTransport(MapTestNetworkTransport().apply {
+                register(GetSessionsQuery(), ApolloResponse.Builder(
+                    GetSessionsQuery(),
+                    uuid4(),
+                    GetSessionsQuery.Data(object: DefaultFakeResolver(__Schema.all) {
+                        override fun resolveLeaf(context: FakeResolverContext): Any {
+                            return when(context.mergedField.type.rawType().name) {
+                                "LocalDateTime" -> return kotlinx.datetime.LocalDateTime(1970, 1, 1, 1, 1, 1)
+                                else -> super.resolveLeaf(context)
+                            }
+                        }
+                    }) {}
+                ).build())
+            })
     }
 }
 


### PR DESCRIPTION
This should fix the flakyness of the tests since we downgraded the class of the AppEngine instances. Cold starts can take more than 10s now (which is another problem but at not relying on the network in tests sounds better)