### PR TITLE
Backend: fix importing UTC dates

### DIFF
--- a/backend/service-import/src/jvmTest/kotlin/test/MainTest.kt
+++ b/backend/service-import/src/jvmTest/kotlin/test/MainTest.kt
@@ -1,5 +1,6 @@
 package test
 
+import dev.johnoreilly.confetti.backend.import.Sessionize.importDroidconLondon2024
 import dev.johnoreilly.confetti.backend.import.SwiftConnection
 import kotlinx.coroutines.runBlocking
 import org.junit.Ignore
@@ -10,7 +11,7 @@ class MainTest {
     @Ignore
     fun test() {
         runBlocking {
-            val updated = SwiftConnection.import()
+            val updated = importDroidconLondon2024()
             println("Updated $updated sessions")
         }
     }


### PR DESCRIPTION
Sessionize has an option to use local datetime or UTC instant for times. Make sure we can decode both.