### PR TITLE
Preview Workflows (compose-ai-tools 0.9.0)

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -1,0 +1,34 @@
+name: Preview Baselines
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-baselines
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          lfs: 'true'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.12
+        with:
+          cli-version: catalog
+          catalog-key: composeai-preview

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: preview-baselines
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   update:
@@ -28,7 +28,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.12
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.9.0
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -28,6 +28,9 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
+      - name: Warm Gradle wrapper
+        run: ./gradlew help
+
       - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.9.0
         with:
           cli-version: catalog

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,37 @@
+name: Preview Comment
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          lfs: 'true'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.12
+        with:
+          cli-version: catalog
+          catalog-key: composeai-preview

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.12
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.9.0
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -31,6 +31,9 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
+      - name: Warm Gradle wrapper
+        run: ./gradlew help
+
       - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.9.0
         with:
           cli-version: catalog

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.17.1"
 roborazzi = "1.59.0"
 screenshot = "0.0.1-alpha14"
-composeai-preview = "0.8.12"
+composeai-preview = "0.9.0"
 
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.17.1"
 roborazzi = "1.59.0"
 screenshot = "0.0.1-alpha14"
-composeai-preview = "0.8.10"
+composeai-preview = "0.8.12"
 
 
 [libraries]


### PR DESCRIPTION
Adds preview-baselines.yml and preview-comment.yml using
yschimke/compose-ai-tools@v0.8.12 with cli-version=catalog, and bumps the
composeai-preview catalog entry from 0.8.10 to 0.8.12 (used by the Gradle
plugin, preview-annotations library, and the CLI resolved at action
runtime).

0.8.11 includes fixes likely relevant to the failing compare run on the
prior 0.8.10 attempt (stdout buffering / error handling in the preview
CLI, androidx.activity version mismatch in the renderer); 0.8.12 adds a
nested-module-discovery fix.