### PR TITLE
Update dependencies to re-enable native caching with CMP 1.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.parallel=true
 
 #Kotlin
 kotlin.code.style=official
-kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,25 +13,22 @@ androidx-datastore = "1.1.5"
 apollo = "4.1.1"
 apollo-cache = "0.0.8"
 compose = "1.8.0"
-compose-hot-reload = "1.0.0-alpha08"
+compose-hot-reload = "1.0.0-alpha09"
 composeLifecyleRuntime="2.9.0-alpha07"
 compose-multiplatform = "1.8.0-rc01"
 compose-material3 = "1.3.2"
 composeWindowSize = "0.5.0"
 credentials = "1.5.0"
-decompose = "3.3.0"
+decompose = "3.4.0-alpha01"
 doistx-normalize = "1.2.0"
 essenty = "2.5.0"
 googleid = "1.1.1"
 horologist = "0.7.10-alpha"
 io-coil-kt = "2.7.0"
-io-coil3-kt = "3.1.0"
+io-coil3-kt = "3.2.0-rc02"
 kermit = "2.0.5"
 kmmbridge = "0.5.7"
-koin-android = "4.0.4"
-koin-android-compose = "4.0.4"
-koin-compose-multiplatform = "4.0.4"
-koin-core = "4.0.4"
+koin = "4.1.0-Beta8"
 kotlinx-coroutines-play-services = "1.10.1"
 lifecycle = "2.8.7"
 lifecycle-livedata-ktx = "2.8.7"
@@ -159,13 +156,13 @@ jsonpath = "com.eygraber:jsonpathkt-kotlinx:3.0.2"
 jsoup = "org.jsoup:jsoup:1.18.3"
 junit = "junit:junit:4.13.2"
 kaml = "com.charleskorn.kaml:kaml:0.66.0"
-koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin-android" }
-koin-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin-android" }
-koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-android-compose" }
-koin-compose-multiplatform = { module = "io.insert-koin:koin-compose", version.ref = "koin-compose-multiplatform" }
-koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin-core" }
-koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin-core" }
-koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin-core" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-workmanager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
+koin-compose-multiplatform = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
https://github.com/joreilly/Confetti/pull/1608 disabled native caching due to [CMP-7571](https://youtrack.jetbrains.com/issue/CMP-7571).

This PR bumps the relevant dependencies (Coil, Koin, and Decompose) to their latest pre-release versions which are compiled against Compose 1.8, and re-enables native caching.