### PR TITLE
Fix Google signin on some devices

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.arkivanov.decompose.defaultComponentContext
-import com.google.accompanist.adaptive.calculateDisplayFeatures
 import dev.johnoreilly.confetti.account.signIn
 import dev.johnoreilly.confetti.auth.Authentication
 import dev.johnoreilly.confetti.decompose.DefaultAppComponent


### PR DESCRIPTION
Google signin fails on my device with `GetCredentialResponse returned from framework`:


```
CredManProvService      dev.johnoreilly.confetti             I  GetCredentialResponse returned from framework
System.out              dev.johnoreilly.confetti             I  NoCredentialException
```

and on @emartynov one with: 

```
CredManProvService      dev.johnoreilly.confetti             I  GetCredentialResponse returned from framework
System.out              dev.johnoreilly.confetti             I  Unknown auth v2.g0@5d1613b
```

It's not 100% clear what's happening under the hood but changing from `GetGoogleIdOption` to `GetSignInWithGoogleOption` fixes the issue, at least on my device:

https://github.com/joreilly/Confetti/assets/3974977/ec3dabe0-612c-4ac8-815a-2dde6733568e

