### PR TITLE
Add AndroidMakers 2026 conference data

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -47,6 +47,7 @@ enum class ConferenceId(val id: String) {
     DevFestVenice2025("devfestvenice2025"),
     DroidconItaly2025("droidconitaly2025"),
     KotlinConf2026("kotlinconf2026"),
+    AndroidMakers2026("androidmakers2026"),
     ;
 
     companion object {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -150,6 +150,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.DevFestVenice2025 -> importDevFestVenice2025()
         ConferenceId.DroidconItaly2025 -> DroidconItaly2025.import()
         ConferenceId.KotlinConf2026 -> Sessionize.importKotlinConf2026()
+        ConferenceId.AndroidMakers2026 -> Sessionize.importAndroidMakers2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -38,6 +38,34 @@ object Sessionize {
         val speakers: List<DSpeaker>,
     )
 
+    suspend fun importAndroidMakers2026(): Int {
+        return writeData(
+            getData(
+                url = "https://sessionize.com/api/v2/kqy4c3ye/view/All",
+            ),
+            config = DConfig(
+                id = ConferenceId.AndroidMakers2026.id,
+                name = "AndroidMakers by droidcon 2026",
+                timeZone = "Europe/Paris",
+                themeColor = "0xffFB5C49"
+            ),
+            venue = DVenue(
+                id = "conference",
+                name = "Beffroi de Montrouge",
+                address = "Av. de la République, 92120 Montrouge",
+                description = mapOf(
+                    "en" to "Cool venue",
+                    "fr" to "Venue fraiche",
+                ),
+                latitude = 48.8188958,
+                longitude = 2.3193016,
+                imageUrl = "https://www.beffroidemontrouge.com/wp-content/uploads/2019/09/moebius-1.jpg",
+                floorPlanUrl = "https://storage.googleapis.com/androidmakers-static/floor_plan.png"
+            ),
+            partnerGroups = emptyList()
+        )
+    }
+
     suspend fun importAndroidMakers2025(): Int {
         return writeData(
             getData(


### PR DESCRIPTION
## Summary
- Adds AndroidMakers 2026 conference with Sessionize URL `kqy4c3ye` (sourced from Paug/AndroidMakersBackend repo)
- Same venue (Beffroi de Montrouge), timezone, and theme color as previous years
- Partner groups left empty for now

## Test plan
- [ ] Run import: `curl -X POST http://localhost:8080/update/androidmakers2026`
- [ ] Verify the conference appears in the GraphQL `conferences` query