### PR TITLE
Fix the issue with firebase auth in r8 fullmode

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -179,11 +179,15 @@ dependencies {
 
     implementation(libs.kmm.viewmodel)
 
+    val excludeAndroidxDataStore = Action<ExternalModuleDependency> {
+        // Crashlytics and PerfMon depend on datastore v1.0 but we're using v1.1
+        exclude(group = "androidx.datastore", module = "datastore-preferences")
+    }
     implementation(platform(libs.firebase.bom))
     implementation(libs.google.services)
-    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.crashlytics, excludeAndroidxDataStore)
     implementation(libs.firebase.analytics)
-    implementation(libs.firebase.performance)
+    implementation(libs.firebase.performance, excludeAndroidxDataStore)
     implementation(libs.play.services.auth)
     coreLibraryDesugaring(libs.desugar)
 

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -11,6 +11,3 @@
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 -keep class androidx.car.app.** { *; }
-
-# See https://github.com/firebase/firebase-android-sdk/issues/2124
--keep class com.google.android.gms.internal.** { *; }

--- a/automotiveApp/build.gradle.kts
+++ b/automotiveApp/build.gradle.kts
@@ -141,11 +141,15 @@ dependencies {
     implementation(libs.compose.compiler)
     implementation(libs.lifecycle.runtime.compose)
 
+    val excludeAndroidxDataStore = Action<ExternalModuleDependency> {
+        // Crashlytics and PerfMon depend on datastore v1.0 but we're using v1.1
+        exclude(group = "androidx.datastore", module = "datastore-preferences")
+    }
     implementation(platform(libs.firebase.bom))
     implementation(libs.google.services)
-    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.crashlytics, excludeAndroidxDataStore)
     implementation(libs.firebase.analytics)
-    implementation(libs.firebase.performance)
+    implementation(libs.firebase.performance, excludeAndroidxDataStore)
     implementation(libs.play.services.auth)
 
     coreLibraryDesugaring(libs.desugar)

--- a/automotiveApp/proguard-rules.pro
+++ b/automotiveApp/proguard-rules.pro
@@ -11,6 +11,3 @@
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 -keep class androidx.car.app.** { *; }
-
-# See https://github.com/firebase/firebase-android-sdk/issues/2124
--keep class com.google.android.gms.internal.** { *; }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,10 @@ dependencies {
     implementation(libs.plugin.appengine)
     implementation(libs.plugin.kmmbridge)
     implementation(libs.plugin.google.services)
-    implementation(libs.plugin.firebase.crashlytics)
+    implementation(libs.plugin.firebase.crashlytics) {
+        // Crashlytics depends on datastore v1.0 but we're using v1.1
+        exclude(group = "androidx.datastore", module = "datastore-preferences")
+    }
     implementation(libs.plugin.wire)
 
 }

--- a/common/car/proguard-rules.pro
+++ b/common/car/proguard-rules.pro
@@ -11,6 +11,3 @@
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 -keep class androidx.car.app.** { *; }
-
-# See https://github.com/firebase/firebase-android-sdk/issues/2124
--keep class com.google.android.gms.internal.** { *; }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,7 +85,7 @@ federation-jvm = "com.apollographql.federation:federation-graphql-java-support:3
 firebase-admin = { module = "com.google.firebase:firebase-admin", version = "9.2.0" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
-firebase-bom = "com.google.firebase:firebase-bom:31.5.0"
+firebase-bom = "com.google.firebase:firebase-bom:32.2.0"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 firebase-performance = { module = "com.google.firebase:firebase-perf-ktx" }
 firebase-mpp-auth = "dev.gitlive:firebase-auth:1.8.1"

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -180,10 +180,14 @@ dependencies {
     implementation(libs.horologist.datalayer)
     implementation(libs.horologist.datalayer.watch)
 
+    val excludeAndroidxDataStore = Action<ExternalModuleDependency> {
+        // Crashlytics and PerfMon depend on datastore v1.0 but we're using v1.1
+        exclude(group = "androidx.datastore", module = "datastore-preferences")
+    }
     implementation(libs.google.services)
-    implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.crashlytics, excludeAndroidxDataStore)
     implementation(libs.firebase.analytics)
-    implementation(libs.firebase.performance)
+    implementation(libs.firebase.performance, excludeAndroidxDataStore)
     implementation(libs.firebase.auth.ktx)
 
     implementation(libs.decompose.decompose)

--- a/wearApp/proguard-benchmark.pro
+++ b/wearApp/proguard-benchmark.pro
@@ -18,5 +18,3 @@
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 
-# See https://github.com/firebase/firebase-android-sdk/issues/2124
--keep class com.google.android.gms.internal.** { *; }

--- a/wearApp/proguard-rules.pro
+++ b/wearApp/proguard-rules.pro
@@ -7,6 +7,3 @@
 
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
-
-# See https://github.com/firebase/firebase-android-sdk/issues/2124
--keep class com.google.android.gms.internal.** { *; }


### PR DESCRIPTION
Now that https://github.com/firebase/firebase-android-sdk/issues/2124 is fixed, it should be fine to remove the proguard rule that keeps `com.google.android.gms.internal.*`.

Also in this PR:
- Upgrade the Firebase BoM to 32.2.0
- Exclude datastore-preferences from crashlytics and performance - the latest version of these libraries come with datastore 1.0, but this project uses an alpha version of 1.1