### PR TITLE
Use Apollo incubating normalized cache

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ lifecyle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtim
 apollo-adapters = { module = "com.apollographql.apollo:apollo-adapters" }
 apollo-normalized-cache-in-memory = { module = "com.apollographql.cache:normalized-cache-incubating", version.ref = "apollo-cache" }
 apollo-normalized-cache-sqlite = { module = "com.apollographql.cache:normalized-cache-sqlite-incubating", version.ref = "apollo-cache" }
+apollo-normalized-cache-compiler-plugin = { module = "com.apollographql.cache:normalized-cache-apollo-compiler-plugin", version.ref = "apollo-cache" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime" }
 apollo-execution-spring = { module = "com.apollographql.execution:apollo-execution-spring", version.ref = "apollo-kotlin-execution" }
 apollo-execution-reporting = { module = "com.apollographql.execution:apollo-execution-reporting", version.ref = "apollo-kotlin-execution" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,8 @@ agp = "8.8.0"
 activity-compose = "1.10.0"
 androidx-lifecycle = "2.8.7"
 androidx-datastore = "1.1.2"
-apollo = "4.1.0"
+apollo = "4.1.1"
+apollo-cache = "0.0.6"
 compose = "1.7.7"
 composeLifecyleRuntime="2.8.4"
 compose-multiplatform = "1.7.3"
@@ -72,8 +73,8 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "work-runtime-ktx" }
 lifecyle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecyleRuntime" }
 apollo-adapters = { module = "com.apollographql.apollo:apollo-adapters" }
-apollo-normalized-cache-in-memory = { module = "com.apollographql.apollo:apollo-normalized-cache" }
-apollo-normalized-cache-sqlite = { module = "com.apollographql.apollo:apollo-normalized-cache-sqlite" }
+apollo-normalized-cache-in-memory = { module = "com.apollographql.cache:normalized-cache-incubating", version.ref = "apollo-cache" }
+apollo-normalized-cache-sqlite = { module = "com.apollographql.cache:normalized-cache-sqlite-incubating", version.ref = "apollo-cache" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime" }
 apollo-execution-spring = { module = "com.apollographql.execution:apollo-execution-spring", version.ref = "apollo-kotlin-execution" }
 apollo-execution-reporting = { module = "com.apollographql.execution:apollo-execution-reporting", version.ref = "apollo-kotlin-execution" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -227,6 +227,10 @@ apollo {
                 schemaFile.set(file("src/commonMain/graphql/schema.graphqls"))
             }
         }
+
+        plugin(libs.apollo.normalized.cache.compiler.plugin.get()) {
+            argument("packageName", packageName.get())
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -14,10 +14,10 @@ import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.decode.SvgDecoder
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo.network.http.ApolloClientAwarenessInterceptor
 import com.apollographql.apollo.network.http.DefaultHttpEngine
 import com.apollographql.apollo.network.ws.DefaultWebSocketEngine

--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/work/SessionNotificationSender.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/work/SessionNotificationSender.kt
@@ -9,7 +9,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.auth.Authentication
 import dev.johnoreilly.confetti.fragment.SessionDetails

--- a/shared/src/commonMain/graphql/extra.graphqls
+++ b/shared/src/commonMain/graphql/extra.graphqls
@@ -3,12 +3,32 @@ extend schema
     url: "https://specs.apollo.dev/kotlin_labs/v0.3",
     import: ["@typePolicy", "@fieldPolicy"]
 )
+@link(
+    url: "https://specs.apollo.dev/cache/v0.1",
+    import: ["@cacheControl", "@cacheControlField"]
+)
 
-extend type Session @typePolicy(keyFields: "id")
-extend type Bookmarks @typePolicy(keyFields: "id")
-extend type Speaker @typePolicy(keyFields: "id")
-extend type Room @typePolicy(keyFields: "id")
-extend type Conference @typePolicy(keyFields: "id")
+extend type Session
+@typePolicy(keyFields: "id")
+@cacheControl(maxAge: 14400)
 
-extend type Query @fieldPolicy(forField: "session", keyArgs: "id")
-extend type Query @fieldPolicy(forField: "speaker", keyArgs: "id")
+extend type Bookmarks
+@typePolicy(keyFields: "id")
+@cacheControl(maxAge: 3600)
+
+extend type Speaker
+@typePolicy(keyFields: "id")
+@cacheControl(maxAge: 14400)
+
+extend type Room
+@typePolicy(keyFields: "id")
+@cacheControl(maxAge: 14400)
+
+extend type Conference
+@typePolicy(keyFields: "id")
+@cacheControl(maxAge: 14400)
+
+extend type Query
+@fieldPolicy(forField: "session", keyArgs: "id")
+@fieldPolicy(forField: "speaker", keyArgs: "id")
+

--- a/shared/src/commonMain/graphql/extra.graphqls
+++ b/shared/src/commonMain/graphql/extra.graphqls
@@ -1,6 +1,14 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/kotlin_labs/v0.3",
+    import: ["@typePolicy", "@fieldPolicy"]
+)
+
 extend type Session @typePolicy(keyFields: "id")
 extend type Bookmarks @typePolicy(keyFields: "id")
 extend type Speaker @typePolicy(keyFields: "id")
+extend type Room @typePolicy(keyFields: "id")
+extend type Conference @typePolicy(keyFields: "id")
 
 extend type Query @fieldPolicy(forField: "session", keyArgs: "id")
 extend type Query @fieldPolicy(forField: "speaker", keyArgs: "id")

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo.network.NetworkMonitor
 import com.apollographql.cache.normalized.api.CacheControlCacheResolver
 import com.apollographql.cache.normalized.api.SchemaCoordinatesMaxAgeProvider
+import com.apollographql.cache.normalized.maxStale
 import com.apollographql.cache.normalized.storeReceiveDate
 import dev.johnoreilly.confetti.cache.Cache
 import dev.johnoreilly.confetti.di.getNormalizedCacheFactory
@@ -132,6 +133,7 @@ class ApolloClientCache : KoinComponent {
                 ),
             )
             .storeReceiveDate(true)
+            .maxStale(Duration.INFINITE)
             .autoPersistedQueries()
             .addInterceptor(tokenProviderInterceptor)
             .build()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -13,6 +13,10 @@ import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo.network.NetworkMonitor
+import com.apollographql.cache.normalized.api.CacheControlCacheResolver
+import com.apollographql.cache.normalized.api.SchemaCoordinatesMaxAgeProvider
+import com.apollographql.cache.normalized.storeReceiveDate
+import dev.johnoreilly.confetti.cache.Cache
 import dev.johnoreilly.confetti.di.getNormalizedCacheFactory
 import dev.johnoreilly.confetti.utils.registerApolloDebugServer
 import dev.johnoreilly.confetti.utils.unregisterApolloDebugServer
@@ -25,6 +29,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import kotlin.time.Duration
 
 interface TokenProvider {
     suspend fun token(forceRefresh: Boolean): String?
@@ -118,8 +123,15 @@ class ApolloClientCache : KoinComponent {
             .addHttpHeader("conference", conference)
             .normalizedCache(
                 normalizedCacheFactory,
-                writeToCacheAsynchronously = writeToCacheAsynchronously
+                writeToCacheAsynchronously = writeToCacheAsynchronously,
+                cacheResolver = CacheControlCacheResolver(
+                    SchemaCoordinatesMaxAgeProvider(
+                        maxAges = Cache.maxAges,
+                        defaultMaxAge = Duration.INFINITE,
+                    )
+                ),
             )
+            .storeReceiveDate(true)
             .autoPersistedQueries()
             .addInterceptor(tokenProviderInterceptor)
             .build()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ApolloClientCache.kt
@@ -6,8 +6,8 @@ import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.cache.normalized.apolloStore
-import com.apollographql.apollo.cache.normalized.normalizedCache
+import com.apollographql.cache.normalized.apolloStore
+import com.apollographql.cache.normalized.normalizedCache
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.interceptor.ApolloInterceptor

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -4,11 +4,11 @@ import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.apolloStore
-import com.apollographql.apollo.cache.normalized.fetchPolicy
-import com.apollographql.apollo.cache.normalized.optimisticUpdates
-import com.apollographql.apollo.cache.normalized.watch
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.apolloStore
+import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.optimisticUpdates
+import com.apollographql.cache.normalized.watch
 import com.apollographql.apollo.exception.DefaultApolloException
 import com.benasher44.uuid.uuid4
 import dev.johnoreilly.confetti.type.buildBookmarks
@@ -54,8 +54,9 @@ class ConfettiRepository : KoinComponent {
     ): Boolean {
         val client = apolloClientCache.getClient(conference, uid)
         val optimisticData = try {
-            val bookmarks = client.apolloStore.readOperation(GetBookmarksQuery()).bookmarks
-            data(bookmarks!!.sessionIds, bookmarks.id)
+            client.apolloStore.readOperation(GetBookmarksQuery()).data?.bookmarks?.let { bookmarks ->
+                data(bookmarks.sessionIds, bookmarks.id)
+            }
         } catch (e: Exception) {
             null
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.cache.normalized.apolloStore
-import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.optimisticUpdates
 import com.apollographql.cache.normalized.watch
 import com.apollographql.apollo.exception.DefaultApolloException

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesVenueComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesVenueComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -3,7 +3,7 @@
 package dev.johnoreilly.confetti.decompose
 
 import com.apollographql.apollo.api.ApolloResponse
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.childContext
 import com.arkivanov.decompose.value.Value

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakersComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakersComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.childContext
 import com.arkivanov.decompose.value.Value

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/VenueComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/VenueComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/di/Koin.kt
@@ -2,7 +2,7 @@
 
 package dev.johnoreilly.confetti.di
 
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.russhwolf.settings.ExperimentalSettingsApi
 import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.AppSettings

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
@@ -1,0 +1,63 @@
+package dev.johnoreilly.confetti
+
+import com.apollographql.apollo.ConcurrencyInfo
+import com.apollographql.apollo.annotations.ApolloExperimental
+import com.apollographql.apollo.api.ApolloRequest
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.MutableExecutionOptions
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.interceptor.ApolloInterceptor
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.cacheInfo
+import com.apollographql.cache.normalized.fetchFromCache
+import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.fetchPolicyInterceptor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.launch
+
+/**
+ * Use our custom fetch policy interceptor for the [FetchPolicy.CacheFirst] policy, and the Apollo built-in interceptors
+ * for the other policies.
+ */
+fun <T> MutableExecutionOptions<T>.fetchPolicy(fetchPolicy: FetchPolicy) = when (fetchPolicy) {
+    FetchPolicy.CacheFirst -> {
+        fetchPolicyInterceptor(CacheFirstInterceptor)
+    }
+
+    else -> {
+        fetchPolicy(fetchPolicy)
+    }
+}
+
+/**
+ * Returns the cached data if available (even if stale), or the network data if not.
+ * If the cache data is stale, it is refreshed from the network in the background.
+ */
+private object CacheFirstInterceptor : ApolloInterceptor {
+    override fun <D : Operation.Data> intercept(
+        request: ApolloRequest<D>,
+        chain: ApolloInterceptorChain
+    ): Flow<ApolloResponse<D>> = flow {
+        val cacheResponse = chain.proceed(
+            request.newBuilder()
+                .fetchFromCache(true)
+                .build()
+        ).single()
+        if (cacheResponse.cacheInfo!!.isCacheHit) {
+            emit(cacheResponse)
+            if (cacheResponse.cacheInfo!!.isStale) {
+                val scope = @OptIn(ApolloExperimental::class) request.executionContext[ConcurrencyInfo]!!.coroutineScope
+                scope.launch {
+                    chain.proceed(request).collect()
+                }
+            }
+        } else {
+            emitAll(chain.proceed(request))
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
@@ -62,7 +62,7 @@ The talk will cover
         JohnOreilly,
         MartinBonnin
     ),
-    room = SessionDetails.Room(name = "Effectenbeurszaal"),
+    room = SessionDetails.Room(name = "Effectenbeurszaal", id = "0", __typename = "Room"),
     tags = listOf(),
     __typename = "Session"
 )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ClientQuery.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ClientQuery.kt
@@ -3,8 +3,8 @@ package dev.johnoreilly.confetti.utils
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.cache.normalized.CacheInfo
-import com.apollographql.apollo.cache.normalized.cacheInfo
+import com.apollographql.cache.normalized.CacheInfo
+import com.apollographql.cache.normalized.cacheInfo
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.CacheMissException
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/work/work.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/work/work.kt
@@ -1,8 +1,8 @@
 package dev.johnoreilly.confetti.work
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
-import com.apollographql.apollo.cache.normalized.writeToCacheAsynchronously
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.writeToCacheAsynchronously
 import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.GetConferenceDataQuery
 import dev.johnoreilly.confetti.GetConferencesQuery

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/work/work.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/work/work.kt
@@ -1,11 +1,11 @@
 package dev.johnoreilly.confetti.work
 
 import com.apollographql.cache.normalized.FetchPolicy
-import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.writeToCacheAsynchronously
 import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.GetConferenceDataQuery
 import dev.johnoreilly.confetti.GetConferencesQuery
+import dev.johnoreilly.confetti.fetchPolicy
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -3,10 +3,10 @@
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo.network.http.ApolloClientAwarenessInterceptor
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.NSUserDefaultsSettings

--- a/shared/src/jvmMain/kotlin/Main.kt
+++ b/shared/src/jvmMain/kotlin/Main.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.DefaultFakeResolver
 import com.apollographql.apollo.api.FakeResolverContext
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.apollographql.apollo.testing.MapTestNetworkTransport
 import com.benasher44.uuid.uuid4
 import dev.johnoreilly.confetti.di.initKoin

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -2,10 +2,10 @@
 
 package dev.johnoreilly.confetti.di
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.PreferencesSettings

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
@@ -2,7 +2,6 @@ package dev.johnoreilly.confetti
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.cache.normalized.FetchPolicy
-import com.apollographql.cache.normalized.fetchPolicy
 import dev.johnoreilly.confetti.di.initKoin
 import kotlinx.coroutines.runBlocking
 import org.junit.Ignore

--- a/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
+++ b/shared/src/jvmTest/kotlin/dev/johnoreilly/confetti/MainTest.kt
@@ -1,8 +1,8 @@
 package dev.johnoreilly.confetti
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
 import dev.johnoreilly.confetti.di.initKoin
 import kotlinx.coroutines.runBlocking
 import org.junit.Ignore

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
@@ -3,9 +3,9 @@
 package dev.johnoreilly.confetti.di
 
 import com.apollographql.apollo.annotations.ApolloExperimental
-import com.apollographql.apollo.cache.normalized.FetchPolicy
-import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.memory.MemoryCacheFactory
+import com.apollographql.cache.normalized.api.NormalizedCacheFactory
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.StorageSettings
 import com.russhwolf.settings.coroutines.FlowSettings

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksComponent.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.wear.bookmarks
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.GetBookmarkedSessionsQuery

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/complication/NextSessionComplicationService.kt
@@ -7,7 +7,7 @@ import android.content.Intent
 import androidx.core.net.toUri
 import androidx.wear.watchface.complications.data.ComplicationType
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.android.horologist.tiles.complication.DataComplicationService
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/di/AppModule.kt
@@ -7,7 +7,7 @@ import androidx.room.Room
 import androidx.wear.tiles.TileService
 import coil.ImageLoader
 import coil.decode.SvgDecoder
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.google.android.horologist.datalayer.watch.WearDataLayerAppHelper
 import com.google.android.horologist.networks.battery.BatteryStatusMonitor
 import com.google.android.horologist.networks.data.DataRequestRepository

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeComponent.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeComponent.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.confetti.wear.home
 
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.GetConferenceDataQuery

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
@@ -19,14 +19,16 @@ object TestFixtures {
             LocalDate.parse("2023-04-14")
         ),
         "KotlinConf 2023",
-        "0xFF800000"
+        "0xFF800000",
+        __typename = "Conference",
     )
 
     val kotlinConf2023Config = GetBookmarkedSessionsQuery.Config(
         kotlinConf2023.id,
         "",
         kotlinConf2023.days,
-        kotlinConf2023.name
+        kotlinConf2023.name,
+        __typename = "Conference"
     )
 
     // Generate from FetchDataTest.fetchConferences
@@ -37,42 +39,48 @@ object TestFixtures {
             "",
             listOf(LocalDate.parse("2023-02-04"), LocalDate.parse("2023-02-05")),
             "Fosdem 2023",
-            "0xFF008000"
+            "0xFF008000",
+            __typename = "Conference",
         ),
         GetConferencesQuery.Conference(
             "droidconlondon2022",
             "",
             listOf(LocalDate.parse("2022-10-27"), LocalDate.parse("2022-10-28")),
             "droidcon London",
-            "0xFF800000"
+            "0xFF800000",
+            __typename = "Conference",
         ),
         GetConferencesQuery.Conference(
             "devfestnantes",
             "",
             listOf(LocalDate.parse("2022-10-20"), LocalDate.parse("2022-10-21")),
             "DevFest Nantes",
-            "0xFF800000"
+            "0xFF800000",
+            __typename = "Conference",
         ),
         GetConferencesQuery.Conference(
             "graphqlsummit2022",
             "",
             listOf(LocalDate.parse("2022-10-04"), LocalDate.parse("2022-10-05")),
             "GraphQL Summit",
-            "0xFF800000"
+            "0xFF800000",
+            __typename = "Conference",
         ),
         GetConferencesQuery.Conference(
             "frenchkit2022",
             "",
             listOf(LocalDate.parse("2022-09-29"), LocalDate.parse("2022-09-30")),
             "FrenchKit",
-            "0xFF800000"
+            "0xFF800000",
+            __typename = "Conference",
         ),
         GetConferencesQuery.Conference(
             "droidconsf",
             "",
             listOf(LocalDate.parse("2022-06-02"), LocalDate.parse("2022-06-03")),
             "droidcon SF",
-            "0xFF800000"
+            "0xFF800000",
+            __typename = "Conference",
         )
     )
 
@@ -134,7 +142,7 @@ The talk will cover
             JohnOreilly,
             MartinBonnin
         ),
-        room = SessionDetails.Room(name = "Effectenbeurszaal"),
+        room = SessionDetails.Room(name = "Effectenbeurszaal", id = "1", __typename = "Room"),
         tags = listOf(),
         __typename = "Session"
     )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileService.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/tile/CurrentSessionsTileService.kt
@@ -7,7 +7,7 @@ import androidx.wear.protolayout.ResourceBuilders
 import androidx.wear.tiles.EventBuilders
 import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.TileBuilders
-import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.FetchPolicy
 import com.google.android.horologist.tiles.SuspendingTileService
 import com.materialkolor.dynamicColorScheme
 import dev.johnoreilly.confetti.ConfettiRepository

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/app/BaseAppTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/app/BaseAppTest.kt
@@ -1,7 +1,7 @@
 package dev.johnoreilly.confetti.wear.app
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.apollographql.apollo.cache.normalized.sql.ApolloInitializer
+import com.apollographql.cache.normalized.sql.ApolloInitializer
 import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.wear.MainActivity
 import kotlinx.coroutines.runBlocking

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/screenshots/FetchDataTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/screenshots/FetchDataTest.kt
@@ -6,7 +6,7 @@ import android.util.Log
 import androidx.work.Configuration
 import androidx.work.impl.utils.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
-import com.apollographql.apollo.cache.normalized.sql.ApolloInitializer
+import com.apollographql.cache.normalized.sql.ApolloInitializer
 import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.GetConferencesQuery
 import dev.johnoreilly.confetti.GetSessionsQuery

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/surfaces/TileScreenshotTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/surfaces/TileScreenshotTest.kt
@@ -33,7 +33,8 @@ class TileScreenshotTest(override val device: WearDevice) : BaseScreenshotTest()
                         TestFixtures.kotlinConf2023.id,
                         "",
                         TestFixtures.kotlinConf2023.days,
-                        TestFixtures.kotlinConf2023.name
+                        TestFixtures.kotlinConf2023.name,
+                        __typename = "Conference",
                     ),
                     listOf(
                         TestFixtures.sessionDetails
@@ -62,7 +63,8 @@ class TileScreenshotTest(override val device: WearDevice) : BaseScreenshotTest()
                         TestFixtures.kotlinConf2023.id,
                         "",
                         TestFixtures.kotlinConf2023.days,
-                        TestFixtures.kotlinConf2023.name
+                        TestFixtures.kotlinConf2023.name,
+                        __typename = "Conference",
                     )
                 )
             }


### PR DESCRIPTION
Use Apollo's [incubating normalized cache](https://github.com/apollographql/apollo-kotlin-normalized-cache-incubating) instead of the main repository one.

Note: this version isn't "stable" yet (the API and storage can evolve in the upcoming versions, and while performance _should_ be improved this isn't completely confirmed) but I think Confetti is a good candidate for dogfooding it, e.g. it's ok for the cached data to be lost when upgrading - fresh data will be fetched from the backend.

Also in this PR I use the new [`@cacheControl`](https://apollographql.github.io/apollo-kotlin-normalized-cache-incubating/cache-control.html) directive with a max age of 4 hours (1 hour for bookmarks) - which is a bit arbitrary, LMK what you think about these values. ~What this means concretely is that cached data older than this will not be displayed and enforce a network call.~ The cached data older than this will still be displayed, but this will trigger a network fetch in the background.