### PR TITLE
Add the .well-known part necessary for the iOS app

### DIFF
--- a/landing-page/public/.well-known/apple-app-site-association
+++ b/landing-page/public/.well-known/apple-app-site-association
@@ -1,0 +1,1 @@
+{"applinks":{"apps":[],"details":[{"appID":"NT77748GS8.dev.johnoreilly.confetti","paths":["/*"]}]}}


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode/supporting-associated-domains#Add-the-associated-domain-file-to-your-website

As discussed here https://kotlinlang.slack.com/archives/C051P2HUVKP/p1711750957962379?thread_ts=1711657801.535509&cid=C051P2HUVKP to try and test this