### PR TITLE
Add missing kmmbridge configuration and update workflow to java 17 compatible version

### DIFF
--- a/.github/workflows/kmmbridgepnblish.yml
+++ b/.github/workflows/kmmbridgepnblish.yml
@@ -1,8 +1,9 @@
 name: KMMBridge Publish Release
 on: workflow_dispatch
+permissions: write-all
 
 jobs:
   call-kmmbridge-publish:
-    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuild.yml@v0.8
+    uses: touchlab/KMMBridgeGithubWorkflow/.github/workflows/faktorybuild.yml@v0.9
     with:
       jvmVersion: 17

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("co.touchlab.faktory.kmmbridge")
     id("com.squareup.wire")
     id("kotlin-parcelize")
+    id("maven-publish")
 }
 
 configureCompilerOptions()
@@ -180,8 +181,10 @@ dependencies {
     coreLibraryDesugaring(libs.desugar)
 }
 
+addGithubPackagesRepository()
 kmmbridge {
     frameworkName.set("ConfettiKit")
+    mavenPublishArtifacts()
     githubReleaseVersions()
     spm()
     versionPrefix.set("0.8")


### PR DESCRIPTION
This updates to our current standard kmmbridge configuration and should allow you to do kmmbridge publishing again. I did a test publish in my fork [here](https://github.com/russhwolf/Confetti/actions/runs/5214515183/jobs/9410876506), because Github's permission model likely won't let you run something with write permissions from my fork.