### PR TITLE
Unbreak schema reporting

### DIFF
--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
@@ -142,10 +142,7 @@ class DefaultApplication {
                         apolloKey = apolloKey,
                         sdl = schema.print(),
                         graph = graph,
-                        variant = "main",
-                        // Name of the subgraph as defined in Apollo Studio
-                        subgraph = "Confetti-current",
-                        revision = Date().toString(),
+                        variant = "current",
                     )
                 } catch (e: Exception) {
                     println("Cannot enable Apollo reporting: ${e.message}")


### PR DESCRIPTION
Reverts parts of https://github.com/joreilly/Confetti/pull/756. Since we're not using the router anymore, trying to push a subgraph failed. 

I'm not 100% happy with this solution. Having to go to studio to download the schema is introducing another moving part. On the other hand, using introspection doesn't return applied directives. I'll look into using `{ _service { sdl }}` from the GH action instead