### PR TITLE
Revert "Update dependency com.google.cloud:libraries-bom to v26.51.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,7 +125,7 @@ firebase-bom = "com.google.firebase:firebase-bom:33.3.0"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-performance = { module = "com.google.firebase:firebase-perf" }
 firebase-mpp-auth = "dev.gitlive:firebase-auth:1.13.0"
-google-cloud-bom = "com.google.cloud:libraries-bom:26.51.0"
+google-cloud-bom = "com.google.cloud:libraries-bom:26.44.0"
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage" }
 google-cloud-datastore = "com.google.cloud:google-cloud-datastore:2.24.3"
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }


### PR DESCRIPTION
Reverts joreilly/Confetti#1497

release builds failing with

```
java.lang.NoSuchMethodError: 'void Query$QueryResponse.makeExtensionsImmutable()'
```

Presumably relating to https://github.com/protocolbuffers/protobuf/issues/19540