### PR TITLE
Check revocation of idTokens on the backend

### DIFF
--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
@@ -400,7 +400,7 @@ class MyGraphQLContextFactory : DefaultSpringGraphQLContextFactory() {
 
         val uid = try {
             request.headers().firstHeader("authorization")
-                ?.substring("bearer_".length)
+                ?.substring("Bearer ".length)
                 ?.firebaseUid()
         } catch (e: FirebaseAuthException) {
             throw e

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/firebase.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/firebase.kt
@@ -23,7 +23,7 @@ fun String.firebaseUid(): String? {
     }
 
     return try {
-        FirebaseAuth.getInstance().verifyIdToken(this).uid
+        FirebaseAuth.getInstance().verifyIdToken(this, true).uid
     } catch (e: Exception) {
         e.printStackTrace()
         throw e


### PR DESCRIPTION
See https://firebase.google.com/docs/auth/admin/manage-sessions#detect_id_token_revocation

It's one additional network roundtrip but I don't see how to avoid it sadly.