### PR TITLE
Support Google Identity Services for Wear OS

### DIFF
--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -83,7 +83,9 @@ val appModule = module {
         SignInProcess(
             credentialManager = get(),
             authentication = get(),
-            webClientId = androidContext().getString(R.string.default_web_client_id)
+            webClientId = androidContext().getString(R.string.default_web_client_id),
+            // Sign in with Google creation flow not supported on Wear 5.1
+            useSignInWithGoogle = false,
         )
     }
 


### PR DESCRIPTION
This commit updates the sign-in process to support Google Identity Services on Wear OS 5.1+.

- It introduces the `useSignInWithGoogle` flag to control whether to use Sign in With Google or the Google Identity Services API.
- On Wear OS, the `useSignInWithGoogle` flag is set to false, as the Sign in With Google UI flow is not fully supported.