### PR TITLE
Backend: run deploy sequentially

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -36,7 +36,10 @@ jobs:
       uses: gradle/gradle-build-action@v2.4.2
 
     - name: Build
-      run: ./gradlew :setupCredentials appengineDeploy uploadLandingPage
+      run: |
+        ./gradlew :setupCredentials uploadLandingPage
+        ./gradlew :backend:service-graphql:appengineDeploy
+        ./gradlew :backend:service-import:appengineDeploy
       env:
         GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         FIREBASE_SERVICES_JSON: ${{ secrets.FIREBASE_SERVICES_JSON }}


### PR DESCRIPTION
Looks like both modules `gcloud` install could run in parallel and step on each other (like [here](https://github.com/joreilly/Confetti/actions/runs/5034528419/jobs/9029410914))