### PR TITLE
wearApp: wire SurfaceTransformation on every TransformingLazyColumn item

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.17.1"
 roborazzi = "1.59.0"
 screenshot = "0.0.1-alpha14"
-composeai-preview = "0.7.1"
+composeai-preview = "0.7.9"
 
 
 [libraries]
@@ -141,9 +141,7 @@ google-cloud-bom = "com.google.cloud:libraries-bom:26.63.0"
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage" }
 google-cloud-datastore = "com.google.cloud:google-cloud-datastore:2.25.1"
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
-horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
-horologist-compose-material = { module = "com.google.android.horologist:horologist-compose-material", version.ref = "horologist" }
 horologist-compose-tools = { module = "com.google.android.horologist:horologist-compose-tools", version.ref = "horologist" }
 horologist-datalayer = { module = "com.google.android.horologist:horologist-datalayer", version.ref = "horologist" }
 horologist-datalayer-phone = { module = "com.google.android.horologist:horologist-datalayer-phone", version.ref = "horologist" }
@@ -152,7 +150,6 @@ horologist-images-coil = { module = "com.google.android.horologist:horologist-im
 horologist-networkawareness-core = { module = "com.google.android.horologist:horologist-network-awareness", version.ref = "horologist" }
 horologist-networkawareness-db = { module = "com.google.android.horologist:horologist-network-awareness-db", version.ref = "horologist" }
 horologist-networkawareness-okhttp = { module = "com.google.android.horologist:horologist-network-awareness-okhttp", version.ref = "horologist" }
-horologist-networkawareness-ui = { module = "com.google.android.horologist:horologist-network-awareness-ui", version.ref = "horologist" }
 horologist-tiles = { module = "com.google.android.horologist:horologist-tiles", version.ref = "horologist" }
 horologist-roboscreenshots = { module = "com.google.android.horologist:horologist-roboscreenshots", version.ref = "horologist" }
 jsonpath = "com.eygraber:jsonpathkt-kotlinx:3.0.2"
@@ -215,7 +212,6 @@ splash-screen = "androidx.core:core-splashscreen:1.0.1"
 test-espressocore = "androidx.test.espresso:espresso-core:3.6.1"
 test-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0"
 wear-complications-data = { module = "androidx.wear.watchface:watchface-complications-data-source-ktx", version.ref = "wear-watchface"}
-wear-compose-material = { module = "androidx.wear.compose:compose-material", version.ref = "wear-compose"}
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose"}
 xoxo = "net.mbonnin.xoxo:xoxo:0.4.0"
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -182,9 +182,6 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.androidx.lifecycle.livedata.ktx)
 
-    implementation(libs.wear.compose.material)
-    api(libs.horologist.compose.material)
-    api(libs.horologist.composables)
     implementation(libs.horologist.tiles)
     implementation(libs.wear.complications.data)
 
@@ -202,7 +199,6 @@ dependencies {
     implementation(libs.horologist.networkawareness.core)
     implementation(libs.horologist.networkawareness.db)
     implementation(libs.horologist.networkawareness.okhttp)
-    implementation(libs.horologist.networkawareness.ui)
     api(libs.horologist.images.coil)
 
     implementation(libs.material3.core)

--- a/wearApp/build.gradle.kts
+++ b/wearApp/build.gradle.kts
@@ -183,7 +183,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.livedata.ktx)
 
     implementation(libs.wear.compose.material)
-    implementation(libs.horologist.compose.layout)
     api(libs.horologist.compose.material)
     api(libs.horologist.composables)
     implementation(libs.horologist.tiles)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
@@ -13,7 +14,10 @@ import androidx.wear.compose.material3.CardDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.rememberPlaceholderState
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
@@ -40,6 +44,7 @@ fun BookmarksScreen(
     modifier: Modifier = Modifier,
 ) {
     val columnState = rememberTransformingLazyColumnState()
+    val transformationSpec = rememberTransformationSpec()
     val placeholderState = rememberPlaceholderState(uiState is QueryResult.Loading)
     ScreenScaffold(
         modifier = modifier,
@@ -59,7 +64,11 @@ fun BookmarksScreen(
                 is QueryResult.Success, QueryResult.Loading -> {
                     item {
                         ScreenHeader(
-                            text = stringResource(R.string.upcoming_sessions)
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec),
+                            text = stringResource(R.string.upcoming_sessions),
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
 
@@ -78,15 +87,28 @@ fun BookmarksScreen(
                             isBookmarked = true,
                             addBookmark = addBookmark,
                             removeBookmark = removeBookmark,
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    CardDefaults.minimumVerticalListContentPadding
+                                ),
                             placeholderState = placeholderState,
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
 
                     if ((uiState as? QueryResult.Success)?.result?.hasUpcomingBookmarks == false) {
                         item {
                             Text(
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .graphicsLayer {
+                                        with(transformationSpec) {
+                                            applyContainerTransformation(scrollProgress)
+                                        }
+                                    }
+                                    .transformedHeight(this, transformationSpec),
                                 text = stringResource(id = R.string.no_upcoming),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -96,7 +118,11 @@ fun BookmarksScreen(
 
                     item {
                         SectionHeader(
-                            modifier = Modifier.fillMaxWidth(), text = stringResource(id = R.string.past_sessions)
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec),
+                            text = stringResource(id = R.string.past_sessions),
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
 
@@ -113,9 +139,11 @@ fun BookmarksScreen(
                                 removeBookmark = {},
                                 modifier = Modifier
                                     .fillMaxWidth()
+                                    .transformedHeight(this, transformationSpec)
                                     .minimumVerticalContentPadding(
                                         CardDefaults.minimumVerticalListContentPadding
                                     ),
+                                transformation = SurfaceTransformation(transformationSpec),
                             )
                         }
 
@@ -124,6 +152,12 @@ fun BookmarksScreen(
                                 Text(
                                     modifier = Modifier
                                         .fillMaxWidth()
+                                        .graphicsLayer {
+                                            with(transformationSpec) {
+                                                applyContainerTransformation(scrollProgress)
+                                            }
+                                        }
+                                        .transformedHeight(this, transformationSpec)
                                         .minimumVerticalContentPadding(
                                             CardDefaults.minimumVerticalListContentPadding
                                         ),
@@ -139,12 +173,23 @@ fun BookmarksScreen(
                 is QueryResult.Error -> {
                     item {
                         ScreenHeader(
-                            text = stringResource(R.string.upcoming_sessions)
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec),
+                            text = stringResource(R.string.upcoming_sessions),
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
                     item {
                         Text(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .graphicsLayer {
+                                    with(transformationSpec) {
+                                        applyContainerTransformation(scrollProgress)
+                                    }
+                                }
+                                .transformedHeight(this, transformationSpec),
                             text = uiState.exception.message ?: "Unknown Error Occurred",
                             color = MaterialTheme.colorScheme.errorDim
                         )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
@@ -11,6 +11,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.CardDefaults
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
@@ -66,7 +67,10 @@ fun BookmarksScreen(
                         ScreenHeader(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .transformedHeight(this, transformationSpec),
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ListHeaderDefaults.minimumTopListContentPadding
+                                ),
                             text = stringResource(R.string.upcoming_sessions),
                             transformation = SurfaceTransformation(transformationSpec),
                         )
@@ -175,7 +179,10 @@ fun BookmarksScreen(
                         ScreenHeader(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .transformedHeight(this, transformationSpec),
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ListHeaderDefaults.minimumTopListContentPadding
+                                ),
                             text = stringResource(R.string.upcoming_sessions),
                             transformation = SurfaceTransformation(transformationSpec),
                         )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/PlaceholderButton.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/PlaceholderButton.kt
@@ -19,6 +19,7 @@ import androidx.wear.compose.material3.ButtonColors
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.PlaceholderDefaults
 import androidx.wear.compose.material3.PlaceholderState
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.placeholderShimmer
 import androidx.wear.compose.material3.rememberPlaceholderState
@@ -35,12 +36,14 @@ public fun PlaceholderButton(
     secondaryLabel: Boolean = true,
     hasIcon: Boolean = true,
     enabled: Boolean = false,
+    transformation: SurfaceTransformation? = null,
 ) {
     Button(
         modifier = modifier
             .height(ButtonDefaults.Height)
             .fillMaxWidth()
             .placeholderShimmer(placeholderState),
+        transformation = transformation,
         onClick = onClick,
         enabled = enabled,
         label = {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SectionHeader.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SectionHeader.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.ListSubHeader
 import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
 
 /**
@@ -21,8 +22,12 @@ import androidx.wear.compose.material3.Text
 fun SectionHeader(
     text: String,
     modifier: Modifier = Modifier,
+    transformation: SurfaceTransformation? = null,
 ) {
-    ListSubHeader(modifier = modifier.fillMaxWidth()) {
+    ListSubHeader(
+        modifier = modifier.fillMaxWidth(),
+        transformation = transformation,
+    ) {
         Text(
             text = text,
             style = MaterialTheme.typography.labelMedium,
@@ -40,8 +45,12 @@ fun SectionHeader(
 fun ScreenHeader(
     text: String,
     modifier: Modifier = Modifier,
+    transformation: SurfaceTransformation? = null,
 ) {
-    ListHeader(modifier = modifier.fillMaxWidth()) {
+    ListHeader(
+        modifier = modifier.fillMaxWidth(),
+        transformation = transformation,
+    ) {
         Text(
             text = text,
             textAlign = TextAlign.Center,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionCard.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionCard.kt
@@ -26,6 +26,7 @@ import androidx.wear.compose.material3.LocalContentColor
 import androidx.wear.compose.material3.LocalTextStyle
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.PlaceholderState
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.SwipeToReveal
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TitleCard
@@ -57,6 +58,7 @@ fun SessionCard(
         }
     },
     placeholderState: PlaceholderState = rememberPlaceholderState(false),
+    transformation: SurfaceTransformation? = null,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val revealState = rememberRevealState()
@@ -70,7 +72,8 @@ fun SessionCard(
                 sessionSelected = sessionSelected,
                 session = session,
                 placeholderState = placeholderState,
-                timeDisplay = timeDisplay
+                timeDisplay = timeDisplay,
+                transformation = transformation,
             )
         }
 
@@ -114,12 +117,14 @@ private fun SessionCardContent(
     sessionSelected: (sessionId: String) -> Unit,
     session: SessionDetails?,
     placeholderState: PlaceholderState,
-    timeDisplay: @Composable () -> Unit
+    timeDisplay: @Composable () -> Unit,
+    transformation: SurfaceTransformation? = null,
 ) {
     TitleCard(
         modifier = modifier
             .fillMaxWidth()
             .placeholderShimmer(placeholderState),
+        transformation = transformation,
         onClick = {
             if (session != null) {
                 sessionSelected(session.id)

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
@@ -11,6 +11,7 @@ import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.SurfaceTransformation
 import coil.compose.SubcomposeAsyncImage
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.fullNameAndCompany
@@ -26,10 +27,12 @@ val SpeakerDetails.wearPhotoUrl: String?
 fun SessionSpeakerChip(
     modifier: Modifier = Modifier,
     speaker: SpeakerDetails,
-    navigateToSpeaker: (String) -> Unit
+    navigateToSpeaker: (String) -> Unit,
+    transformation: SurfaceTransformation? = null,
 ) {
     Button(
         modifier = modifier,
+        transformation = transformation,
         icon = {
             SubcomposeAsyncImage(
                 model = speaker.wearPhotoUrl,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -1,9 +1,13 @@
 package dev.johnoreilly.confetti.wear.conferences
 
 import androidx.activity.compose.ReportDrawnWhen
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -16,6 +20,8 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.FilledIconButton
+import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
@@ -142,16 +148,19 @@ fun ConferencesView(
                         )
                     }
                     item {
-                        Button(
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .transformedHeight(this, transformationSpec)
-                                .minimumVerticalContentPadding(
-                                    ButtonDefaults.minimumVerticalListContentPadding
-                                ),
-                            transformation = SurfaceTransformation(transformationSpec),
-                            onClick = onRetry,
-                        ) { Text("Retry") }
+                                .padding(vertical = 8.dp),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            FilledIconButton(onClick = onRetry) {
+                                Icon(
+                                    imageVector = Icons.Default.Refresh,
+                                    contentDescription = "Retry",
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -192,6 +201,18 @@ fun ConferencesViewPreview() {
             uiState = ConferencesComponent.Success(
                 TestFixtures.conferences.groupBy { it.days[0].year }
             ),
+            navigateToConference = {},
+        )
+    }
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun ConferencesViewErrorPreview() {
+    ConfettiPreviewScaffold {
+        ConferencesView(
+            uiState = ConferencesComponent.Error,
             navigateToConference = {},
         )
     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -3,10 +3,13 @@ package dev.johnoreilly.confetti.wear.conferences
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
@@ -14,6 +17,7 @@ import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.ListHeaderDefaults
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
@@ -53,7 +57,8 @@ fun ConferencesRoute(
         uiState = uiState,
         navigateToConference = { conference ->
             component.onConferenceClicked(conference)
-        }
+        },
+        onRetry = component::refresh,
     )
 }
 
@@ -63,6 +68,7 @@ fun ConferencesView(
     navigateToConference: (GetConferencesQuery.Conference) -> Unit,
     modifier: Modifier = Modifier,
     columnState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),
+    onRetry: () -> Unit = {},
 ) {
     val transformationSpec = rememberTransformationSpec()
     ScreenScaffold(
@@ -124,8 +130,29 @@ fun ConferencesView(
                     }
                 }
 
-                else -> {
-                    // TODO
+                is ConferencesComponent.Error -> {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                            text = "Couldn't load conferences. Check your connection and try again.",
+                            color = MaterialTheme.colorScheme.errorDim,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    item {
+                        Button(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ButtonDefaults.minimumVerticalListContentPadding
+                                ),
+                            transformation = SurfaceTransformation(transformationSpec),
+                            onClick = onRetry,
+                        ) { Text("Retry") }
+                    }
                 }
             }
         }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -15,7 +15,10 @@ import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
@@ -60,6 +63,7 @@ fun ConferencesView(
     modifier: Modifier = Modifier,
     columnState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),
 ) {
+    val transformationSpec = rememberTransformationSpec()
     ScreenScaffold(
         modifier = modifier,
         scrollState = columnState,
@@ -76,7 +80,11 @@ fun ConferencesView(
         ) {
             item {
                 ScreenHeader(
-                    text = "Conferences"
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec),
+                    text = "Conferences",
+                    transformation = SurfaceTransformation(transformationSpec),
                 )
             }
 
@@ -86,9 +94,11 @@ fun ConferencesView(
                         PlaceholderButton(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
                                 .minimumVerticalContentPadding(
                                     ButtonDefaults.minimumVerticalListContentPadding
                                 ),
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
                 }
@@ -99,11 +109,13 @@ fun ConferencesView(
                         ConferencesChip(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
                                 .minimumVerticalContentPadding(
                                     ButtonDefaults.minimumVerticalListContentPadding
                                 ),
-                            conference,
-                            navigateToConference,
+                            conference = conference,
+                            navigateToConference = navigateToConference,
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
                 }
@@ -120,7 +132,8 @@ fun ConferencesView(
 private fun ConferencesChip(
     modifier: Modifier = Modifier,
     conference: GetConferencesQuery.Conference,
-    navigateToConference: (GetConferencesQuery.Conference) -> Unit
+    navigateToConference: (GetConferencesQuery.Conference) -> Unit,
+    transformation: SurfaceTransformation? = null,
 ) {
     // Curated conference themes (KotlinConf, AndroidMakers, Droidcon,
     // DevFest) win over the backend-supplied themeColor so each chip on
@@ -130,6 +143,7 @@ private fun ConferencesChip(
     ConfettiTheme(seedColor = conference.seedColor()) {
         Button(
             modifier = modifier.fillMaxWidth(),
+            transformation = transformation,
             onClick = {
                 navigateToConference(conference)
             },

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -13,6 +13,7 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
@@ -82,7 +83,10 @@ fun ConferencesView(
                 ScreenHeader(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .transformedHeight(this, transformationSpec),
+                        .transformedHeight(this, transformationSpec)
+                        .minimumVerticalContentPadding(
+                            ListHeaderDefaults.minimumTopListContentPadding
+                        ),
                     text = "Conferences",
                     transformation = SurfaceTransformation(transformationSpec),
                 )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/decompose/SwipeToDismissBox.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/decompose/SwipeToDismissBox.kt
@@ -17,13 +17,13 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.value.Value
 
 /**
- * Displays the [ChildStack] in [SwipeToDismissBox][androidx.wear.compose.material.SwipeToDismissBox].
+ * Displays the [ChildStack] in [SwipeToDismissBox][androidx.wear.compose.material3.SwipeToDismissBox].
  *
  * @param stack a [ChildStack] to be displayed.
  * @param onDismissed called when the swipe to dismiss gesture has completed, allows popping the stack.
  * See [StackNavigator#pop][com.arkivanov.decompose.router.stack.pop].
  * @param modifier a [Modifier] to be applied to the underlying
- * [SwipeToDismissBox][androidx.wear.compose.material.SwipeToDismissBox].
+ * [SwipeToDismissBox][androidx.wear.compose.material3.SwipeToDismissBox].
  * @param content a Composable slot displaying a [Child][Child.Created].
  */
 @Composable
@@ -44,13 +44,13 @@ fun <C : Any, T : Any> SwipeToDismissBox(
 }
 
 /**
- * Displays the [ChildStack] in [SwipeToDismissBox][androidx.wear.compose.material.SwipeToDismissBox].
+ * Displays the [ChildStack] in [SwipeToDismissBox][androidx.wear.compose.material3.SwipeToDismissBox].
  *
  * @param stack a [ChildStack] to be displayed.
  * @param onDismissed called when the swipe to dismiss gesture has completed, allows popping the stack.
  * See [StackNavigator#pop][com.arkivanov.decompose.router.stack.pop].
  * @param modifier a [Modifier] to be applied to the underlying
- * [SwipeToDismissBox][androidx.wear.compose.material.SwipeToDismissBox].
+ * [SwipeToDismissBox][androidx.wear.compose.material3.SwipeToDismissBox].
  * @param content a Composable slot displaying a [Child][Child.Created].
  */
 @Composable

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/decompose/SwipeToDismissBox.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/decompose/SwipeToDismissBox.kt
@@ -11,8 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
 import androidx.wear.compose.foundation.SwipeToDismissKeys
 import androidx.wear.compose.material3.SwipeToDismissBox
-import androidx.wear.compose.material3.TimeText
-import androidx.wear.compose.material3.AppScaffold
 import com.arkivanov.decompose.Child
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.router.stack.ChildStack
@@ -33,7 +31,6 @@ fun <C : Any, T : Any> SwipeToDismissBox(
     stack: Value<ChildStack<C, T>>,
     onDismissed: () -> Unit,
     modifier: Modifier = Modifier,
-    timeText: @Composable () -> Unit = { TimeText() },
     content: @Composable (child: Child.Created<C, T>) -> Unit,
 ) {
     val state = stack.subscribeAsState()
@@ -43,7 +40,6 @@ fun <C : Any, T : Any> SwipeToDismissBox(
         onDismissed = onDismissed,
         modifier = modifier,
         content = content,
-        timeText = timeText
     )
 }
 
@@ -62,7 +58,6 @@ fun <C : Any, T : Any> SwipeToDismissBox(
     stack: ChildStack<C, T>,
     onDismissed: () -> Unit,
     modifier: Modifier = Modifier,
-    timeText: @Composable () -> Unit = { TimeText() },
     content: @Composable (child: Child.Created<C, T>) -> Unit,
 ) {
     val active: Child.Created<C, T> = stack.active
@@ -71,18 +66,16 @@ fun <C : Any, T : Any> SwipeToDismissBox(
 
     RetainStates(holder, stack.getConfigurations())
 
-    AppScaffold(timeText = timeText) {
-        SwipeToDismissBox(
-            onDismissed = onDismissed,
-            modifier = modifier,
-            backgroundKey = background?.configuration ?: SwipeToDismissKeys.Background,
-            contentKey = active.configuration,
-            userSwipeEnabled = background != null,
-        ) { isBackground ->
-            val child = background?.takeIf { isBackground } ?: active
-            holder.SaveableStateProvider(child.configuration.key()) {
-                content(child)
-            }
+    SwipeToDismissBox(
+        onDismissed = onDismissed,
+        modifier = modifier,
+        backgroundKey = background?.configuration ?: SwipeToDismissKeys.Background,
+        contentKey = active.configuration,
+        userSwipeEnabled = background != null,
+    ) { isBackground ->
+        val child = background?.takeIf { isBackground } ?: active
+        holder.SaveableStateProvider(child.configuration.key()) {
+            content(child)
         }
     }
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
@@ -380,7 +380,10 @@ fun HomeListViewPreview() {
 }
 
 @WearPreviewLargeRound
-@ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END, ScrollMode.LONG])
+@ScrollingPreview(
+    modes = [ScrollMode.TOP, ScrollMode.END, ScrollMode.LONG, ScrollMode.GIF],
+    reduceMotion = false,
+)
 @Composable
 fun HomeListViewLongPreview() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
@@ -12,26 +12,34 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumnItemScope
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnScope
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.CardDefaults
 import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.EdgeButtonSize
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.OutlinedButton
 import androidx.wear.compose.material3.PlaceholderState
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.TransformationSpec
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.placeholderShimmer
 import androidx.wear.compose.material3.rememberPlaceholderState
@@ -71,6 +79,7 @@ fun HomeScreen(
     val dayFormatter = remember { DateTimeFormatter.ofPattern("cccc") }
 
     val columnState = rememberTransformingLazyColumnState()
+    val transformationSpec = rememberTransformationSpec()
     val placeholderState = rememberPlaceholderState(uiState is QueryResult.Loading)
     ScreenScaffold(
         modifier = modifier,
@@ -97,7 +106,11 @@ fun HomeScreen(
             state = columnState,
             contentPadding = contentPadding,
         ) {
-            titleSection(uiState = uiState, placeholderState = placeholderState)
+            titleSection(
+                uiState = uiState,
+                placeholderState = placeholderState,
+                transformationSpec = transformationSpec,
+            )
 
             bookmarksSection(
                 uiState = uiState,
@@ -105,24 +118,39 @@ fun HomeScreen(
                 sessionSelected = sessionSelected,
                 addBookmark = addBookmark,
                 removeBookmark = removeBookmark,
-                onBookmarksClick = onBookmarksClick
+                onBookmarksClick = onBookmarksClick,
+                transformationSpec = transformationSpec,
             )
 
-            conferenceDaysSection(uiState = uiState, daySelected = daySelected, dayFormatter = dayFormatter)
+            conferenceDaysSection(
+                uiState = uiState,
+                daySelected = daySelected,
+                dayFormatter = dayFormatter,
+                transformationSpec = transformationSpec,
+            )
         }
     }
 }
 
 private fun TransformingLazyColumnScope.titleSection(
     uiState: QueryResult<HomeUiState>,
-    placeholderState: PlaceholderState
+    placeholderState: PlaceholderState,
+    transformationSpec: TransformationSpec,
 ) {
     when (uiState) {
         is QueryResult.Success, QueryResult.Loading -> {
             item {
                 val success = uiState as? QueryResult.Success
                 val conferenceTheme = conferenceThemeFor(success?.result?.conference)
-                ListHeader(modifier = Modifier.fillMaxWidth()) {
+                ListHeader(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec)
+                        .minimumVerticalContentPadding(
+                            ListHeaderDefaults.minimumTopListContentPadding
+                        ),
+                    transformation = SurfaceTransformation(transformationSpec),
+                ) {
                     Column(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -171,13 +199,16 @@ private fun TransformingLazyColumnScope.bookmarksSection(
     sessionSelected: (String) -> Unit,
     addBookmark: ((sessionId: String) -> Unit)?,
     removeBookmark: ((sessionId: String) -> Unit)?,
-    onBookmarksClick: () -> Unit
+    onBookmarksClick: () -> Unit,
+    transformationSpec: TransformationSpec,
 ) {
     item {
         SectionHeader(
             modifier = Modifier
-                .fillMaxWidth(),
-            text = stringResource(R.string.home_bookmarked_sessions)
+                .fillMaxWidth()
+                .transformedHeight(this, transformationSpec),
+            text = stringResource(R.string.home_bookmarked_sessions),
+            transformation = SurfaceTransformation(transformationSpec),
         )
     }
 
@@ -188,7 +219,11 @@ private fun TransformingLazyColumnScope.bookmarksSection(
                 key(session.id) {
                     SessionCard(
                         modifier = Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec)
+                            .minimumVerticalContentPadding(
+                                CardDefaults.minimumVerticalListContentPadding
+                            ),
                         session = session, sessionSelected = {
                             if (uiState is QueryResult.Success) {
                                 sessionSelected(it)
@@ -197,7 +232,8 @@ private fun TransformingLazyColumnScope.bookmarksSection(
                         currentTime = bookmarksUiState.result.now,
                         addBookmark = addBookmark,
                         removeBookmark = removeBookmark,
-                        isBookmarked = bookmarksUiState.result.isBookmarked(session.id)
+                        isBookmarked = bookmarksUiState.result.isBookmarked(session.id),
+                        transformation = SurfaceTransformation(transformationSpec),
                     )
                 }
             }
@@ -205,7 +241,13 @@ private fun TransformingLazyColumnScope.bookmarksSection(
                 item {
                     Text(
                         modifier = Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec),
                         text = stringResource(id = R.string.no_upcoming),
                     )
                 }
@@ -218,7 +260,12 @@ private fun TransformingLazyColumnScope.bookmarksSection(
     item {
         OutlinedButton(
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .transformedHeight(this, transformationSpec)
+                .minimumVerticalContentPadding(
+                    ButtonDefaults.minimumVerticalListContentPadding
+                ),
+            transformation = SurfaceTransformation(transformationSpec),
             onClick = {
                 if (uiState is QueryResult.Success) {
                     onBookmarksClick()
@@ -233,13 +280,16 @@ private fun TransformingLazyColumnScope.bookmarksSection(
 private fun TransformingLazyColumnScope.conferenceDaysSection(
     uiState: QueryResult<HomeUiState>,
     daySelected: (LocalDate) -> Unit,
-    dayFormatter: DateTimeFormatter
+    dayFormatter: DateTimeFormatter,
+    transformationSpec: TransformationSpec,
 ) {
     item {
         SectionHeader(
             modifier = Modifier
-                .fillMaxWidth(),
-            text = stringResource(id = R.string.conference_days)
+                .fillMaxWidth()
+                .transformedHeight(this, transformationSpec),
+            text = stringResource(id = R.string.conference_days),
+            transformation = SurfaceTransformation(transformationSpec),
         )
     }
     when (uiState) {
@@ -248,12 +298,15 @@ private fun TransformingLazyColumnScope.conferenceDaysSection(
                 DayChip(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec)
                         .minimumVerticalContentPadding(
                             ButtonDefaults.minimumVerticalListContentPadding
                         ),
                     dayFormatter,
                     date,
-                    daySelected = { daySelected(date) })
+                    daySelected = { daySelected(date) },
+                    transformation = SurfaceTransformation(transformationSpec),
+                )
             }
         }
 
@@ -262,9 +315,11 @@ private fun TransformingLazyColumnScope.conferenceDaysSection(
                 PlaceholderButton(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec)
                         .minimumVerticalContentPadding(
                             ButtonDefaults.minimumVerticalListContentPadding
                         ),
+                    transformation = SurfaceTransformation(transformationSpec),
                 )
             }
         }
@@ -278,10 +333,12 @@ fun DayChip(
     modifier: Modifier = Modifier,
     dayFormatter: DateTimeFormatter,
     date: LocalDate,
-    daySelected: () -> Unit
+    daySelected: () -> Unit,
+    transformation: SurfaceTransformation? = null,
 ) {
     Button(
         modifier = modifier.fillMaxWidth(),
+        transformation = transformation,
         onClick = daySelected,
         colors = ButtonDefaults.filledVariantButtonColors(),
     ) {
@@ -323,7 +380,7 @@ fun HomeListViewPreview() {
 }
 
 @WearPreviewLargeRound
-@ScrollingPreview(modes = [ScrollMode.LONG])
+@ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END, ScrollMode.LONG])
 @Composable
 fun HomeListViewLongPreview() {
     ConfettiPreviewScaffold {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
@@ -5,14 +5,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
-import com.google.android.horologist.compose.layout.ColumnItemType
-import com.google.android.horologist.compose.layout.rememberResponsiveColumnPadding
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import dev.johnoreilly.confetti.decompose.SessionDetailsUiState
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.wear.components.ScreenHeader
@@ -28,11 +33,16 @@ fun SessionDetailView(
     modifier: Modifier = Modifier,
 ) {
     val timeFormatter = remember { DateTimeFormatter.ofPattern("eeee HH:mm") }
-    val columnPadding = rememberResponsiveColumnPadding(
-        first = ColumnItemType.ListHeader,
-        last = ColumnItemType.Button
-    )
-    ScreenScaffold(modifier = modifier, scrollState = columnState, contentPadding = columnPadding) { contentPadding ->
+    val transformationSpec = rememberTransformationSpec()
+    ScreenScaffold(
+        modifier = modifier,
+        scrollState = columnState,
+        scrollIndicator = {
+            if (!LocalScrollCaptureInProgress.current) {
+                ScrollIndicator(columnState)
+            }
+        },
+    ) { contentPadding ->
         TransformingLazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = columnState,
@@ -45,8 +55,11 @@ fun SessionDetailView(
 
                     item {
                         ScreenHeader(
-                            modifier = Modifier,
-                            text = session.title
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec),
+                            text = session.title,
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
 
@@ -56,7 +69,13 @@ fun SessionDetailView(
                         }
                         Text(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .graphicsLayer {
+                                    with(transformationSpec) {
+                                        applyContainerTransformation(scrollProgress)
+                                    }
+                                }
+                                .transformedHeight(this, transformationSpec),
                             text = time,
                         )
                     }
@@ -64,7 +83,13 @@ fun SessionDetailView(
                     items(description) {
                         Text(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .graphicsLayer {
+                                    with(transformationSpec) {
+                                        applyContainerTransformation(scrollProgress)
+                                    }
+                                }
+                                .transformedHeight(this, transformationSpec),
                             text = it,
                         )
                     }
@@ -72,9 +97,14 @@ fun SessionDetailView(
                     items(session.speakers) { speaker ->
                         SessionSpeakerChip(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ButtonDefaults.minimumVerticalListContentPadding
+                                ),
                             speaker = speaker.speakerDetails,
-                            navigateToSpeaker = navigateToSpeaker
+                            navigateToSpeaker = navigateToSpeaker,
+                            transformation = SurfaceTransformation(transformationSpec),
                         )
                     }
                 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
@@ -12,6 +12,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
@@ -57,7 +58,10 @@ fun SessionDetailView(
                         ScreenHeader(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .transformedHeight(this, transformationSpec),
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ListHeaderDefaults.minimumTopListContentPadding
+                                ),
                             text = session.title,
                             transformation = SurfaceTransformation(transformationSpec),
                         )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
@@ -13,6 +13,9 @@ import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.CardDefaults
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
@@ -34,6 +37,7 @@ fun SessionsScreen(
     columnState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),
     modifier: Modifier = Modifier,
 ) {
+    val transformationSpec = rememberTransformationSpec()
     ScreenScaffold(
         modifier = modifier,
         scrollState = columnState,
@@ -56,7 +60,10 @@ fun SessionsScreen(
                         item {
                             SectionHeader(
                                 modifier = Modifier
-                                    .fillMaxWidth(), text = time
+                                    .fillMaxWidth()
+                                    .transformedHeight(this, transformationSpec),
+                                text = time,
+                                transformation = SurfaceTransformation(transformationSpec),
                             )
                         }
 
@@ -64,6 +71,7 @@ fun SessionsScreen(
                             SessionCard(
                                 modifier = Modifier
                                     .fillMaxWidth()
+                                    .transformedHeight(this, transformationSpec)
                                     .minimumVerticalContentPadding(
                                         CardDefaults.minimumVerticalListContentPadding
                                     ),
@@ -75,6 +83,7 @@ fun SessionsScreen(
                                 isBookmarked = uiState.bookmarks.contains(session.id),
                                 addBookmark = addBookmark,
                                 removeBookmark = removeBookmark,
+                                transformation = SurfaceTransformation(transformationSpec),
                             )
                         }
                     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
@@ -11,6 +11,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.CardDefaults
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
@@ -61,7 +62,10 @@ fun SessionsScreen(
                             SectionHeader(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .transformedHeight(this, transformationSpec),
+                                    .transformedHeight(this, transformationSpec)
+                                    .minimumVerticalContentPadding(
+                                        ListHeaderDefaults.minimumTopListContentPadding
+                                    ),
                                 text = time,
                                 transformation = SurfaceTransformation(transformationSpec),
                             )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
@@ -30,6 +30,7 @@ import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.EdgeButtonSize
 import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.ListSubHeader
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
@@ -99,7 +100,10 @@ fun SettingsListView(
                 ScreenHeader(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .transformedHeight(this, transformationSpec),
+                        .transformedHeight(this, transformationSpec)
+                        .minimumVerticalContentPadding(
+                            ListHeaderDefaults.minimumTopListContentPadding
+                        ),
                     text = stringResource(id = R.string.settings),
                     transformation = SurfaceTransformation(transformationSpec),
                 )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -25,6 +26,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnScope
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.EdgeButton
 import androidx.wear.compose.material3.EdgeButtonSize
 import androidx.wear.compose.material3.Icon
@@ -32,8 +34,12 @@ import androidx.wear.compose.material3.ListSubHeader
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.TransformationSpec
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
@@ -63,6 +69,7 @@ fun SettingsListView(
     columnState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),
     modifier: Modifier = Modifier,
 ) {
+    val transformationSpec = rememberTransformationSpec()
     ScreenScaffold(
         modifier = modifier,
         scrollState = columnState,
@@ -90,15 +97,23 @@ fun SettingsListView(
         ) {
             item {
                 ScreenHeader(
-                    modifier = Modifier,
-                    text = stringResource(id = R.string.settings)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec),
+                    text = stringResource(id = R.string.settings),
+                    transformation = SurfaceTransformation(transformationSpec),
                 )
             }
 
             item {
                 Button(
                     modifier = Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .transformedHeight(this, transformationSpec)
+                        .minimumVerticalContentPadding(
+                            ButtonDefaults.minimumVerticalListContentPadding
+                        ),
+                    transformation = SurfaceTransformation(transformationSpec),
                     onClick = conferenceCleared,
                 ) {
                     Text(stringResource(R.string.settings_change_conference))
@@ -114,7 +129,12 @@ fun SettingsListView(
                     if (authUser == null) {
                         Button(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ButtonDefaults.minimumVerticalListContentPadding
+                                ),
+                            transformation = SurfaceTransformation(transformationSpec),
                             onClick = onSignIn,
                         ) {
                             Text(stringResource(R.string.settings_sign_in))
@@ -128,6 +148,10 @@ fun SettingsListView(
                         Button(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .transformedHeight(this, transformationSpec)
+                                .minimumVerticalContentPadding(
+                                    ButtonDefaults.minimumVerticalListContentPadding
+                                )
                                 .clearAndSetSemantics {
                                     contentDescription = chipContentDescription
                                     onClick(clickActionLabel) {
@@ -135,6 +159,7 @@ fun SettingsListView(
                                         true
                                     }
                                 },
+                            transformation = SurfaceTransformation(transformationSpec),
                             icon = { AsyncImage(model = authUser.photoUrl, contentDescription = null) },
                             onClick = { onSignOut() }
                         ) {
@@ -146,7 +171,12 @@ fun SettingsListView(
                 item {
                     SwitchButton(
                         modifier = Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec)
+                            .minimumVerticalContentPadding(
+                                ButtonDefaults.minimumVerticalListContentPadding
+                            ),
+                        transformation = SurfaceTransformation(transformationSpec),
                         label = { Text(stringResource(R.string.settings_allow_lte)) },
                         icon = {
                             androidx.wear.compose.material3.Icon(
@@ -174,7 +204,12 @@ fun SettingsListView(
                 item {
                     Button(
                         modifier = Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec)
+                            .minimumVerticalContentPadding(
+                                ButtonDefaults.minimumVerticalListContentPadding
+                            ),
+                        transformation = SurfaceTransformation(transformationSpec),
                         label = {
                             Text(
                                 when (wearPreferences?.showNetworks) {
@@ -212,6 +247,12 @@ fun SettingsListView(
                     Text(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec)
                             .padding(top = 10.dp)
                             .run {
                                 if (!uiState.developerMode) {
@@ -232,7 +273,7 @@ fun SettingsListView(
                 }
 
                 if (uiState.developerMode) {
-                    developerModeOptions(uiState)
+                    developerModeOptions(uiState, transformationSpec)
                 }
             }
         }
@@ -241,13 +282,16 @@ fun SettingsListView(
 
 private fun TransformingLazyColumnScope.developerModeOptions(
     uiState: SettingsUiState.Success,
+    transformationSpec: TransformationSpec,
 ) {
     val authUser = uiState.authUser
 
     item {
         ListSubHeader(
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .transformedHeight(this, transformationSpec),
+            transformation = SurfaceTransformation(transformationSpec),
         ) {
             Text(
                 text = "Developer Mode",
@@ -259,7 +303,13 @@ private fun TransformingLazyColumnScope.developerModeOptions(
         item {
             Text(
                 modifier = Modifier
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .graphicsLayer {
+                        with(transformationSpec) {
+                            applyContainerTransformation(scrollProgress)
+                        }
+                    }
+                    .transformedHeight(this, transformationSpec),
                 style = MaterialTheme.typography.labelSmall,
                 text = "Email: ${authUser.email}"
             )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
@@ -17,13 +19,15 @@ import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.ScrollIndicator
+import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.rememberPlaceholderState
 import coil.compose.SubcomposeAsyncImage
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
-import com.google.android.horologist.compose.layout.ColumnItemType
-import com.google.android.horologist.compose.layout.rememberResponsiveColumnPadding
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsComponent
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
@@ -45,12 +49,17 @@ fun SpeakerDetailsView(
     columnState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),
 ) {
     val placeholderState = rememberPlaceholderState(uiState is SpeakerDetailsUiState.Loading)
+    val transformationSpec = rememberTransformationSpec()
 
-    val columnPadding = rememberResponsiveColumnPadding(
-        first = ColumnItemType.IconButton,
-        last = ColumnItemType.BodyText
-    )
-    ScreenScaffold(modifier = modifier, scrollState = columnState, contentPadding = columnPadding) { contentPadding ->
+    ScreenScaffold(
+        modifier = modifier,
+        scrollState = columnState,
+        scrollIndicator = {
+            if (!LocalScrollCaptureInProgress.current) {
+                ScrollIndicator(columnState)
+            }
+        },
+    ) { contentPadding ->
         TransformingLazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = columnState,
@@ -62,6 +71,12 @@ fun SpeakerDetailsView(
                         imageVector = ConfettiIcons.Person,
                         contentDescription = "",
                         modifier = Modifier
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec)
                             .size(80.dp)
                             .clip(RoundedCornerShape(16.dp))
                     )
@@ -72,10 +87,12 @@ fun SpeakerDetailsView(
                         text = "",
                         modifier = Modifier
                             .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec)
                             .padding(horizontal = 60.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .height(24.dp)
-                            .placeholder(placeholderState)
+                            .placeholder(placeholderState),
+                        transformation = SurfaceTransformation(transformationSpec),
                     )
                 }
 
@@ -84,6 +101,12 @@ fun SpeakerDetailsView(
                         text = "",
                         modifier = Modifier
                             .fillMaxWidth()
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec)
                             .padding(horizontal = 30.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .height(24.dp)
@@ -94,7 +117,14 @@ fun SpeakerDetailsView(
                 item {
                     Text(
                         modifier = Modifier
-                            .fillMaxWidth(), text = ""
+                            .fillMaxWidth()
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec),
+                        text = ""
                     )
                 }
             } else {
@@ -118,6 +148,12 @@ fun SpeakerDetailsView(
                         },
                         modifier = Modifier
                             .fillMaxWidth()
+                            .graphicsLayer {
+                                with(transformationSpec) {
+                                    applyContainerTransformation(scrollProgress)
+                                }
+                            }
+                            .transformedHeight(this, transformationSpec)
                             .size(80.dp)
                             .clip(RoundedCornerShape(16.dp))
                     )
@@ -126,8 +162,10 @@ fun SpeakerDetailsView(
                 item {
                     SectionHeader(
                         modifier = Modifier
-                            .fillMaxWidth(),
+                            .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec),
                         text = speaker?.name ?: "",
+                        transformation = SurfaceTransformation(transformationSpec),
                     )
                 }
 
@@ -135,7 +173,13 @@ fun SpeakerDetailsView(
                     item {
                         Text(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .graphicsLayer {
+                                    with(transformationSpec) {
+                                        applyContainerTransformation(scrollProgress)
+                                    }
+                                }
+                                .transformedHeight(this, transformationSpec),
                             text = speaker?.tagline ?: "",
                         )
                     }
@@ -145,7 +189,13 @@ fun SpeakerDetailsView(
                     item {
                         Text(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .graphicsLayer {
+                                    with(transformationSpec) {
+                                        applyContainerTransformation(scrollProgress)
+                                    }
+                                }
+                                .transformedHeight(this, transformationSpec),
                             text = speaker?.bio ?: "",
                         )
                     }
@@ -154,5 +204,3 @@ fun SpeakerDetailsView(
         }
     }
 }
-
-

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiApp.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalHorologistApi::class)
-
 package dev.johnoreilly.confetti.wear.ui
 
 import androidx.compose.runtime.Composable
@@ -8,8 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.TimeText
-import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.networks.ui.DataUsageTimeText
 import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.wear.bookmarks.BookmarksRoute
 import dev.johnoreilly.confetti.wear.conferences.ConferencesRoute
@@ -17,7 +13,6 @@ import dev.johnoreilly.confetti.wear.decompose.SwipeToDismissBox
 import dev.johnoreilly.confetti.wear.home.HomeRoute
 import dev.johnoreilly.confetti.wear.navigation.Child
 import dev.johnoreilly.confetti.wear.navigation.WearAppComponent
-import dev.johnoreilly.confetti.wear.proto.NetworkDetail
 import dev.johnoreilly.confetti.wear.sessiondetails.SessionDetailsRoute
 import dev.johnoreilly.confetti.wear.sessions.SessionsRoute
 import dev.johnoreilly.confetti.wear.settings.SettingsRoute
@@ -56,23 +51,6 @@ fun ConfettiApp(
             }
         }
     }
-}
-
-@Composable
-private fun NetworkTimeText(component: WearAppComponent, showNetworks: NetworkDetail) {
-    val networkState by component.networkState.collectAsStateWithLifecycle()
-    val enabled =
-        showNetworks == NetworkDetail.NETWORK_DETAIL_NETWORKS_AND_DATA || showNetworks == NetworkDetail.NETWORK_DETAIL_NETWORKS
-
-    DataUsageTimeText(
-        showData = enabled,
-        networkStatus = networkState.networks,
-        networkUsage = if (showNetworks == NetworkDetail.NETWORK_DETAIL_NETWORKS_AND_DATA) {
-            networkState.dataUsage
-        } else {
-            null
-        }
-    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Every TLC screen in the wear app (Home, Bookmarks, Sessions, Conferences, SessionDetails, SpeakerDetails, Settings) was structured correctly around `TransformingLazyColumn` but was skipping the *expressive* layer: no `SurfaceTransformation`, no `rememberTransformationSpec()`, no `Modifier.transformedHeight`. Items rendered as a plain lazy column — losing the shape-morph / scale / fade that is TLC's reason to exist on Material 3.

This PR threads the standard TLC item recipe through every screen, matching the pattern documented at <https://developer.android.com/training/wearables/compose/lists> and exemplified by [android/wear-os-samples/ComposeStarter `ListScreen`](https://github.com/android/wear-os-samples/blob/main/ComposeStarter/app/src/main/java/com/example/android/wearable/composestarter/presentation/MainActivity.kt).

Detailed analysis (including the diff table vs ComposeStarter): **https://gist.github.com/yschimke/14447bd4ab826ae9c71809ae6bafa19e**

Companion documentation PR: [yschimke/compose-ai-tools#153](https://github.com/yschimke/compose-ai-tools/pull/153) spells out the recipe in `WEAR_UI.md` so future agents don't miss it.

## What changed

- Added `val transformationSpec = rememberTransformationSpec()` to every TLC screen.
- Every item whose composable accepts a `transformation` slot (`Button` / `OutlinedButton` / `SwitchButton` / `TitleCard` / `ListHeader` / `ListSubHeader`) now gets `transformation = SurfaceTransformation(transformationSpec)` and `Modifier.transformedHeight(this, transformationSpec)`. Wrapper composables (`SessionCard`, `SectionHeader`, `ScreenHeader`, `PlaceholderButton`, `SessionSpeakerChip`, `DayChip`, `ConferencesChip`) gain an optional `transformation: SurfaceTransformation?` parameter so callers can forward the spec to the underlying M3 surface.
- Items that *don't* accept a `transformation` slot (plain `Text`, `Row`, speaker image in `SpeakerDetails`, developer-mode email) apply the transform manually via
  ```kotlin
  Modifier.graphicsLayer {
      with(transformationSpec) { applyContainerTransformation(scrollProgress) }
  }.transformedHeight(this, transformationSpec)
  ```
  — the same fallback used by ComposeStarter for its `ButtonGroup` item.
- `Modifier.minimumVerticalContentPadding(...)` applied consistently on items that were missing it. First TLC item on every screen (Home / Bookmarks / Conferences / Sessions / SessionDetails / Settings) uses `ListHeaderDefaults.minimumTopListContentPadding`.
- **Horologist removed from the layout path.** `SessionDetailsView` and `SpeakerDetailsView` previously used `rememberResponsiveColumnPadding` / `ColumnItemType`; they now use the M3 per-item `minimumVerticalContentPadding` approach. `horologist-compose-layout` dropped from `wearApp/build.gradle.kts`. The two detail screens also pick up the standard `scrollIndicator` slot with the `LocalScrollCaptureInProgress` guard that the other TLC screens use.
- `HomeListViewLongPreview` now fans out over `TOP`, `END`, `LONG`, `GIF` so the surface transform at initial anchor, the revealed `EdgeButton` at scroll-to-end, and the stitched full extent are all captured. (See note on `GIF` below.)

## Previews

Rendered via `compose-preview` on `id:wearos_large_round`.

### Home — top of list (TOP anchor)
| BEFORE | AFTER |
|---|---|
| <img src="https://raw.githubusercontent.com/yschimke/Confetti/preview-images/wear-tlc-surface-transformation/home_long_SCROLL_top_BEFORE.png" width="280" /> | <img src="https://raw.githubusercontent.com/yschimke/Confetti/preview-images/wear-tlc-surface-transformation/home_long_SCROLL_top_AFTER.png" width="280" /> |

The SessionCard entering the bottom of the viewport in BEFORE has a flat top edge clipped by the screen curve; AFTER it morphs into a capsule with rounded corners that hug the bezel.

### Home — bottom of list (END anchor)
| BEFORE | AFTER |
|---|---|
| <img src="https://raw.githubusercontent.com/yschimke/Confetti/preview-images/wear-tlc-surface-transformation/home_long_SCROLL_end_BEFORE.png" width="280" /> | <img src="https://raw.githubusercontent.com/yschimke/Confetti/preview-images/wear-tlc-surface-transformation/home_long_SCROLL_end_AFTER.png" width="280" /> |

The EdgeButton reveals at the bottom; the "Wednesday" day chip morphs as it leaves the top of the viewport.

> Note: I wanted to include an animated scrolling GIF here, but `ScrollMode.GIF` in compose-preview 0.7.1 currently produces a single-frame GIF (identical to the END capture). Bug filed at [yschimke/compose-ai-tools#154](https://github.com/yschimke/compose-ai-tools/issues/154). Once that's fixed, a real scroll animation will land.

## Test plan

- [x] Code compiles on Android Gradle (render pipeline exercises the full Kotlin compile via Robolectric).
- [x] Every TLC screen renders without runtime errors (`compose-preview render` for Home, Bookmarks, Sessions, Conferences, Settings, SessionDetails).
- [x] `SurfaceTransformation` visibly applied — see TOP/END side-by-side above.
- [ ] Screenshot baselines under `wearApp/src/screenshotTest` + Roborazzi refs need regenerating — follow-up pass once merged (every round-face screenshot shifts because items now morph).
- [ ] SpeakerDetails: no `@Preview` on the screen-level composable yet; the existing screenshot test `SpeakerDetailsTest` will exercise the new layout on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)