### PR TITLE
Fix: Keep proto generated message classes

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -12,6 +12,8 @@
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 -keep class androidx.car.app.** { *; }
 
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
 -keep class com.google.firebase.** { *; }
 
 -dontwarn okhttp3.internal.Util

--- a/wearApp/proguard-rules.pro
+++ b/wearApp/proguard-rules.pro
@@ -6,4 +6,7 @@
 -dontwarn kotlinx.serialization.Serializable
 
 -keep class com.squareup.wire.** { *; }
--keep class dev.johnoreilly.confetti.wear.proto.** { *; }
+
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite { <fields>; }
+
+-keep class com.google.firebase.** { *; }


### PR DESCRIPTION
Keep proto generated message classes and fields in proguard rules for both wearApp and androidApp. This prevents these classes from being obfuscated and ensures proper functionality.