### PR TITLE
refactor(ios) : adds consistent padding for the segmented control and fixes list scrolling beneath toolbar

### DIFF
--- a/iosApp/iosApp/Sessions/SessionListView.swift
+++ b/iosApp/iosApp/Sessions/SessionListView.swift
@@ -36,6 +36,8 @@ private struct SessionsContentView: View {
                 }
             }
             .pickerStyle(.segmented)
+            .padding([.leading, .trailing], 16)
+            .padding(.bottom, 8)
 
             List {
                 ForEach(sessionUiState.sessionsByStartTimeList[selectedDateIndex].keys.sorted(), id: \.self) {key in

--- a/iosApp/iosApp/Speakers/SpeakerListView.swift
+++ b/iosApp/iosApp/Speakers/SpeakerListView.swift
@@ -30,13 +30,12 @@ private struct SpeakersContentView: View {
     let uiState: SpeakersUiStateSuccess
     
     var body: some View {
-        NavigationView {
-            List(uiState.speakers, id: \.self) { speaker in
-                SpeakerView(speaker: speaker)
-                    .onTapGesture { component.onSpeakerClicked(id: speaker.id) }
-            }
+        List(uiState.speakers, id: \.self) { speaker in
+            SpeakerView(speaker: speaker)
+                .onTapGesture { component.onSpeakerClicked(id: speaker.id) }
         }
     }
+    
 }
 
 struct SpeakerView: View {
@@ -61,4 +60,5 @@ struct SpeakerView: View {
         }
     }
 }
+
 


### PR DESCRIPTION
# What?

* The segmented control looks out of place because of the missing surrounding padding
* Fixes list scrolling beneath toolbar


# Result
|Before|After|
|-|-|
|<img width="496" alt="image" src="https://github.com/joreilly/Confetti/assets/17780580/1f2c929e-00cc-471f-aeda-f120f6388dde">|<img width="505" alt="image" src="https://github.com/joreilly/Confetti/assets/17780580/02588a31-627d-4e86-8a11-601ad6a4886a">|

# List scrolling

|Before|After|
|-|-|
|<img src="https://github.com/joreilly/Confetti/assets/17780580/5f612825-fb72-41b5-964e-fcae0e8a8115" width=320/>|<img src="https://github.com/joreilly/Confetti/assets/17780580/f1207d37-e6a5-4b17-aac4-be75c609b148" width=320/>|
