### PR TITLE
Import droidcon USA 2026 conference data

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -48,6 +48,7 @@ enum class ConferenceId(val id: String) {
     DroidconItaly2025("droidconitaly2025"),
     KotlinConf2026("kotlinconf2026"),
     AndroidMakers2026("androidmakers2026"),
+    DroidconUSA2026("droidconusa2026"),
     ;
 
     companion object {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -151,6 +151,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.DroidconItaly2025 -> DroidconItaly2025.import()
         ConferenceId.KotlinConf2026 -> Sessionize.importKotlinConf2026()
         ConferenceId.AndroidMakers2026 -> Sessionize.importAndroidMakers2026()
+        ConferenceId.DroidconUSA2026 -> Sessionize.importDroidconUSA2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -861,6 +861,36 @@ object Sessionize {
         )
     }
 
+    suspend fun importDroidconUSA2026(): Int {
+        val timeZone = "America/New_York"
+        return writeData(
+            getData(url = "https://sessionize.com/api/v2/gl1b6col/view/All", zoneId = timeZone),
+            config = DConfig(
+                id = ConferenceId.DroidconUSA2026.id,
+                name = "droidcon USA 2026",
+                timeZone = timeZone,
+                days = listOf(
+                    LocalDate(2026, 7, 16),
+                    LocalDate(2026, 7, 17)
+                ),
+                themeColor = "0xFFED1C24"
+            ),
+            venue = DVenue(
+                id = "main",
+                name = "Orange County Convention Center",
+                address = "P.O. Box 691509, Orlando, FL 32869-1509",
+                description = mapOf(
+                    "en" to "The Orange County Convention Center (OCCC), located in the heart of Central Florida and only fifteen minutes from the Orlando International Airport.",
+                ),
+                latitude = 28.4253,
+                longitude = -81.4683,
+                imageUrl = "https://static.wixstatic.com/media/6e1ab2_6388f2cd6bea4472bfe293d8ac7c7413~mv2.jpeg",
+                floorPlanUrl = null
+            ),
+            partnerGroups = emptyList()
+        )
+    }
+
     suspend fun importDevFestVenice2024(): Int {
         return writeData(
             getData("https://sessionize.com/api/v2/r14kt8fj/view/All"),


### PR DESCRIPTION
## Summary
- Add `ConferenceId.DroidconUSA2026` and an `importDroidconUSA2026()` Sessionize importer wired to the public feed `https://sessionize.com/api/v2/gl1b6col/view/All`
- Venue: Orange County Convention Center, Orlando FL (Jul 16-17 2026, `America/New_York`)
- Theme color `0xFFED1C24` taken from the droidcon USA site palette; venue image sourced from the same site

