### PR TITLE
fix(a11y): make the speaker photo decorative in SpeakerDetailsView

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -107,7 +107,10 @@ fun SpeakerDetailsView(
                     val url =  speaker.photoUrl // "https://confetti-app.dev/images/avatar/${conference}/${speaker.id}"
                     AsyncImage(
                         model = url,
-                        contentDescription = speaker.name,
+                        // Decorative: the speaker's name is already the screen title, so labelling the
+                        // photo with it makes a screen reader announce the name twice
+                        // (DuplicateSpeakableTextCheck). A null description lets TalkBack skip the image.
+                        contentDescription = null,
                         contentScale = ContentScale.Fit,
                         modifier = Modifier
                             .size(240.dp)


### PR DESCRIPTION
Follow-up to the mobile design catalog (#1706): its a11y report flagged a `DuplicateSpeakableTextCheck` on `SpeakerDetailsView` (via `SpeakerDetailsScreenPreview` and the pre-existing `AndroidSpeakerDetailsPreview`).

`SpeakerDetailsView` shows the speaker's name as the `CenterAlignedTopAppBar` title **and** repeats it as the 240dp photo's `contentDescription`, so a screen reader announces the name twice. The photo is decorative here — the name is already presented as text — so this marks it `contentDescription = null`, letting TalkBack skip the image.

No visual change (content description isn't rendered); the design-catalog a11y report on this PR should show the finding cleared on `SpeakerDetailsScreenPreview` / `AndroidSpeakerDetailsPreview`.

## Test plan

- [x] Compiles (semantics-only, one-line change to an existing `AsyncImage`).
- [ ] a11y report no longer lists `DuplicateSpeakableTextCheck` for the speaker-detail previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XEsGXHoe6XNKB4qvXBpbp

---
_Generated by [Claude Code](https://claude.ai/code/session_011XEsGXHoe6XNKB4qvXBpbp)_