### PR TITLE
Re-add @ScrollingPreview(LONG) annotations on wear previews

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -228,6 +228,8 @@ roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", versi
 roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
 roborazzi-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
 
+composeai-preview-annotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composeai-preview" }
+
 [bundles]
 multiplatform-settings = ["multiplatform-settings", "multiplatform-settings-coroutines", "multiplatform-settings-serialization", "multiplatform-settings-make-observable"]
 apollo = ["apollo-normalized-cache-in-memory", "apollo-adapters"]

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -147,6 +147,8 @@ dependencies {
 dependencies {
     implementation(projects.shared)
 
+    implementation(libs.composeai.preview.annotations)
+
     implementation(libs.coil.compose)
     implementation(libs.coil.svg)
     implementation(libs.compose.ui.tooling)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
@@ -18,6 +18,8 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.utils.QueryResult
 import dev.johnoreilly.confetti.wear.components.ScreenHeader
@@ -222,6 +224,7 @@ fun BookmarksPreviewEmpty() {
 }
 
 @WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun BookmarksPreviewLong() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -20,6 +20,8 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.BuildConfig
 import dev.johnoreilly.confetti.GetConferencesQuery
 import dev.johnoreilly.confetti.decompose.ConferencesComponent
@@ -147,6 +149,7 @@ fun ConferencesViewPreview() {
 }
 
 @WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun ConferencesViewLongPreview() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
@@ -32,6 +32,8 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.utils.QueryResult
 import dev.johnoreilly.confetti.wear.bookmarks.BookmarksUiState
@@ -286,6 +288,7 @@ fun HomeListViewPreview() {
 }
 
 @WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun HomeListViewLongPreview() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
@@ -16,6 +16,8 @@ import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.decompose.SessionsUiState
 import dev.johnoreilly.confetti.wear.components.SectionHeader
 import dev.johnoreilly.confetti.wear.components.SessionCard
@@ -123,6 +125,7 @@ fun SessionListViewPreview() {
 }
 
 @WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun SessionListViewLongPreview() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
@@ -38,6 +38,8 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import coil.compose.AsyncImage
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.BuildConfig
 import dev.johnoreilly.confetti.R
 import dev.johnoreilly.confetti.wear.components.ScreenHeader
@@ -281,6 +283,7 @@ fun SettingsListViewPreview() {
 }
 
 @WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun SettingsListViewLongPreview() {
     ConfettiPreviewScaffold {


### PR DESCRIPTION
## Goal

Re-add the long scrolling previews in wearApp. The `*LongPreview` composables are still there — just add the `@ScrollingPreview(mode = ScrollMode.LONG)` annotation back, plus the `preview-annotations` Gradle dependency.

## Summary

**Changes made**
- Add `composeai-preview-annotations` library to [gradle/libs.versions.toml](gradle/libs.versions.toml) (reuses the `composeai-preview` version ref introduced in #1678).
- Declare `libs.composeai.preview.annotations` in [wearApp/build.gradle.kts](wearApp/build.gradle.kts).
- Re-apply `@ScrollingPreview(mode = ScrollMode.LONG)` and re-add the two imports on the five preserved `*LongPreview` composables:
  - [BookmarksScreen.kt](wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt)
  - [ConferencesView.kt](wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt)
  - [HomeScreen.kt](wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt)
  - [SessionsScreen.kt](wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt)
  - [SettingsListView.kt](wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt)

**Known gaps**
- Only the five `*LongPreview` functions are annotated. The sibling `BookmarksPreviewErrorLong` that fans out across device/font variants is unchanged (no scrolling state to exercise).

**Verification**
Rendered base vs. head locally with `compose-preview show`. All five `*LongPreview_Devices - Large Round` captures show `scroll: {mode: LONG, axis: VERTICAL, reduceMotion: true}` on head and produce the expected tall capsule-shaped PNGs covering the full scrollable extent. See the preview-diff comment below for side-by-side renders.