### PR TITLE
feat(wear): render SessionDetails + SpeakerDetails in the design catalog

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -91,12 +91,12 @@
         },
         {
           "componentId": "SessionDetails",
-          "preview": "SessionDetailViewPreview",
+          "preview": "SessionDetailsScreen",
           "caption": "Session details — title, time, description and speakers."
         },
         {
           "componentId": "SpeakerDetails",
-          "preview": "SpeakerDetailsViewPreview",
+          "preview": "SpeakerDetailsScreen",
           "caption": "Speaker details — photo, name, tagline and bio."
         },
         {

--- a/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/SpeakerDetailsScreenTest.kt
+++ b/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/SpeakerDetailsScreenTest.kt
@@ -1,0 +1,23 @@
+@file:OptIn(ExperimentalCoilApi::class)
+
+package dev.johnoreilly.confetti.wear
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import coil.annotation.ExperimentalCoilApi
+import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
+import dev.johnoreilly.confetti.wear.preview.TestFixtures
+import dev.johnoreilly.confetti.wear.speakerdetails.SpeakerDetailsView
+
+@WearPreviewLargeRound
+@Composable
+fun SpeakerDetailsScreen() {
+    TestScaffold {
+        SpeakerDetailsView(
+            uiState = SpeakerDetailsUiState.Success(
+                conference = TestFixtures.conference,
+                details = TestFixtures.JohnOreilly.speakerDetails,
+            )
+        )
+    }
+}


### PR DESCRIPTION
The catalog spec pointed SessionDetails/SpeakerDetails at the in-main SessionDetailView/SpeakerDetailsView previews, which the preview plugin doesn't discover, so the catalog job only published them under --allow-incomplete (dropping both screens). Point the spec at the screenshotTest screen previews instead: SessionDetailsScreen already exists there and renders; add a matching SpeakerDetailsScreen. Both now carry layout trees, so a strict render (no --allow-incomplete) publishes all 15 components with wireframe/figma SVGs.