### PR TITLE
Lift Koin out of ConferenceMaterialTheme

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -76,7 +76,7 @@ fun App(component: DefaultAppComponent) {
 @OptIn(ExperimentalDecomposeApi::class)
 @Composable
 fun ConferenceView(component: ConferenceComponent) {
-    ConferenceMaterialTheme(component.conferenceThemeColor) {
+    ConferenceMaterialThemeFromSettings(component.conferenceThemeColor) {
         ChildStack(
             stack = component.stack,
             animation = predictiveBackAnimation(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -102,7 +102,7 @@ fun ConferenceCard(
     conference: GetConferencesQuery.Conference,
     navigateToConference: (GetConferencesQuery.Conference) -> Unit
 ) {
-    ConferenceMaterialTheme(conference.themeColor) {
+    ConferenceMaterialThemeFromSettings(conference.themeColor) {
         Card(
             modifier = Modifier
                 .clip(shape = RoundedCornerShape(8.dp))

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceMaterialTheme.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceMaterialTheme.kt
@@ -13,63 +13,22 @@ import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.decompose.DarkThemeConfig
 import org.koin.compose.koinInject
 
-@OptIn(ExperimentalStdlibApi::class, ExperimentalSettingsApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 @Composable
 fun ConferenceMaterialTheme(
     seedColorString: String?,
+    useDynamicColor: Boolean = false,
+    darkThemeConfig: DarkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
     content: @Composable () -> Unit,
 ) {
-    // Previews (LocalInspectionMode = true) can't reach Koin — the compose-
-    // ai-tools renderer installs a stub Application by default and skips the
-    // consumer's onCreate, so Koin is never started. Short-circuit with the
-    // settings defaults (dynamic color off, follow-system dark theme) so
-    // previews render without an Application-level DI container.
-    if (LocalInspectionMode.current) {
-        ConferenceMaterialThemeWithDefaults(seedColorString, content)
+    if (useDynamicColor) {
+        content()
         return
     }
 
-    val appSettings = koinInject<AppSettings>()
-    val useDynamicColor by appSettings.settings.getBooleanFlow("useDynamicColorKey", false)
-        .collectAsState(false)
-
-    if (!useDynamicColor) {
-        val darkThemeConfigString by appSettings.settings.getStringFlow(
-            "darkThemeConfigKey",
-            DarkThemeConfig.FOLLOW_SYSTEM.toString()
-        )
-            .collectAsState(DarkThemeConfig.FOLLOW_SYSTEM.toString())
-        val darkThemeConfig = DarkThemeConfig.valueOf(darkThemeConfigString)
-        ApplyMaterialTheme(seedColorString, darkThemeConfig, content)
-    } else {
-        content()
-    }
-}
-
-/**
- * Theme path used when there's no Koin container available (previews, tests).
- * Mirrors the `!useDynamicColor` branch of [ConferenceMaterialTheme] with
- * settings pinned to their defaults: dynamic color off, dark mode follows the
- * system.
- */
-@Composable
-private fun ConferenceMaterialThemeWithDefaults(
-    seedColorString: String?,
-    content: @Composable () -> Unit,
-) {
-    ApplyMaterialTheme(seedColorString, DarkThemeConfig.FOLLOW_SYSTEM, content)
-}
-
-@OptIn(ExperimentalStdlibApi::class)
-@Composable
-private fun ApplyMaterialTheme(
-    seedColorString: String?,
-    darkThemeConfig: DarkThemeConfig,
-    content: @Composable () -> Unit,
-) {
     val shouldUseDarkTheme = shouldUseDarkTheme(darkThemeConfig)
 
-    var seedColor = Color(0xFF008000) // default if none set
+    var seedColor = Color(0xFF008000)
     seedColorString?.let {
         try {
             seedColor = Color(seedColorString.hexToLong(HexFormat { number.prefix = "0x" }))
@@ -86,6 +45,41 @@ private fun ApplyMaterialTheme(
     MaterialTheme(colorScheme = colorScheme) {
         content()
     }
+}
+
+/**
+ * Settings-aware wrapper around [ConferenceMaterialTheme]. Reads the user's
+ * theme preferences from Koin-provided [AppSettings] and forwards them as
+ * plain parameters, so the theme function itself stays free of DI.
+ *
+ * Falls back to defaults under [LocalInspectionMode] (previews, screenshot
+ * tests) where Koin may not be initialised.
+ */
+@OptIn(ExperimentalSettingsApi::class)
+@Composable
+fun ConferenceMaterialThemeFromSettings(
+    seedColorString: String?,
+    content: @Composable () -> Unit,
+) {
+    if (LocalInspectionMode.current) {
+        ConferenceMaterialTheme(seedColorString, content = content)
+        return
+    }
+
+    val appSettings = koinInject<AppSettings>()
+    val useDynamicColor by appSettings.settings.getBooleanFlow("useDynamicColorKey", false)
+        .collectAsState(false)
+    val darkThemeConfigString by appSettings.settings.getStringFlow(
+        "darkThemeConfigKey",
+        DarkThemeConfig.FOLLOW_SYSTEM.toString()
+    ).collectAsState(DarkThemeConfig.FOLLOW_SYSTEM.toString())
+
+    ConferenceMaterialTheme(
+        seedColorString = seedColorString,
+        useDynamicColor = useDynamicColor,
+        darkThemeConfig = DarkThemeConfig.valueOf(darkThemeConfigString),
+        content = content,
+    )
 }
 
 @Composable

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/ui/SharedViewControllers.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/ui/SharedViewControllers.kt
@@ -9,7 +9,7 @@ import platform.UIKit.UIViewController
 
 fun SessionDetailsViewController(conference: String, session: SessionDetails, conferenceThemeColor: String?, onSpeakerClick: (speakerId: String) -> Unit, onSocialLinkClicked: (String) -> Unit): UIViewController =
     ComposeUIViewController {
-        ConferenceMaterialTheme(conferenceThemeColor) {
+        ConferenceMaterialThemeFromSettings(conferenceThemeColor) {
             SessionDetailViewShared(conference, session, onSpeakerClick, onSocialLinkClicked)
         }
     }


### PR DESCRIPTION
## Summary
- Refactor `ConferenceMaterialTheme` to take `useDynamicColor` and `darkThemeConfig` as plain parameters with sensible defaults; remove the in-theme `koinInject` and `LocalInspectionMode` branch.
- Add a thin `ConferenceMaterialThemeFromSettings` wrapper that performs the Koin lookup (with a `LocalInspectionMode` fallback) and forwards plain values into the pure theme function.
- Switch production call sites (`ConferenceView`, `ConferenceCard`, iOS `SessionDetailsViewController`) to the wrapper so behaviour is preserved.

Motivation: `ConferenceMaterialTheme` was reaching into Koin via `currentKoinScope()`, which made it unrenderable in any context that hadn't run the consumer Application's `onCreate` (notably the wearApp's `ThemePreview`, where `ConferenceCard` transitively pulled in the shared theme). With the DI lookup moved into the wrapper, the theme function itself is self-contained and preview-safe.

## Test plan
- [ ] `./gradlew :shared:compileDebugKotlinAndroid` — clean build (only pre-existing deprecation warnings).
- [ ] Run the Android app and switch between dark/light/system themes in settings; confirm `ConferenceView` and per-card theming behave as before.
- [ ] Verify iOS `SessionDetailsViewController` still themes correctly.
- [ ] Render `wearApp` `ThemePreview` (Compose preview / screenshot test) — should no longer require a started Koin container.