### PR TITLE
Use GraphQL introspection instead of registry to download the schema in CI 

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -12,6 +12,6 @@ jobs:
 
       - uses: apollographql/update-graphql-schema@2a22b8257e916188812982d64c1f2f087959d8c0 #main
         with:
-          key: ${{ secrets.APOLLO_KEY }}
-          graph: "Confetti"
+          endpoint: "https://confetti-app.dev/graphql"
           schema: "shared/src/commonMain/graphql/schema.graphqls"
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We used to download the schema from the Apollo Registry in CI but this has proven fragile because:

1. it requires another secret in the chain `APOLLO_KEY` 
2. it uncouples the endpoint from its schema 
3. it returns different formatted results than introspection, rendering useless diffs

This PR switches CI to use introspection instead. One of the drawback is that as part of this we lose applied schema directives (cf https://github.com/graphql/graphql-spec/issues/300) but we're not using them so far. If we were to need them, we could use a special `Query.__sdl` field for that purpose.


Also set `github_token` to have checks run in PRs