### PR TITLE
feat(wear): add missing screen/component previews and a design-catalo…

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,0 +1,120 @@
+{
+  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, so the single mode is the large-round breakpoint. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog; the Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
+  "system": "confetti-wear",
+  "title": "Confetti Wear",
+  "library": ["androidx.wear.compose:compose-material3"],
+  "module": "wearApp",
+  "modes": ["largeRound"],
+  "groups": [
+    {
+      "name": "Theme",
+      "section": "Themes",
+      "components": [
+        {
+          "componentId": "Typography",
+          "preview": "TypographySpecimenPreview",
+          "caption": "A type ramp read from MaterialTheme.typography (Wear Material 3)."
+        },
+        {
+          "componentId": "ColorScheme",
+          "preview": "ColorSchemeSpecimenPreview",
+          "caption": "Colour-role swatches read from MaterialTheme.colorScheme."
+        }
+      ]
+    },
+    {
+      "name": "Components",
+      "section": "Components",
+      "components": [
+        {
+          "componentId": "SessionCard",
+          "preview": "SessionCardPopulatedPreview",
+          "caption": "Session TitleCard — title, speakers, room and time.",
+          "variants": [
+            {
+              "state": "loading",
+              "preview": "SessionCardLoadingPreview",
+              "caption": "Placeholder / loading state (session = null)."
+            },
+            {
+              "state": "bookmarked",
+              "preview": "SessionCardBookmarkedPreview",
+              "caption": "Bookmarked session (swipe-to-reveal un-bookmark action)."
+            }
+          ]
+        },
+        {
+          "componentId": "SessionSpeakerChip",
+          "preview": "SessionSpeakerChipPreview",
+          "caption": "Speaker chip with avatar, name and tagline."
+        },
+        {
+          "componentId": "SectionHeader",
+          "preview": "SectionHeaderPreview",
+          "caption": "Inline list section divider in the theme's primary accent."
+        },
+        {
+          "componentId": "ScreenHeader",
+          "preview": "ScreenHeaderPreview",
+          "caption": "Top-of-screen title (ListHeader)."
+        },
+        {
+          "componentId": "PlaceholderButton",
+          "preview": "PlaceholderButtonPreview",
+          "caption": "Shimmering placeholder chip shown while content loads."
+        },
+        {
+          "componentId": "SocialIcon",
+          "preview": "SocialIconPreview",
+          "caption": "Tappable social-link icon (ImageVector overload)."
+        },
+        {
+          "componentId": "DayChip",
+          "preview": "DayChipPreview",
+          "caption": "Conference-day selector button."
+        }
+      ]
+    },
+    {
+      "name": "Screens",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "Home",
+          "preview": "HomeListViewPreview",
+          "caption": "Home screen — conference title, bookmarks and day list."
+        },
+        {
+          "componentId": "Sessions",
+          "preview": "SessionListViewPreview",
+          "caption": "Sessions schedule list grouped by start time."
+        },
+        {
+          "componentId": "SessionDetails",
+          "preview": "SessionDetailViewPreview",
+          "caption": "Session details — title, time, description and speakers."
+        },
+        {
+          "componentId": "SpeakerDetails",
+          "preview": "SpeakerDetailsViewPreview",
+          "caption": "Speaker details — photo, name, tagline and bio."
+        },
+        {
+          "componentId": "Bookmarks",
+          "preview": "BookmarksPreview",
+          "caption": "Bookmarks screen — upcoming and past bookmarked sessions."
+        },
+        {
+          "componentId": "Conferences",
+          "preview": "ConferencesViewPreview",
+          "caption": "Conference picker list."
+        },
+        {
+          "componentId": "Settings",
+          "preview": "SettingsListViewPreview",
+          "caption": "Settings screen."
+        }
+      ]
+    }
+  ]
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
@@ -19,10 +19,13 @@ import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import dev.johnoreilly.confetti.decompose.SessionDetailsUiState
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.wear.components.ScreenHeader
 import dev.johnoreilly.confetti.wear.components.SessionSpeakerChip
+import dev.johnoreilly.confetti.wear.preview.ConfettiPreviewScaffold
+import dev.johnoreilly.confetti.wear.preview.TestFixtures
 import kotlinx.datetime.toJavaLocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -121,3 +124,17 @@ fun SessionDetailView(
 
 private fun SessionDetails?.descriptionParagraphs(): List<String> =
     this?.sessionDescription?.split("\n+".toRegex()).orEmpty()
+
+@WearPreviewLargeRound
+@Composable
+fun SessionDetailViewPreview() {
+    ConfettiPreviewScaffold {
+        SessionDetailView(
+            uiState = SessionDetailsUiState.Success(
+                conference = TestFixtures.conference,
+                sessionDetails = TestFixtures.sessionDetails,
+            ),
+            navigateToSpeaker = {},
+        )
+    }
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -26,13 +26,18 @@ import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.rememberPlaceholderState
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import coil.compose.SubcomposeAsyncImage
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsComponent
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import dev.johnoreilly.confetti.ui.icons.Person
 import dev.johnoreilly.confetti.wear.components.SectionHeader
+import dev.johnoreilly.confetti.wear.preview.ConfettiPreviewScaffold
+import dev.johnoreilly.confetti.wear.preview.TestFixtures
 
 @Composable
 fun SpeakerDetailsRoute(
@@ -202,5 +207,19 @@ fun SpeakerDetailsView(
                 }
             }
         }
+    }
+}
+
+@WearPreviewLargeRound
+@ScrollingPreview(modes = [ScrollMode.LONG])
+@Composable
+fun SpeakerDetailsViewPreview() {
+    ConfettiPreviewScaffold {
+        SpeakerDetailsView(
+            uiState = SpeakerDetailsUiState.Success(
+                conference = TestFixtures.conference,
+                details = TestFixtures.JohnOreilly.speakerDetails,
+            )
+        )
     }
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
@@ -1,0 +1,176 @@
+package dev.johnoreilly.confetti.wear.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.rememberPlaceholderState
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.icons.Github
+import dev.johnoreilly.confetti.wear.components.PlaceholderButton
+import dev.johnoreilly.confetti.wear.components.SectionHeader
+import dev.johnoreilly.confetti.wear.components.ScreenHeader
+import dev.johnoreilly.confetti.wear.components.SessionCard
+import dev.johnoreilly.confetti.wear.components.SessionSpeakerChip
+import dev.johnoreilly.confetti.wear.home.DayChip
+import dev.johnoreilly.confetti.wear.preview.TestFixtures
+import dev.johnoreilly.confetti.wear.ui.component.SocialIcon
+import kotlinx.datetime.toKotlinLocalDateTime
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Single-component "sticker sheet" catalog. Each `@Preview` wraps exactly one
+ * component (or one theme specimen) in [ConfettiThemeFixed] + [TestFixtures],
+ * mirroring `ThemePreview.kt` but rendered from the **main** source set so the
+ * `ee.schimke.composeai.preview` plugin discovers them for the published
+ * design catalog. Screen-level previews live next to their screens; this file
+ * is the component + theme layer.
+ */
+
+private val catalogNow =
+    LocalDateTime.of(2020, 1, 1, 1, 1).toKotlinLocalDateTime()
+
+@Preview(widthDp = 227)
+@Composable
+fun SessionCardPopulatedPreview() {
+    ConfettiThemeFixed {
+        SessionCard(
+            session = TestFixtures.sessionDetails,
+            sessionSelected = {},
+            currentTime = catalogNow,
+            isBookmarked = false,
+            addBookmark = {},
+            removeBookmark = {},
+        )
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun SessionCardLoadingPreview() {
+    ConfettiThemeFixed {
+        SessionCard(
+            session = null,
+            sessionSelected = {},
+            currentTime = null,
+            isBookmarked = false,
+            addBookmark = {},
+            removeBookmark = {},
+            placeholderState = rememberPlaceholderState(true),
+        )
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun SessionCardBookmarkedPreview() {
+    ConfettiThemeFixed {
+        SessionCard(
+            session = TestFixtures.sessionDetails,
+            sessionSelected = {},
+            currentTime = catalogNow,
+            isBookmarked = true,
+            addBookmark = {},
+            removeBookmark = {},
+        )
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun SessionSpeakerChipPreview() {
+    ConfettiThemeFixed {
+        SessionSpeakerChip(
+            speaker = TestFixtures.JohnOreilly.speakerDetails,
+            navigateToSpeaker = {},
+        )
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun SectionHeaderPreview() {
+    ConfettiThemeFixed {
+        SectionHeader("Bookmarked sessions")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ScreenHeaderPreview() {
+    ConfettiThemeFixed {
+        ScreenHeader("KotlinConf 2023")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun PlaceholderButtonPreview() {
+    ConfettiThemeFixed {
+        PlaceholderButton()
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun SocialIconPreview() {
+    ConfettiThemeFixed {
+        SocialIcon(
+            imageVector = ConfettiIcons.Github,
+            contentDescription = "Github",
+            onClick = {},
+        )
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun DayChipPreview() {
+    val dayFormatter = remember { DateTimeFormatter.ofPattern("cccc") }
+    ConfettiThemeFixed {
+        DayChip(
+            dayFormatter = dayFormatter,
+            date = catalogNow.date,
+            daySelected = {},
+        )
+    }
+}
+
+// Theme specimens — the Confetti Wear type ramp and colour-scheme swatches read
+// straight from [MaterialTheme], mirroring the wear-m3 sample's specimens but
+// self-contained on Confetti's own theme.
+@Preview(widthDp = 227)
+@Composable
+fun TypographySpecimenPreview() {
+    ConfettiThemeFixed {
+        Column {
+            Text("Title Large", style = MaterialTheme.typography.titleLarge)
+            Text("Title Medium", style = MaterialTheme.typography.titleMedium)
+            Text("Body Large", style = MaterialTheme.typography.bodyLarge)
+            Text("Label Medium", style = MaterialTheme.typography.labelMedium)
+        }
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ColorSchemeSpecimenPreview() {
+    ConfettiThemeFixed {
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.primary))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.secondary))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.surfaceContainer))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.error))
+        }
+    }
+}


### PR DESCRIPTION
…g spec

Add in-main @Preview coverage for the Wear module so the compose-ai-tools preview plugin (which only discovers previews in the main source set) renders them for the visual-diff bot and the published design catalog:

- SpeakerDetailsView / SessionDetailView: add the missing in-main previews.
- ComponentCatalog.kt: one @Preview per reusable component (SessionCard + loading/bookmarked states, SessionSpeakerChip, Section/ScreenHeader, PlaceholderButton, SocialIcon, DayChip) plus Typography/ColorScheme theme specimens, in the ThemePreview.kt idiom (ConfettiThemeFixed + TestFixtures).

Add catalog.spec.json (system confetti-wear) declaring the sticker sheet.