### PR TITLE
Update Wear image loader

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ essenty = "1.3.0"
 googleid = "1.1.0"
 horologist = "0.5.13"
 image-loader = "1.7.1"
+io-coil-kt = "2.5.0"
 kmp-nativecoroutines = "1.0.0-ALPHA-22"
 kmm-viewmodel = "1.0.0-ALPHA-16"
 koin-android = "3.5.0"
@@ -66,8 +67,9 @@ atomicfu = "org.jetbrains.kotlinx:atomicfu:0.23.1"
 bare-graphQL = "net.mbonnin.bare-graphql:bare-graphql:0.0.2"
 car-app-auto = "androidx.car.app:app:1.3.0-rc01"
 car-app-automotive = "androidx.car.app:app-automotive:1.2.0"
-coil-base = "io.coil-kt:coil-base:2.5.0"
-coil-compose = "io.coil-kt:coil-compose:2.5.0"
+coil-base = { module = "io.coil-kt:coil-base", version.ref = "io-coil-kt" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "io-coil-kt" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "io-coil-kt" }
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -121,6 +121,7 @@ kotlin {
                 api(libs.koin.workmanager)
                 api(libs.okio)
                 implementation(libs.horologist.datalayer)
+                implementation(libs.coil.svg)
 
                 implementation(libs.firebase.analytics)
                 implementation(libs.compose.navigation)

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.work.WorkManager
 import coil.ImageLoader
+import coil.decode.SvgDecoder
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
@@ -79,6 +80,9 @@ actual fun platformModule() = module {
     single<ImageLoader> {
         ImageLoader.Builder(androidContext())
             .callFactory { get(named("images")) }
+            .components {
+                add(SvgDecoder.Factory())
+            }
             .build()
     }
     single<AnalyticsLogger> {

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
     testImplementation(project(":androidTest"))
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.svg)
     implementation(libs.compose.ui.tooling)
     implementation(libs.activity.compose)
     implementation(libs.lifecycle.runtime.compose)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.ConnectivityManager
 import androidx.room.Room
 import androidx.wear.tiles.TileService
+import coil.ImageLoader
+import coil.decode.SvgDecoder
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -178,6 +180,17 @@ val appModule = module {
             delegate = get<Call.Factory>(),
             defaultRequestType = RequestType.LogsRequest,
         )
+    }
+
+    single<ImageLoader> {
+        ImageLoader.Builder(androidContext())
+            .callFactory { get(named("images")) }
+            .crossfade(false)
+            .respectCacheHeaders(false)
+            .components {
+                add(SvgDecoder.Factory())
+            }
+            .build()
     }
 
     single<FirebaseAuthUserRepository> { FirebaseAuthUserRepositoryImpl(get(), get()) }


### PR DESCRIPTION
For both Wear and Mobile, include an Svg decoder because we don't control images.

For Wear 
- turn off crossfade (trivial performance concern)
- assume all content permanently cacheable (avoid conditional gets)