### PR TITLE
Remove excessive curly brackets on session tile deeplink

### DIFF
--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileRenderer.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileRenderer.kt
@@ -170,7 +170,7 @@ class CurrentSessionsTileRenderer(
     ): Clickable =
         Clickable.Builder()
             .setOnClick(LoadAction.Builder().build())
-            .setId("session/{${conference}}/{${sessionDetails.id}}")
+            .setId("session/${conference}/${sessionDetails.id}")
             .build()
 
     private fun browseClickable(


### PR DESCRIPTION
In reference of https://kotlinlang.slack.com/archives/C051P2HUVKP/p1730368174142119.  Here after clicking the tile service we showed an empty screen instead of the session details

From what I could see we were sending excessive curly braces around the details in the deep link. This made the config values to store the ids with these curly braces.  I'm not sure if we actually need the curly braces here for some other reason. Maybe you know better @yschimke ? If that is the case we might want to consider stripping them from the build config path instead. For now I just removed them in the deep link.


After this change it works as expected 


https://github.com/user-attachments/assets/c59c0346-df80-44dc-8249-773e4e7179d1

