### PR TITLE
feat(mobile): add mobile design catalog sticker sheet

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -1,17 +1,22 @@
 name: Design Artifacts
 
-# Render the Confetti Wear design catalog (:wearApp @Preview sticker sheet) and
-# publish its importable bundle (catalog.json + DTCG tokens + Figma variables +
-# PNGs) to a clean `design-artifacts/confetti-wear` branch. The public preview
-# server (preview.coo.ee) fetches that branch and serves it at /confetti-wear/.
+# Render the Confetti design catalogs (@Preview sticker sheets) and publish each
+# importable bundle (catalog.json + DTCG tokens + Figma variables + PNGs) to a
+# clean `design-artifacts/<system>` branch. The public preview server
+# (preview.coo.ee) fetches those branches and serves them at /<system>/.
+#
+# Two catalogs, one per row of the matrix below:
+#   * confetti-wear   — :wearApp,    catalog.spec.json
+#   * confetti-mobile — :androidApp, catalog.mobile.spec.json
 #
 # Pipeline mirrors compose-ai-tools' own design-artifacts job (and the
 # meshcore-mobile consumer):
 #   compose-preview bundle pack  ->  @design-parity/catalog-export driver
 #   (from a compose-ai-tools checkout)  ->  force-push out/ to the branch.
 #
-# :wearApp is an Android (com.android.application) module, so the render runs on
-# Robolectric (headless, no Skiko/xvfb/GL) — same backend as compose-preview.yml.
+# Both :wearApp and :androidApp are Android (com.android.application) modules, so
+# the render runs on Robolectric (headless, no Skiko/xvfb/GL) — same backend as
+# compose-preview.yml.
 
 on:
   # Weekly, so the published sticker sheet tracks the catalog as it evolves.
@@ -33,12 +38,22 @@ concurrency:
 
 jobs:
   generate:
-    name: confetti-wear
+    name: ${{ matrix.system }}
     # Don't run on forks that can't publish the delivery branch. Runs on the
     # upstream repo and on the yschimke fork used to prototype the pipeline.
     if: ${{ github.repository == 'joreilly/Confetti' || github.repository == 'yschimke/Confetti' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: confetti-wear
+            module: ':wearApp'
+            spec: catalog.spec.json
+          - system: confetti-mobile
+            module: ':androidApp'
+            spec: catalog.mobile.spec.json
     steps:
       - uses: actions/checkout@v6
         with:
@@ -82,41 +97,41 @@ jobs:
 
       # Render the catalog module into a portable bundle with semantics (a11y
       # greenlines + layout tree -> tokens/wireframes in the exported catalog).
-      - name: Render catalog bundle (:wearApp, Android/Robolectric)
+      - name: Render catalog bundle (${{ matrix.module }}, Android/Robolectric)
         run: |
           set -euo pipefail
-          compose-preview bundle pack --module :wearApp --with-semantics \
-            -o "$GITHUB_WORKSPACE/confetti-wear-bundle.png"
+          compose-preview bundle pack --module ${{ matrix.module }} --with-semantics \
+            -o "$GITHUB_WORKSPACE/${{ matrix.system }}-bundle.png"
 
-      # Join the render to catalog.spec.json and write the importable bundle.
+      # Join the render to the spec and write the importable bundle.
       # `source: {repo, ref, module}` lets a trusted, toolchain-equipped box
       # live-rerender; it's inert on the desktop-only public server.
       - name: Generate importable catalog
         run: |
           set -euo pipefail
           node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
-            --spec catalog.spec.json \
-            --renders "$GITHUB_WORKSPACE/confetti-wear-bundle.png" \
+            --spec ${{ matrix.spec }} \
+            --renders "$GITHUB_WORKSPACE/${{ matrix.system }}-bundle.png" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-ref main \
-            --source-module :wearApp \
+            --source-module ${{ matrix.module }} \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_incomplete) && '--allow-incomplete' || '' }}
 
-      - name: Publish to design-artifacts/confetti-wear
+      - name: Publish to design-artifacts/${{ matrix.system }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE/out"
           git init -q
-          git checkout -q -b design-artifacts/confetti-wear
+          git checkout -q -b design-artifacts/${{ matrix.system }}
           # Generated delivery branch — attributed to the repo owner, not a bot.
           git config user.name 'Yuri Schimke'
           git config user.email 'yuri@schimke.ee'
           git add -A
-          git commit -q -m "chore(design-artifacts): regenerate confetti-wear catalog ($(date -u +%F))"
+          git commit -q -m "chore(design-artifacts): regenerate ${{ matrix.system }} catalog ($(date -u +%F))"
           git push --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "HEAD:refs/heads/design-artifacts/confetti-wear"
+            "HEAD:refs/heads/design-artifacts/${{ matrix.system }}"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -10,6 +10,10 @@ plugins {
     id("io.github.takahirom.roborazzi")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.screenshot)
+    // Design-catalog sticker sheet: discovers the @Preview functions in ComponentCatalog.kt /
+    // AndroidScreenPreviews.kt and renders them for the published mobile catalog (see
+    // catalog.mobile.spec.json + the design-artifacts workflow). Mirrors :wearApp.
+    alias(libs.plugins.composeai.preview)
 }
 
 configureCompilerOptions()

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
@@ -1,0 +1,221 @@
+package dev.johnoreilly.confetti.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.johnoreilly.confetti.preview.breakSession
+import dev.johnoreilly.confetti.preview.johnOreillySpeaker
+import dev.johnoreilly.confetti.preview.lightningSession
+import dev.johnoreilly.confetti.preview.sessionDetails
+import dev.johnoreilly.confetti.preview.sessionsSuccessState
+import dev.johnoreilly.confetti.ui.bookmarks.Bookmark
+import dev.johnoreilly.confetti.ui.component.ConfettiHeader
+import dev.johnoreilly.confetti.ui.icons.AccessTime
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.sessions.SessionDetailViewShared
+import dev.johnoreilly.confetti.ui.sessions.SessionItemView
+import dev.johnoreilly.confetti.ui.sessions.SessionListView
+import dev.johnoreilly.confetti.ui.speakers.SpeakerDetailsView
+import dev.johnoreilly.confetti.ui.speakers.SpeakerItemView
+
+/**
+ * Single-component "sticker sheet" catalog for the **phone** app — the mobile counterpart of
+ * `dev.johnoreilly.confetti.wear.ui.ComponentCatalog`. Each `@Preview` wraps exactly one real shared
+ * component (or a theme specimen) in the real [ConfettiTheme] fed by `dev.johnoreilly.confetti.preview`
+ * mock data, rendered from the **main** source set so the `ee.schimke.composeai.preview` plugin
+ * discovers them for the published design catalog (it discovers `@Preview`s in the rendered module's
+ * main classes only — the shared module's own CMP previews are invisible to a `:androidApp` render).
+ *
+ * The theme is pinned with `disableDynamicTheming = true` so the render always shows Confetti's own
+ * brand scheme rather than the render host's Material-You dynamic colours — the catalog is a brand
+ * reference. `@CatalogModes` captures every sticker in light + dark; `@CatalogScreen` frames the
+ * full-screen entries on a phone.
+ */
+
+/** Confetti's brand theme with dynamic (Material You) theming disabled, so the catalog is deterministic. */
+@Composable
+private fun CatalogTheme(content: @Composable () -> Unit) {
+    ConfettiTheme(disableDynamicTheming = true, content = content)
+}
+
+/** Component sticker multipreview — light + dark, phone width, height wraps to the component. */
+@Preview(name = "Light", widthDp = 411, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", widthDp = 411, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+annotation class CatalogModes
+
+/**
+ * Session-row multipreview — a bounded height, because [SessionItemView]'s root is `fillMaxSize`, so
+ * without a fixed height it would fill the whole 800dp sandbox and leave the sticker mostly empty.
+ */
+@Preview(name = "Light", widthDp = 411, heightDp = 190, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", widthDp = 411, heightDp = 190, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+annotation class CatalogRow
+
+/** Full-screen multipreview — light + dark on a phone frame. */
+@Preview(name = "Light", widthDp = 411, heightDp = 914, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", widthDp = 411, heightDp = 914, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+annotation class CatalogScreen
+
+// ---------------------------------------------------------------------------
+// Components.
+// ---------------------------------------------------------------------------
+
+@CatalogRow
+@Composable
+fun SessionItemPopulatedPreview() {
+    CatalogTheme {
+        SessionItemView(
+            session = sessionDetails,
+            sessionSelected = {},
+            isBookmarked = true,
+            addBookmark = {},
+            removeBookmark = {},
+            isLoggedIn = true,
+        )
+    }
+}
+
+@CatalogRow
+@Composable
+fun SessionItemLightningPreview() {
+    CatalogTheme {
+        SessionItemView(
+            session = lightningSession,
+            sessionSelected = {},
+            isBookmarked = false,
+            addBookmark = {},
+            removeBookmark = {},
+            isLoggedIn = false,
+        )
+    }
+}
+
+@Preview(name = "Light", widthDp = 411, heightDp = 110, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", widthDp = 411, heightDp = 110, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SessionItemBreakPreview() {
+    CatalogTheme {
+        SessionItemView(
+            session = breakSession,
+            sessionSelected = {},
+            isBookmarked = false,
+            addBookmark = {},
+            removeBookmark = {},
+            isLoggedIn = false,
+        )
+    }
+}
+
+@CatalogModes
+@Composable
+fun BookmarkAddPreview() {
+    CatalogTheme { Bookmark(isBookmarked = false, onBookmarkChange = {}) }
+}
+
+@CatalogModes
+@Composable
+fun BookmarkOnPreview() {
+    CatalogTheme { Bookmark(isBookmarked = true, onBookmarkChange = {}) }
+}
+
+@CatalogModes
+@Composable
+fun SpeakerItemPreview() {
+    CatalogTheme { SpeakerItemView(speaker = johnOreillySpeaker, navigateToSpeaker = {}) }
+}
+
+@CatalogModes
+@Composable
+fun ConfettiHeaderPreview() {
+    CatalogTheme { ConfettiHeader(text = "14:00", icon = ConfettiIcons.AccessTime) }
+}
+
+// ---------------------------------------------------------------------------
+// Theme specimens — the Confetti phone type ramp and colour-scheme swatches read straight from the
+// real [MaterialTheme], mirroring the Wear catalog's specimens on Confetti's own brand theme.
+// ---------------------------------------------------------------------------
+
+@CatalogModes
+@Composable
+fun TypographySpecimenPreview() {
+    CatalogTheme {
+        Column {
+            Text("Display Small", style = MaterialTheme.typography.displaySmall)
+            Text("Title Large", style = MaterialTheme.typography.titleLarge)
+            Text("Body Large", style = MaterialTheme.typography.bodyLarge)
+            Text("Label Small", style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}
+
+@CatalogModes
+@Composable
+fun ColorSchemeSpecimenPreview() {
+    CatalogTheme {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(8.dp)) {
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.primary))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.primaryContainer))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.secondary))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.tertiary))
+            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.surfaceVariant))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Screens — full-screen entry points built from the real shared screens + mock state.
+// ---------------------------------------------------------------------------
+
+@CatalogScreen
+@Composable
+fun ScheduleScreenPreview() {
+    CatalogTheme {
+        SessionListView(
+            uiState = sessionsSuccessState,
+            sessionSelected = {},
+            addBookmark = {},
+            removeBookmark = {},
+            onRefresh = {},
+            onNavigateToSignIn = {},
+            isLoggedIn = false,
+        )
+    }
+}
+
+@CatalogScreen
+@Composable
+fun SessionDetailsScreenPreview() {
+    CatalogTheme {
+        SessionDetailViewShared(
+            conference = "kotlinconf2023",
+            session = sessionDetails,
+            onSpeakerClick = {},
+            onSocialLinkClicked = {},
+        )
+    }
+}
+
+@CatalogScreen
+@Composable
+fun SpeakerDetailsScreenPreview() {
+    CatalogTheme {
+        SpeakerDetailsView(
+            conference = "kotlinconf2023",
+            speaker = johnOreillySpeaker,
+            navigateToSession = {},
+            popBack = {},
+            onSocialLinkClicked = {},
+        )
+    }
+}

--- a/catalog.mobile.spec.json
+++ b/catalog.mobile.spec.json
@@ -1,0 +1,92 @@
+{
+  "$comment": "Design-catalog spec for the Confetti mobile (phone) app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :androidApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under androidApp/src/main/... . The mobile app is Material 3 with a light/dark brand scheme. Theme + Component specimens are in dev.johnoreilly.confetti.ui.ComponentCatalog; the Screens are the full-screen @Preview entry points in that same file, built from the real shared screens + preview mock data. Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens. Mirrors catalog.spec.json (the Wear sheet).",
+  "system": "confetti-mobile",
+  "title": "Confetti Mobile",
+  "library": ["androidx.compose.material3:material3"],
+  "module": "androidApp",
+  "modes": ["light", "dark"],
+  "groups": [
+    {
+      "name": "Theme",
+      "section": "Themes",
+      "components": [
+        {
+          "componentId": "Typography",
+          "preview": "TypographySpecimenPreview",
+          "caption": "A type ramp read from MaterialTheme.typography (Confetti's Material 3 scale)."
+        },
+        {
+          "componentId": "ColorScheme",
+          "preview": "ColorSchemeSpecimenPreview",
+          "caption": "Colour-role swatches read from MaterialTheme.colorScheme (the brand purple scheme)."
+        }
+      ]
+    },
+    {
+      "name": "Components",
+      "section": "Components",
+      "components": [
+        {
+          "componentId": "SessionItemView",
+          "preview": "SessionItemPopulatedPreview",
+          "caption": "Session row — bold title, speakers, room, and the bookmark toggle.",
+          "variants": [
+            {
+              "state": "lightning",
+              "preview": "SessionItemLightningPreview",
+              "caption": "Lightning talk — the primaryContainer bolt pill above the title."
+            },
+            {
+              "state": "break",
+              "preview": "SessionItemBreakPreview",
+              "caption": "Break row — title only, no room and no bookmark."
+            }
+          ]
+        },
+        {
+          "componentId": "Bookmark",
+          "preview": "BookmarkAddPreview",
+          "caption": "Bookmark toggle — the outlined add-bookmark icon.",
+          "variants": [
+            {
+              "state": "bookmarked",
+              "preview": "BookmarkOnPreview",
+              "caption": "Bookmarked — the ribbon tinted with the primary colour."
+            }
+          ]
+        },
+        {
+          "componentId": "SpeakerItemView",
+          "preview": "SpeakerItemPreview",
+          "caption": "Speaker list row — circular avatar, name, and tagline."
+        },
+        {
+          "componentId": "ConfettiHeader",
+          "preview": "ConfettiHeaderPreview",
+          "caption": "Sticky section header — leading icon + bold title between two dividers."
+        }
+      ]
+    },
+    {
+      "name": "Screens",
+      "section": "Screens",
+      "components": [
+        {
+          "componentId": "Schedule",
+          "preview": "ScheduleScreenPreview",
+          "caption": "Sessions schedule — day tabs over a list grouped by start time."
+        },
+        {
+          "componentId": "SessionDetails",
+          "preview": "SessionDetailsScreenPreview",
+          "caption": "Session details — title, time, description, and speakers."
+        },
+        {
+          "componentId": "SpeakerDetails",
+          "preview": "SpeakerDetailsScreenPreview",
+          "caption": "Speaker details — photo, name, tagline, and bio."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Mirrors the Wear design catalog (#1702/#1703) for the **phone** app, so Confetti publishes a mobile sticker sheet alongside the Wear one. Unlike a hand-built copy, every sticker renders a **real shared component** wrapped in the real `ConfettiTheme` — the catalog is a live reference to the actual app UI.

## What's here

- **Applies `ee.schimke.composeai.preview` to `:androidApp`** (mirrors `:wearApp`).
- **`androidApp/.../ui/ComponentCatalog.kt`** — one `@Preview` per real component:
  - Components: `SessionItemView` (populated / lightning / break), `Bookmark` (add / on), `SpeakerItemView`, `ConfettiHeader`.
  - Screens: `SessionListView` (schedule), `SessionDetailViewShared`, `SpeakerDetailsView`.
  - Theme specimens: type ramp + colour-role swatches read from `MaterialTheme`.
  - Each is wrapped in the real `ConfettiTheme(disableDynamicTheming = true)` — so the sheet renders Confetti's own brand scheme rather than the render host's Material-You dynamic colours — fed by the existing `dev.johnoreilly.confetti.preview` mock data. Follows the `AndroidScreenPreviews.kt` precedent (Android `@Preview` FQN + `uiMode` light/dark), rendered from `:androidApp`'s **main** source set so the plugin discovers them (a `:androidApp` render can't see the shared module's own CMP previews).
- **`catalog.mobile.spec.json`** at the repo root — `module: androidApp`, light/dark modes, groups Themes / Components / Screens — mirroring `catalog.spec.json`.
- **`design-artifacts.yml`** — converted the single Wear job to a matrix, adding a `confetti-mobile` row that renders `:androidApp` against `catalog.mobile.spec.json` and publishes `design-artifacts/confetti-mobile`.

## Verification

- Spec validated with the `validate-catalog-spec` pre-flight → 0 errors, all 18 discovered `@Preview`s resolve.
- `./gradlew :androidApp:composePreviewRenderAll` → **BUILD SUCCESSFUL**, 37 PNGs (every catalog preview × light/dark). The session/detail/speaker screens render the real app surfaces with the brand purple theme; the lightning pill, purple bookmark tint, day-tab indicator, and sticky time headers all come from the real components.
- The `compose-preview.yml` diff bot renders these previews inline on this PR (same-repo), and the `design-artifacts` workflow can be dispatched to publish `design-artifacts/confetti-mobile` once merged.

## Test plan

- [x] `./gradlew :androidApp:composePreviewRenderAll` (renders all catalog previews)
- [x] `validate-catalog-spec --spec catalog.mobile.spec.json` (0 errors)
- [ ] Dispatch **Design Artifacts** after merge to publish `design-artifacts/confetti-mobile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XEsGXHoe6XNKB4qvXBpbp

---
_Generated by [Claude Code](https://claude.ai/code/session_011XEsGXHoe6XNKB4qvXBpbp)_