### PR TITLE
Revert "Update dependency com.google.cloud:google-cloud-datastore to v2.24.3"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,7 +127,7 @@ firebase-performance = { module = "com.google.firebase:firebase-perf" }
 firebase-mpp-auth = "dev.gitlive:firebase-auth:1.13.0"
 google-cloud-bom = "com.google.cloud:libraries-bom:26.51.0"
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage" }
-google-cloud-datastore = "com.google.cloud:google-cloud-datastore:2.24.3"
+google-cloud-datastore = "com.google.cloud:google-cloud-datastore:2.24.1"
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }


### PR DESCRIPTION
Reverts joreilly/Confetti#1484

release builds failing with

```
java.lang.NoSuchMethodError: 'void Query$QueryResponse.makeExtensionsImmutable()'
```

Presumably relating to https://github.com/protocolbuffers/protobuf/issues/19540