### PR TITLE
Update Horologist version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ compose-compiler = "1.4.7-dev-k1.9.0-Beta-bb7dc8b44eb"
 compose-material-3 = "1.0.1"
 decompose = "2.0.0-alpha-02"
 essenty = "1.1.0"
-horologist = "0.4.9"
+horologist = "0.4.10"
 junit = "4.13"
 kmp-nativecoroutines = "1.0.0-ALPHA-11"
 kmm-viewmodel = "1.0.0-ALPHA-9"
@@ -98,9 +98,9 @@ graphql-kotlin-spring-server = "com.expediagroup:graphql-kotlin-spring-server:7.
 horologist-auth-composables = { module = "com.google.android.horologist:horologist-auth-composables", version.ref = "horologist" }
 horologist-auth-ui = { module = "com.google.android.horologist:horologist-auth-ui", version.ref = "horologist" }
 horologist-auth-data = { module = "com.google.android.horologist:horologist-auth-data", version.ref = "horologist" }
-horologist-base-ui = { module = "com.google.android.horologist:horologist-base-ui", version.ref = "horologist" }
 horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
+horologist-compose-material = { module = "com.google.android.horologist:horologist-compose-material", version.ref = "horologist" }
 horologist-compose-tools = { module = "com.google.android.horologist:horologist-compose-tools", version.ref = "horologist" }
 horologist-datalayer = { module = "com.google.android.horologist:horologist-datalayer", version.ref = "horologist" }
 horologist-datalayer-phone = { module = "com.google.android.horologist:horologist-datalayer-phone", version.ref = "horologist" }

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -161,9 +161,9 @@ dependencies {
     implementation(libs.wear.compose.material)
     implementation(libs.wear.compose.navigation)
     implementation(libs.horologist.compose.layout)
+    implementation(libs.horologist.compose.material)
     implementation(libs.horologist.compose.tools)
     implementation(libs.horologist.composables)
-    implementation(libs.horologist.base.ui)
     implementation(libs.horologist.tiles)
     implementation(libs.wear.complications.data)
 

--- a/wearApp/src/debug/java/dev/johnoreilly/confetti/wear/ThemePreview.kt
+++ b/wearApp/src/debug/java/dev/johnoreilly/confetti/wear/ThemePreview.kt
@@ -10,11 +10,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.ListHeader
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardChip
-import com.google.android.horologist.base.ui.components.StandardChipType
+import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.tools.ThemeValues
 import com.google.android.horologist.compose.tools.WearPreview
 import dev.johnoreilly.confetti.wear.components.SectionHeader
@@ -50,11 +50,11 @@ fun ThemePreview() {
             )
         }
         item {
-            StandardChip(
+            Chip(
                 label = "Secondary Chip",
                 secondaryLabel = "with secondary label",
                 onClick = { /*TODO*/ },
-                chipType = StandardChipType.Secondary
+                colors = ChipDefaults.secondaryChipColors()
             )
         }
         // Breaks screenshot tests

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/auth/FirebaseSignOutScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/auth/FirebaseSignOutScreen.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.ConfirmationDialog
+import com.google.android.horologist.compose.material.Confirmation
 import dev.johnoreilly.confetti.R
 import org.koin.androidx.compose.getViewModel
 
@@ -44,7 +44,7 @@ fun FirebaseSignOutScreen(
             SideEffect {
                 onAuthChanged()
             }
-            ConfirmationDialog(
+            Confirmation(
                 onTimeout = navigateUp
             ) {
                 Text(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.wear.compose.material.ChipDefaults
 import coil.compose.AsyncImage
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardChip
+import com.google.android.horologist.compose.material.Chip
 import dev.johnoreilly.confetti.shared.R
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.fullNameAndCompany
@@ -24,7 +24,7 @@ fun SessionSpeakerChip(
     speaker: SpeakerDetails,
     navigateToSpeaker: (SpeakerDetailsKey) -> Unit
 ) {
-    StandardChip(
+    Chip(
         modifier = modifier,
         label = speaker.fullNameAndCompany(),
         icon = {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -12,12 +12,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.ChipDefaults
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardChip
-import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Chip
 import dev.johnoreilly.confetti.BuildConfig
 import dev.johnoreilly.confetti.utils.QueryResult
 import dev.johnoreilly.confetti.wear.components.SectionHeader
@@ -77,13 +76,13 @@ fun ConferencesView(
 
             is QueryResult.Success -> {
                 items(uiState.result.conferences) { conference ->
-                    StandardChip(
+                    Chip(
                         modifier = Modifier.fillMaxWidth(),
                         label = conference.name,
                         onClick = {
                             navigateToConference(conference.id)
                         },
-                        chipType = StandardChipType.Secondary
+                        colors = ChipDefaults.secondaryChipColors()
                     )
                 }
             }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.MaterialTheme
@@ -27,12 +28,11 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.placeholder
 import androidx.wear.compose.material.rememberPlaceholderState
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardChip
-import com.google.android.horologist.base.ui.components.StandardChipType
 import com.google.android.horologist.composables.PlaceholderChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Chip
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.navigation.ConferenceDayKey
 import dev.johnoreilly.confetti.navigation.SessionDetailsKey
@@ -125,10 +125,10 @@ fun HomeScreen(
             items(uiState.result.confDates.size) {
                 // TODO format date
                 val date = uiState.result.confDates[it]
-                StandardChip(
+                Chip(
                     label = dayFormatter.format(date.toJavaLocalDate()),
                     onClick = { daySelected(ConferenceDayKey(uiState.result.conference, date)) },
-                    chipType = StandardChipType.Secondary
+                    colors = ChipDefaults.secondaryChipColors()
                 )
             }
         } else if (uiState is QueryResult.Loading) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
@@ -20,10 +20,10 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.base.ui.components.StandardChip
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
+import com.google.android.horologist.compose.material.Chip
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GetTokenResult
 import dev.johnoreilly.confetti.BuildConfig
@@ -57,14 +57,14 @@ fun SettingsListView(
         }
 
         item {
-            StandardChip(
+            Chip(
                 label = "Change Conference",
                 onClick = conferenceCleared,
             )
         }
 
         item {
-            StandardChip(
+            Chip(
                 label = "Refresh",
                 onClick = onRefreshClick,
             )
@@ -74,12 +74,12 @@ fun SettingsListView(
             item {
                 val authUser = (uiState as? SettingsUiState.Success)?.authUser
                 if (authUser == null) {
-                    StandardChip(
+                    Chip(
                         label = "Sign In",
                         onClick = navigateToGoogleSignIn,
                     )
                 } else {
-                    StandardChip(
+                    Chip(
                         modifier = Modifier.clearAndSetSemantics {
                             contentDescription = "Logged in as " + authUser.displayName
                             onClick("Sign Out") {
@@ -166,7 +166,7 @@ private fun ScalingLazyListScope.developerModeOptions(
         }
 
         item {
-            StandardChip(label = "Refresh Token", onClick = onRefreshToken)
+            Chip(label = "Refresh Token", onClick = onRefreshToken)
         }
     }
 }


### PR DESCRIPTION
### WHAT

Update Horologist version to `0.4.10` and update usage of components.

### WHY

- New version contains fixes related to a11y;
- Some components were moved from `base-ui` to `compose-material` library in `0.4.9`;