### PR TITLE
feat(wear): enrich theme catalog specimens (typography ramp + colour roles)

### DIFF
--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
@@ -5,12 +5,22 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.rememberPlaceholderState
@@ -146,31 +156,92 @@ fun DayChipPreview() {
     }
 }
 
-// Theme specimens — the Confetti Wear type ramp and colour-scheme swatches read
-// straight from [MaterialTheme], mirroring the wear-m3 sample's specimens but
-// self-contained on Confetti's own theme.
+// Theme specimens — the Confetti Wear type ramp and colour-scheme roles read straight
+// from [MaterialTheme]. Kept deliberately fuller than a bare list so the published Themes
+// tab actually documents the scale and the colour roles (each labelled with its token and,
+// for colours, an on-role glyph proving contrast), mirroring the richer phone catalog.
+
+/** One labelled step of the type ramp: the sample rendered in [style], its token name muted below. */
+@Composable
+private fun TypeRow(sample: String, token: String, style: androidx.compose.ui.text.TextStyle) {
+    Column {
+        Text(sample, style = style, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(
+            token,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+        )
+    }
+}
+
 @Preview(widthDp = 227)
 @Composable
 fun TypographySpecimenPreview() {
     ConfettiThemeFixed {
-        Column {
-            Text("Title Large", style = MaterialTheme.typography.titleLarge)
-            Text("Title Medium", style = MaterialTheme.typography.titleMedium)
-            Text("Body Large", style = MaterialTheme.typography.bodyLarge)
-            Text("Label Medium", style = MaterialTheme.typography.labelMedium)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+        ) {
+            TypeRow("Confetti", "displaySmall", MaterialTheme.typography.displaySmall)
+            TypeRow("Title Large", "titleLarge", MaterialTheme.typography.titleLarge)
+            TypeRow("Title Medium", "titleMedium", MaterialTheme.typography.titleMedium)
+            TypeRow("Body large text", "bodyLarge", MaterialTheme.typography.bodyLarge)
+            TypeRow("Body medium text", "bodyMedium", MaterialTheme.typography.bodyMedium)
+            TypeRow("LABEL MEDIUM", "labelMedium", MaterialTheme.typography.labelMedium)
         }
+    }
+}
+
+/** A single colour-role swatch: the role colour with its on-role glyph, token name muted below. */
+@Composable
+private fun ColorSwatch(color: Color, onColor: Color, token: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(58.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(color),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("Aa", color = onColor, style = MaterialTheme.typography.labelMedium)
+        }
+        Text(
+            token,
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.width(58.dp),
+        )
     }
 }
 
 @Preview(widthDp = 227)
 @Composable
 fun ColorSchemeSpecimenPreview() {
+    val scheme = MaterialTheme.colorScheme
     ConfettiThemeFixed {
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.primary))
-            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.secondary))
-            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.surfaceContainer))
-            Box(Modifier.size(44.dp).background(MaterialTheme.colorScheme.error))
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .background(scheme.background)
+                .padding(14.dp),
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ColorSwatch(scheme.primary, scheme.onPrimary, "primary")
+                ColorSwatch(scheme.secondary, scheme.onSecondary, "secondary")
+                ColorSwatch(scheme.tertiary, scheme.onTertiary, "tertiary")
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ColorSwatch(scheme.primaryContainer, scheme.onPrimaryContainer, "prim cont")
+                ColorSwatch(scheme.surfaceContainer, scheme.onSurface, "surface")
+                ColorSwatch(scheme.error, scheme.onError, "error")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

The Wear design-catalog **Themes** tab was much thinner than the phone catalog — a bare 4-line type list and 4 unlabelled colour boxes. This enriches both theme specimens in `wearApp/.../ui/ComponentCatalog.kt` so the published Themes tab actually documents the scale and the colour roles. Both still read straight from the Wear M3 `MaterialTheme` and render within the 227 dp large-round preview.

- **`TypographySpecimenPreview`** — a labelled type ramp (`displaySmall`, `titleLarge`, `titleMedium`, `bodyLarge`, `bodyMedium`, `labelMedium`); each sample is rendered in its own style with the token name muted beneath, and the panel fills the watch width.
- **`ColorSchemeSpecimenPreview`** — a 2×3 grid of rounded role swatches (`primary`, `secondary`, `tertiary`, `primaryContainer`, `surfaceContainer`, `error`); each swatch carries its on-role `Aa` glyph (so contrast is visible) plus its token label.

## Visual evidence

Rendered via the `compose-preview` pipeline (Robolectric, largeRound / 227 dp).

**Typography** — before (4 bare lines) → after (labelled ramp):
the after render shows displaySmall "Confetti" down to labelMedium, each row in its own style with the muted token name.

**ColorScheme** — before (4 boxes) → after (2×3 labelled role grid):
the after render shows six rounded swatches, each with an `Aa` in its on-colour and a token label (primary / secondary / tertiary / prim cont / surface / error).

The Confetti preview CI (`compose-preview/pr`) will render and diff these on the PR.

## Test plan

- [x] `./gradlew :wearApp:composePreviewRenderAll` — BUILD SUCCESSFUL; both specimens render cleanly at 227 dp with no clipped labels.
- [x] Verified the two rendered PNGs visually (ramp legible, swatches labelled, dark panel fills width).

## Notes

After merge, regenerate the `confetti-wear` catalog (design-artifacts export) so preview.coo.ee picks up the richer Themes tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_0139VLZEXpg4KASSpjm6mxg9)_