### PR TITLE
Enable Gradle distribution verification

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
Enables Gradle distribution verification by adding the expected `distributionSha256Sum` value for Gradle 8.10 within the `gradle/wrapper/gradle-wrapper.properties` file. This ensures that any local/CI processes only use the verified and [expected distribution](https://gradle.org/release-checksums/#v8.10) of Gradle, protecting against supply-chain-style attacks. [^1]

You can verify this works as expected locally by running:
```bash
./gradlew wrapper --gradle-version=8.10 --distribution-type=bin --gradle-distribution-sha256-sum=5b9c5eb3f9fc2c94abaea57d90bd78747ca117ddbbf96c859d3741181a12bf2a
```

Finally, it's my understanding that Renovate [should be able to update this value](
https://github.com/renovatebot/renovate/blob/a471762e137619c06e73a678d6b63ca984da7dba/lib/modules/manager/gradle-wrapper/artifacts.ts#L155-L166) if it is present in future Gradle version updates. It's worth noting that #1442 may need to be rebased or otherwise re-generated should this be merged.

✨ Any questions, feel free to ask!

[^1]: [There's a fun talk and blog about this...](https://www.spght.dev/articles/28-05-2024/gradle-upgrade)