### PR TITLE
ci(wear): bump compose-preview to 0.17.2 for the daemon @argfile fix

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -58,7 +58,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.16.57
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.2
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -95,7 +95,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.16.57
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.2
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.16.57
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.2
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.69.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.16.57"
+composeai-preview = "0.17.2"
 koogAgents = "1.0.0"
 koogPromptExecutorAll = "1.0.0-beta"
 


### PR DESCRIPTION
0.17.2 spawns the render daemon via a classpath @argfile, so bundle pack --with-semantics no longer overflows the OS arg limit on :wearApp's large classpath. Bumps the version-catalog key (which drives both the installed CLI and the applied plugin) plus the install/apply action refs, so the catalog job now captures layout trees and produces the wear wireframe/figma SVGs.