### PR TITLE
Add ee.schimke.composeai.preview plugin 0.6.1 to wearApp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("base")
+    alias(libs.plugins.composeai.preview) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.17.1"
 roborazzi = "1.59.0"
 screenshot = "0.0.1-alpha14"
+composeai-preview = "0.6.1"
 
 
 [libraries]
@@ -238,6 +239,7 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-multip
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload" }
 screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot"}
+composeai-preview = { id = "ee.schimke.composeai.preview", version.ref = "composeai-preview" }
 kgp-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 gratatouille = { id = "com.gradleup.gratatouille", version = "0.2.1" }

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
     id("io.github.takahirom.roborazzi")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.screenshot)
+
+    id("ee.schimke.composeai.preview") version "0.6.1"
 }
 
 configureCompilerOptions()

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -12,8 +12,7 @@ plugins {
     id("io.github.takahirom.roborazzi")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.screenshot)
-
-    id("ee.schimke.composeai.preview") version "0.6.1"
+    alias(libs.plugins.composeai.preview)
 }
 
 configureCompilerOptions()


### PR DESCRIPTION
## Summary
- Re-adds the `ee.schimke.composeai.preview` Gradle plugin to `wearApp` at version 0.6.1, follow-up to #1677 which dropped it pending this upgrade.

## Test plan
- [ ] `./gradlew :wearApp:assembleDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)