### PR TITLE
Tweak the custom fetch policy

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
@@ -1,11 +1,10 @@
 package dev.johnoreilly.confetti
 
-import com.apollographql.apollo.ConcurrencyInfo
-import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.MutableExecutionOptions
 import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.cache.normalized.FetchPolicy
@@ -14,11 +13,8 @@ import com.apollographql.cache.normalized.fetchFromCache
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.fetchPolicyInterceptor
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.single
-import kotlinx.coroutines.launch
 
 /**
  * Use our custom fetch policy interceptor for the [FetchPolicy.CacheFirst] policy, and the Apollo built-in interceptors
@@ -35,29 +31,51 @@ fun <T> MutableExecutionOptions<T>.fetchPolicy(fetchPolicy: FetchPolicy) = when 
 }
 
 /**
- * Returns the cached data if available (even if stale), or the network data if not.
- * If the cache data is stale, it is refreshed from the network in the background.
+ * Returns by priority:
+ * - the cached data if it's fresh
+ * - the network data if it could be fetched
+ * - the stale cached data
  */
 private object CacheFirstInterceptor : ApolloInterceptor {
     override fun <D : Operation.Data> intercept(
         request: ApolloRequest<D>,
         chain: ApolloInterceptorChain
     ): Flow<ApolloResponse<D>> = flow {
-        val cacheResponse = chain.proceed(
-            request.newBuilder()
-                .fetchFromCache(true)
-                .build()
-        ).single()
-        if (cacheResponse.cacheInfo!!.isCacheHit) {
+        val cacheResponse = chain.proceed(request.newBuilder().fetchFromCache(true).build()).single()
+        if (cacheResponse.cacheInfo!!.isCacheHit && !cacheResponse.cacheInfo!!.isStale) {
             emit(cacheResponse)
-            if (cacheResponse.cacheInfo!!.isStale) {
-                val scope = @OptIn(ApolloExperimental::class) request.executionContext[ConcurrencyInfo]!!.coroutineScope
-                scope.launch {
-                    chain.proceed(request).collect()
-                }
-            }
         } else {
-            emitAll(chain.proceed(request))
+            // If the first emission is an exception, emit the cache response.
+            // For exceptions on subsequent emissions, emit the network responses.
+            var first = true
+            chain.proceed(request).collect { networkResponse ->
+                emit(
+                    if (networkResponse.exception == null || !first) {
+                        networkResponse
+                    } else {
+                        cacheResponse.cacheMissAsException()
+                    }
+                )
+                first = false
+            }
         }
     }
 }
+
+private fun <D : Operation.Data> ApolloResponse<D>.cacheMissAsException(): ApolloResponse<D> {
+    return if (cacheInfo!!.isCacheHit) {
+        this
+    } else {
+        val cacheMissException =
+            errors.orEmpty().mapNotNull { it.extensions?.get("exception") as? ApolloException }.reduceOrNull { acc, e ->
+                acc.addSuppressed(e)
+                acc
+            }
+        newBuilder()
+            .exception(cacheMissException)
+            .data(null)
+            .errors(null)
+            .build()
+    }
+}
+


### PR DESCRIPTION
The interceptor introduced in #1537 fetches data in the background, which can make the UI change while the user is using the app without an action from their part. This can be confusing or annoying.

Instead, this version returns the data from the cache if it's fresh, if not, tries the network, and if that didn't work, falls back to the stale data from the cache.

Thanks @martinbonnin for the idea!