### PR TITLE
Update update-graphql-schema version

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: apollographql/update-graphql-schema@2a22b8257e916188812982d64c1f2f087959d8c0 #main
+      - uses: apollographql/update-graphql-schema@59d4aa970db7d8559e48a5ddc5b3c09c052c88b0
         with:
           endpoint: "https://confetti-app.dev/graphql"
           schema: "shared/src/commonMain/graphql/schema.graphqls"


### PR DESCRIPTION
See https://github.com/joreilly/Confetti/pull/1180, the GitHub action was ignoring builtin types which are needed for client side validation (see also https://github.com/graphql/graphql-wg/discussions/1391). 