### PR TITLE
Fix iOS crash - Add missing dependency definition inside KoiniOS

### DIFF
--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -3,6 +3,7 @@
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.russhwolf.settings.ExperimentalSettingsApi
@@ -27,6 +28,7 @@ actual fun platformModule() = module {
     single { get<ObservableSettings>().toFlowSettings() }
     single<NormalizedCacheFactory> { SqlNormalizedCacheFactory("confetti.db") }
     singleOf(::IosDateService) { bind<DateService>() }
+    single<FetchPolicy> { FetchPolicy.CacheAndNetwork }
     factory {
         ApolloClient.Builder()
             .serverUrl("https://confetti-app.dev/graphql")


### PR DESCRIPTION
The App crashes on iOS due to a missing dependency definition inside the `KoiniOS` file.

When we try to navigate to session details, the app crashes with the exception:

```
org.koin.core.error.NoBeanDefFoundException: No definition found for type 'com.apollographql.apollo3.cache.normalized.FetchPolicy'. Check your Modules configuration and add missing type and/or qualifier!
```

https://github.com/joreilly/Confetti/assets/45492687/5aa23f57-b41d-49e7-b4c0-3d157796bc9b

The navigation flow is fixed after adding the missing dependency definition. 

https://github.com/joreilly/Confetti/assets/45492687/52fd0757-1c0e-4759-b24d-7b6a4515693c