### PR TITLE
Better fix for snakeyaml and spring dependencies

### DIFF
--- a/backend/service-graphql/build.gradle.kts
+++ b/backend/service-graphql/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
 
   implementation(libs.scrimage.core)
   implementation(libs.scrimage.filters)
-  implementation(libs.spring.web)
-  implementation(libs.snakeyaml)
 
   testImplementation(libs.junit)
 }


### PR DESCRIPTION
Just let `graphql-kotlin-spring-server` determine all dependencies, we don't need to pin `spring-web`