### PR TITLE
Enable support for high refresh rate displays

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -24,6 +24,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
Adds the missing flag to the Info.plist.

For some behind the scenes, check out https://youtu.be/Df1ZCmmHWzM?si=PUHYBbw0dEb3aNnA&t=839!