### PR TITLE
Update Wear to use app and tile status helpers (1 of 2)

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/di/AppModule.kt
@@ -28,7 +28,6 @@ val appModule = module {
         DefaultSettingsComponent(
             componentContext = DefaultComponentContext(lifecycle),
             appSettings = get(),
-            wearSettingsSync = get(),
             authentication = get(),
         ).also { lifecycle.resume() }
     }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/settings/SettingsRoute.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/settings/SettingsRoute.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
@@ -50,7 +49,6 @@ import dev.johnoreilly.confetti.DeveloperSettings
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.ThemeBrand
 import dev.johnoreilly.confetti.UserEditableSettings
-import dev.johnoreilly.confetti.WearStatus
 import dev.johnoreilly.confetti.decompose.SettingsComponent
 import dev.johnoreilly.confetti.ui.supportsDynamicTheming
 
@@ -65,7 +63,6 @@ fun SettingsRoute(
         onChangeThemeBrand = component::updateThemeBrand,
         onChangeDynamicColorPreference = component::updateDynamicColorPreference,
         onChangeDarkThemeConfig = component::updateDarkThemeConfig,
-        onInstallOnWatch = component::installOnWatch,
         onChangeUseExperimentalFeatures = component::updateUseExperimentalFeatures,
         developerSettings = developerSettings,
         onEnableDeveloperMode = component::enableDeveloperMode
@@ -80,7 +77,6 @@ fun SettingsScreen(
     onChangeThemeBrand: (themeBrand: ThemeBrand) -> Unit,
     onChangeDynamicColorPreference: (useDynamicColor: Boolean) -> Unit,
     onChangeDarkThemeConfig: (darkThemeConfig: DarkThemeConfig) -> Unit,
-    onInstallOnWatch: (String) -> Unit,
     developerSettings: DeveloperSettings?,
     onEnableDeveloperMode: () -> Unit
 ) {
@@ -127,25 +123,6 @@ fun SettingsScreen(
                             onChangeDarkThemeConfig = onChangeDarkThemeConfig,
                             onChangeUseExperimentalFeatures = onChangeUseExperimentalFeatures,
                         )
-                    }
-                }
-
-                item {
-                    Row(
-                        modifier = Modifier
-                            .padding(top = 16.dp, start = 8.dp, end = 8.dp),
-                    ) {
-                        when (val wearStatus = userEditableSettings?.wearStatus) {
-                            is WearStatus.NotInstalled -> {
-                                Button(onClick = { onInstallOnWatch(wearStatus.nodeId) }) {
-                                    Text(stringResource(id = R.string.install_on_watch))
-                                }
-                            }
-
-                            else -> {
-                                Text(stringResource(id = R.string.no_paired_watch))
-                            }
-                        }
                     }
                 }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/wear/WearSettingsSync.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/wear/WearSettingsSync.kt
@@ -2,91 +2,22 @@
 
 package dev.johnoreilly.confetti.wear
 
-import android.os.Build
-import android.util.Log
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.common.api.AvailabilityException
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.data.ProtoDataStoreHelper.protoDataStore
 import com.google.android.horologist.data.WearDataLayerRegistry
 import com.google.android.horologist.datalayer.phone.PhoneDataLayerAppHelper
 import dev.johnoreilly.confetti.wear.proto.WearSettings
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
 class WearSettingsSync(
     val dataLayerRegistry: WearDataLayerRegistry,
     val phoneDataLayerRegistry: PhoneDataLayerAppHelper,
     val coroutineScope: CoroutineScope
 ) {
-    private var job: Job? = null
-
     val settingsDataStore by lazy { dataLayerRegistry.protoDataStore<WearSettings>(coroutineScope) }
 
-    suspend fun isAvailable(): Boolean {
-        if (Build.VERSION.SDK_INT < 23)
-            return false
-
-        return try {
-            GoogleApiAvailability.getInstance()
-                .checkApiAvailability(dataLayerRegistry.dataClient)
-                .await()
-
-            true
-        } catch (e: AvailabilityException) {
-            Log.d(
-                "WearSettingsSync",
-                "DataClient API is not available in this device. WearSettingsSync will fail silently and all functionality will be no-op."
-            )
-            false
-        }
-    }
-
-    val settingsFlow: Flow<WearSettings> = flow {
-        if (isAvailable()) {
-            emitAll(settingsDataStore.data)
-        } else {
-            emit(WearSettings())
-        }
-    }.catch {
-        emit(WearSettings())
-    }
-
-    val wearNodes = flow {
-        emit(phoneDataLayerRegistry.connectedNodes())
-    }.catch { emit(listOf()) }
-
-    // public non-suspend function to be called from button callbacks, etc...
-    fun installOnWearNode(nodeId: String) {
-        if (job != null) {
-            // already installing, skip
-            return
-        }
-
-        // coroutineScope at this point is a app-global scope
-        job = coroutineScope.launch {
-            installOnWearNodeInternal(nodeId)
-            job = null
-        }
-    }
-
-    private suspend fun installOnWearNodeInternal(nodeId: String) {
-        try {
-            phoneDataLayerRegistry.installOnNode(nodeId)
-        } catch (rie: Exception) {
-            // likely RemoteIntentException due to emulator without playstore
-            // TODO handle error
-        }
-    }
-
     suspend fun setConference(conference: String, colorScheme: String?) {
-        if (isAvailable()) {
+        if (phoneDataLayerRegistry.isAvailable()) {
             settingsDataStore.updateData {
                 it.copy(conference = conference, color_scheme = colorScheme)
             }

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/SettingsComponent.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/SettingsComponent.kt
@@ -1,7 +1,5 @@
 package dev.johnoreilly.confetti
 
-import dev.johnoreilly.confetti.wear.proto.WearSettings
-
 data class DeveloperSettings(
     val token: String?
 )
@@ -14,16 +12,7 @@ data class UserEditableSettings(
     val useDynamicColor: Boolean,
     val darkThemeConfig: DarkThemeConfig,
     val useExperimentalFeatures: Boolean,
-    val wearStatus: WearStatus
 )
-
-sealed interface WearStatus {
-    object Unavailable : WearStatus
-    data class NotInstalled(val nodeId: String) : WearStatus
-    data class Paired(
-        val wearSettings: WearSettings
-    ) : WearStatus
-}
 
 enum class ThemeBrand {
     DEFAULT, ANDROID

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/decompose/SettingsComponent.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/decompose/SettingsComponent.kt
@@ -15,6 +15,5 @@ actual interface SettingsComponent {
     fun updateDarkThemeConfig(darkThemeConfig: DarkThemeConfig)
     fun updateDynamicColorPreference(useDynamicColor: Boolean)
     fun updateUseExperimentalFeatures(value: Boolean)
-    fun installOnWatch(nodeId: String)
     fun enableDeveloperMode()
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/MainActivity.kt
@@ -8,26 +8,41 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import com.arkivanov.decompose.defaultComponentContext
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.firebase.FirebaseApp
 import dev.johnoreilly.confetti.analytics.AnalyticsLogger
 import dev.johnoreilly.confetti.wear.navigation.DefaultWearAppComponent
 import dev.johnoreilly.confetti.wear.navigation.NavigationHelper.logNavigationEvent
 import dev.johnoreilly.confetti.wear.navigation.WearAppComponent
+import dev.johnoreilly.confetti.wear.tile.TileSync
 import dev.johnoreilly.confetti.wear.ui.ConfettiApp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.compose.KoinAndroidContext
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
+import kotlin.time.Duration.Companion.seconds
 
 class MainActivity : ComponentActivity() {
     internal lateinit var appComponent: WearAppComponent
     private val analyticsLogger: AnalyticsLogger by inject()
 
+    private val tileSync: TileSync by inject()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
 
         super.onCreate(savedInstanceState)
+
+        // Schedule an update of tiles if user keeps apps open for 5 seconds
+        lifecycleScope.launch {
+            delay(5.seconds)
+
+            tileSync.trackInstalledTiles(this@MainActivity)
+        }
 
         appComponent =
             DefaultWearAppComponent(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
@@ -3,11 +3,13 @@ package dev.johnoreilly.confetti.wear.complication
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
+import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.android.horologist.tiles.complication.DataComplicationService
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.auth.Authentication
@@ -16,6 +18,7 @@ import dev.johnoreilly.confetti.toTimeZone
 import dev.johnoreilly.confetti.wear.MainActivity
 import dev.johnoreilly.confetti.wear.settings.PhoneSettingsSync
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toLocalDateTime
 import org.koin.android.ext.android.inject
@@ -30,6 +33,20 @@ class NextSessionComplicationService :
     private val phoneSettingsSync: PhoneSettingsSync by inject()
 
     private val authentication: Authentication by inject()
+
+    private val wearAppHelper: WearDataLayerAppHelper by inject()
+
+    override fun onComplicationActivated(complicationInstanceId: Int, type: ComplicationType) {
+        runBlocking {
+            wearAppHelper.markComplicationAsActivated(this@NextSessionComplicationService.javaClass.simpleName, complicationInstanceId, type)
+        }
+    }
+
+    override fun onComplicationDeactivated(complicationInstanceId: Int) {
+        runBlocking {
+            wearAppHelper.markComplicationAsDeactivated(this@NextSessionComplicationService.javaClass.simpleName, complicationInstanceId, ComplicationType.EMPTY)
+        }
+    }
 
     override suspend fun data(request: ComplicationRequest): NextSessionComplicationData {
         val conference = phoneSettingsSync.conferenceFlow.first().conference

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.horologist.auth.ui.common.screens.prompt.SignInPromptViewModel
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInViewModel
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.android.horologist.networks.battery.BatteryStatusMonitor
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.data.RequestType
@@ -41,6 +42,7 @@ import dev.johnoreilly.confetti.wear.data.auth.FirebaseAuthUserRepositoryImpl
 import dev.johnoreilly.confetti.wear.networks.WearNetworkingRules
 import dev.johnoreilly.confetti.wear.settings.PhoneSettingsSync
 import dev.johnoreilly.confetti.wear.settings.WearPreferencesStore
+import dev.johnoreilly.confetti.wear.tile.TileSync
 import dev.johnoreilly.confetti.wear.tile.TileUpdater
 import dev.johnoreilly.confetti.wear.work.WearConferenceSetting
 import dev.johnoreilly.confetti.work.AvatarType
@@ -198,6 +200,14 @@ val appModule = module {
 
     single<AvatarType> {
         { wearPhotoUrl }
+    }
+
+    single<TileSync> {
+        TileSync(get(), get())
+    }
+
+    single<WearDataLayerAppHelper> {
+        WearDataLayerAppHelper(context = androidContext(), registry = get(), scope = get())
     }
 
     single<FirebaseAuthUserRepository> { FirebaseAuthUserRepositoryImpl(get(), get()) }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/navigation/WearAppComponent.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/navigation/WearAppComponent.kt
@@ -12,6 +12,7 @@ import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.push
 import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.value.Value
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.android.horologist.networks.data.DataRequestRepository
 import com.google.android.horologist.networks.data.DataUsageReport
 import com.google.android.horologist.networks.data.Networks
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
+import org.koin.android.ext.android.inject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -80,6 +82,7 @@ class DefaultWearAppComponent(
     val wearPreferencesStore: WearPreferencesStore by inject()
     private val networkRepository: NetworkRepository by inject()
     private val dataRequestRepository: DataRequestRepository by inject()
+    private val wearAppHelper: WearDataLayerAppHelper by inject()
 
     override val appState: StateFlow<AppUiState?> = combine(
         phoneSettingsSync.conferenceFlow,
@@ -111,7 +114,15 @@ class DefaultWearAppComponent(
         )
 
     override suspend fun waitForConference(): String {
-        return appState.filterNotNull().map { it.defaultConference }.firstOrNull() ?: AppSettings.CONFERENCE_NOT_SET
+        val conference = appState.filterNotNull().map { it.defaultConference }.firstOrNull()
+
+        if (conference == null) {
+            wearAppHelper.markSetupNoLongerComplete()
+        } else {
+            wearAppHelper.markSetupComplete()
+        }
+
+        return conference ?: AppSettings.CONFERENCE_NOT_SET
     }
 
     override val isWaitingOnThemeOrData: Boolean

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileService.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileService.kt
@@ -35,6 +35,8 @@ class CurrentSessionsTileService : SuspendingTileService() {
 
     private val authentication: Authentication by inject()
 
+    private val tileSync: TileSync by inject()
+
     override suspend fun resourcesRequest(requestParams: RequestBuilders.ResourcesRequest): ResourceBuilders.Resources {
         return renderer.produceRequestedResources(tileState(), requestParams)
     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/TileSync.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/TileSync.kt
@@ -1,0 +1,37 @@
+package dev.johnoreilly.confetti.wear.tile
+
+import android.content.Context
+import androidx.concurrent.futures.await
+import androidx.wear.tiles.TileService
+import com.google.android.gms.wearable.PutDataRequest
+import com.google.android.horologist.data.WearDataLayerRegistry
+import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.tasks.await
+
+class TileSync(
+    private val registry: WearDataLayerRegistry,
+    private val wearAppHelper: WearDataLayerAppHelper,
+) {
+    private val executor = Dispatchers.Default.asExecutor()
+
+    suspend fun trackInstalledTiles(context: Context) {
+        registry.dataClient
+            .putDataItem(PutDataRequest.create("/tile_tracking_enabled")).await()
+
+        val myTilesList = listOf(
+            CurrentSessionsTileService::class.java.name,
+        )
+
+        val activeTiles = TileService.getActiveTilesAsync(context, executor).await()
+
+        for (tileName in myTilesList) {
+            if (activeTiles.any { it.componentName.className == tileName }) {
+                wearAppHelper.markTileAsInstalled(tileName)
+            } else {
+                wearAppHelper.markTileAsRemoved(tileName)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes the Wear app to use some supporting libraries for prompting Wear App.

This change disables the existing menu items for prompting install.

Will discuss best ways to bring it back in follow up PR. 