### PR TITLE
Add apollo-debug-server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ apollo-runtime = { module = "com.apollographql.apollo3:apollo-runtime" }
 apollo-annotations = { module = "com.apollographql.apollo3:apollo-annotations", version.ref = "apollo" }
 apollo-tooling = { module = "com.apollographql.apollo3:apollo-tooling", version.ref = "apollo" }
 apollo-testing = { module = "com.apollographql.apollo3:apollo-testing-support" }
+apollo-debug-server = { module = "com.apollographql.apollo3:apollo-debug-server" }
 atomicfu = "org.jetbrains.kotlinx:atomicfu:0.23.1"
 bare-graphQL = "net.mbonnin.bare-graphql:bare-graphql:0.0.2"
 car-app-auto = "androidx.car.app:app:1.3.0-rc01"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -131,6 +131,8 @@ kotlin {
                 api(libs.multiplatform.settings.datastore)
                 api(libs.androidx.datastore)
                 api(libs.androidx.datastore.preferences)
+
+                implementation(libs.apollo.debug.server)
             }
         }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -131,7 +131,11 @@ kotlin {
                 api(libs.multiplatform.settings.datastore)
                 api(libs.androidx.datastore)
                 api(libs.androidx.datastore.preferences)
+            }
+        }
 
+        sourceSets.invokeWhenCreated("androidDebug") {
+            dependencies {
                 implementation(libs.apollo.debug.server)
             }
         }

--- a/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -2,12 +2,11 @@ package dev.johnoreilly.confetti.utils
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.debugserver.ApolloDebugServer
-import dev.johnoreilly.confetti.shared.BuildConfig
 
 actual fun ApolloClient.registerApolloDebugServer(conference: String) {
-    if (BuildConfig.DEBUG) ApolloDebugServer.registerApolloClient(this, conference)
+    ApolloDebugServer.registerApolloClient(this, conference)
 }
 
 actual fun ApolloClient.unregisterApolloDebugServer() {
-    if (BuildConfig.DEBUG) ApolloDebugServer.unregisterApolloClient(this)
+    ApolloDebugServer.unregisterApolloClient(this)
 }

--- a/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -4,6 +4,10 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.debugserver.ApolloDebugServer
 
 actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    if (isInUnitTests) {
+        // No-op in unit tests, as it's called multiple times without calling unregister
+        return
+    }
     ApolloDebugServer.registerApolloClient(this, conference)
 }
 

--- a/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/Environment.kt
+++ b/shared/src/androidDebug/kotlin/dev/johnoreilly/confetti/utils/Environment.kt
@@ -1,0 +1,5 @@
+package dev.johnoreilly.confetti.utils
+
+import android.os.Build
+
+val isInUnitTests = Build.DEVICE == "robolectric"

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,13 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.debugserver.ApolloDebugServer
+import dev.johnoreilly.confetti.shared.BuildConfig
+
+actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    if (BuildConfig.DEBUG) ApolloDebugServer.registerApolloClient(this, conference)
+}
+
+actual fun ApolloClient.unregisterApolloDebugServer() {
+    if (BuildConfig.DEBUG) ApolloDebugServer.unregisterApolloClient(this)
+}

--- a/shared/src/androidRelease/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/androidRelease/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,11 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+
+actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    // no-op
+}
+
+actual fun ApolloClient.unregisterApolloDebugServer() {
+    // no-op
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,7 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+
+expect fun ApolloClient.registerApolloDebugServer(conference: String)
+
+expect fun ApolloClient.unregisterApolloDebugServer()

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,12 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+
+actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    // no-op
+}
+
+actual fun ApolloClient.unregisterApolloDebugServer() {
+    // no-op
+}
+

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,12 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+
+actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    // no-op
+}
+
+actual fun ApolloClient.unregisterApolloDebugServer() {
+    // no-op
+}
+

--- a/shared/src/macOSMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
+++ b/shared/src/macOSMain/kotlin/dev/johnoreilly/confetti/utils/ApolloDebugServer.kt
@@ -1,0 +1,12 @@
+package dev.johnoreilly.confetti.utils
+
+import com.apollographql.apollo3.ApolloClient
+
+actual fun ApolloClient.registerApolloDebugServer(conference: String) {
+    // no-op
+}
+
+actual fun ApolloClient.unregisterApolloDebugServer() {
+    // no-op
+}
+


### PR DESCRIPTION
This allows the Apollo IDE plugin to connect to the app (via adb) and [visualize the normalized caches](https://www.apollographql.com/docs/kotlin/v4/testing/android-studio-plugin#normalized-cache-viewer).