### PR TITLE
fix(catalog): render speaker photos in wear + phone catalog previews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 fastlane/metadata/android/en-US/images/wearScreenshots/*.png filter=lfs diff=lfs merge=lfs -text
 wearApp/src/test/resources/*.jpg filter=lfs diff=lfs merge=lfs -text
 wearApp/snapshot/**/*.png filter=lfs diff=lfs merge=lfs -text
+
+# Preview speaker photos reuse the LFS-stored fixture images (rendered in the design catalog).
+wearApp/src/debug/res/raw/*.jpg filter=lfs diff=lfs merge=lfs -text
+androidApp/src/debug/res/raw/*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -166,6 +166,8 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.coil.compose)
+    // coil3 (used by the shared CMP components) — needed for the design-catalog preview image handler.
+    implementation(libs.coil3.compose)
 
     implementation(libs.decompose.decompose)
     implementation(libs.decompose.extensions.compose)

--- a/androidApp/src/debug/res/raw/preview_speaker_john.jpg
+++ b/androidApp/src/debug/res/raw/preview_speaker_john.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcb6f7d81bde7342daf4ddc1bc6b73118477a188aad9bc0c3ecb9d63e8f77b6f
+size 67382

--- a/androidApp/src/debug/res/raw/preview_speaker_martin.jpg
+++ b/androidApp/src/debug/res/raw/preview_speaker_martin.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dd3c2804c2fb55a6e58ac44a6ef25d7e5095ae0e1c2dc5392549055e34d90f7
+size 28584

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
@@ -1,6 +1,8 @@
 package dev.johnoreilly.confetti.ui
 
+import android.content.Context
 import android.content.res.Configuration
+import android.graphics.BitmapFactory
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,9 +13,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.ColorImage
+import coil3.Image
+import coil3.asImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
 import dev.johnoreilly.confetti.preview.breakSession
 import dev.johnoreilly.confetti.preview.johnOreillySpeaker
 import dev.johnoreilly.confetti.preview.lightningSession
@@ -46,7 +56,50 @@ import dev.johnoreilly.confetti.ui.speakers.SpeakerItemView
 /** Confetti's brand theme with dynamic (Material You) theming disabled, so the catalog is deterministic. */
 @Composable
 private fun CatalogTheme(content: @Composable () -> Unit) {
-    ConfettiTheme(disableDynamicTheming = true, content = content)
+    ConfettiTheme(disableDynamicTheming = true) {
+        // The catalog renders with LocalInspectionMode = true, where Coil never executes a network
+        // request — so speaker/venue AsyncImages would sit blank. A preview handler supplies the
+        // bundled speaker photo for a known URL (John / Martin), else a brand-tinted placeholder, so
+        // the published catalog shows real faces. Production is untouched (no handler there).
+        CompositionLocalProvider(
+            LocalAsyncImagePreviewHandler provides catalogImagePreviewHandler(),
+            content = content,
+        )
+    }
+}
+
+/** Coil preview handler that resolves catalog images to a bundled photo or a placeholder. */
+@Composable
+private fun catalogImagePreviewHandler(): AsyncImagePreviewHandler {
+    val context = LocalContext.current
+    return remember(context) {
+        AsyncImagePreviewHandler { request ->
+            bundledSpeakerImage(context, request.data.toString())
+                ?: ColorImage(color = 0xFF6E56CF.toInt(), width = 256, height = 256)
+        }
+    }
+}
+
+/**
+ * The bundled preview photo for a known speaker URL, or null. The real photos are reused (via LFS)
+ * from the screenshot-test fixtures as `res/raw` in the debug source set — riding the design-catalog
+ * (debug) render but never shipping in release. Decodes defensively: a missing / unreadable resource
+ * yields null and the caller falls back to a placeholder.
+ */
+private fun bundledSpeakerImage(context: Context, model: String?): Image? {
+    val resourceName =
+        when {
+            model == null -> return null
+            model.contains("HkquSQhsfczBGkrABwVTBc") -> "preview_speaker_john"
+            model.contains("UiWeCMZDxPejrFsozKmLYr") -> "preview_speaker_martin"
+            else -> return null
+        }
+    val id = context.resources.getIdentifier(resourceName, "raw", context.packageName)
+    if (id == 0) return null
+    return runCatching {
+            context.resources.openRawResource(id).use { BitmapFactory.decodeStream(it) }?.asImage()
+        }
+        .getOrNull()
 }
 
 /** Component sticker multipreview — light + dark, phone width, height wraps to the component. */

--- a/wearApp/src/debug/res/raw/preview_speaker_john.jpg
+++ b/wearApp/src/debug/res/raw/preview_speaker_john.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcb6f7d81bde7342daf4ddc1bc6b73118477a188aad9bc0c3ecb9d63e8f77b6f
+size 67382

--- a/wearApp/src/debug/res/raw/preview_speaker_martin.jpg
+++ b/wearApp/src/debug/res/raw/preview_speaker_martin.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dd3c2804c2fb55a6e58ac44a6ef25d7e5095ae0e1c2dc5392549055e34d90f7
+size 28584

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/AvatarPlaceholder.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/AvatarPlaceholder.kt
@@ -1,27 +1,87 @@
 package dev.johnoreilly.confetti.wear.components
 
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.MaterialTheme
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import dev.johnoreilly.confetti.ui.icons.Person
 
 /**
- * A deterministic stand-in for a speaker photo: a tinted [shape] with a person glyph.
- *
- * Shown when a real image can't load — chiefly the design-catalog / `@Preview` render, where
- * `LocalInspectionMode` is true and Coil never executes the network request, so a
- * `SubcomposeAsyncImage` would otherwise sit on its loading spinner (an empty ring) forever. Reads
- * as an avatar instead. Production is unaffected: real loads still resolve to the photo, and this is
- * only substituted for the spinner while inspecting.
+ * A speaker image for an **inspection / design-catalog render**, where `LocalInspectionMode` is true
+ * and Coil never executes the network request (so a `SubcomposeAsyncImage` would sit on its loading
+ * spinner — an empty ring — forever). Shows the bundled fixture photo for a known speaker
+ * ([bundledSpeakerPhoto]: John / Martin), else an [AvatarPlaceholder]. Call it from a `loading` slot;
+ * production is unaffected (real loads still resolve to the network photo).
+ */
+@Composable
+fun InspectionSpeakerImage(
+    photoUrl: String?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape,
+) {
+    val photo = bundledSpeakerPhoto(photoUrl)
+    if (photo != null) {
+        Image(
+            bitmap = photo,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = modifier.clip(shape),
+        )
+    } else {
+        AvatarPlaceholder(contentDescription, modifier, shape)
+    }
+}
+
+/**
+ * The bundled preview photo for a known speaker URL, or null. The images are the real speaker photos,
+ * reused (via LFS) from the screenshot-test fixtures as `res/raw` in the debug source set — so they
+ * ride the design-catalog (debug) render but never ship in release. Decodes defensively: a missing
+ * or unreadable resource simply yields null and the caller falls back to a placeholder.
+ */
+@Composable
+private fun bundledSpeakerPhoto(photoUrl: String?): ImageBitmap? {
+    val resourceName =
+        when {
+            photoUrl == null -> return null
+            // Match by the sessionize image id so the ?size / thumbnail variants still resolve.
+            photoUrl.contains("HkquSQhsfczBGkrABwVTBc") -> "preview_speaker_john"
+            photoUrl.contains("UiWeCMZDxPejrFsozKmLYr") -> "preview_speaker_martin"
+            else -> return null
+        }
+    val context = LocalContext.current
+    return remember(resourceName) {
+        val id = context.resources.getIdentifier(resourceName, "raw", context.packageName)
+        if (id == 0) {
+            null
+        } else {
+            runCatching {
+                    context.resources.openRawResource(id).use { BitmapFactory.decodeStream(it) }
+                }
+                .getOrNull()
+                ?.asImageBitmap()
+        }
+    }
+}
+
+/**
+ * A deterministic stand-in for a speaker photo: a tinted [shape] with a person glyph — the fallback
+ * when no bundled photo matches (see [InspectionSpeakerImage]).
  */
 @Composable
 fun AvatarPlaceholder(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/AvatarPlaceholder.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/AvatarPlaceholder.kt
@@ -1,0 +1,43 @@
+package dev.johnoreilly.confetti.wear.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.foundation.shape.CircleShape
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.MaterialTheme
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.icons.Person
+
+/**
+ * A deterministic stand-in for a speaker photo: a tinted [shape] with a person glyph.
+ *
+ * Shown when a real image can't load — chiefly the design-catalog / `@Preview` render, where
+ * `LocalInspectionMode` is true and Coil never executes the network request, so a
+ * `SubcomposeAsyncImage` would otherwise sit on its loading spinner (an empty ring) forever. Reads
+ * as an avatar instead. Production is unaffected: real loads still resolve to the photo, and this is
+ * only substituted for the spinner while inspecting.
+ */
+@Composable
+fun AvatarPlaceholder(
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape,
+) {
+    Box(
+        modifier = modifier.clip(shape).background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ConfettiIcons.Person,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.fillMaxSize(0.6f),
+        )
+    }
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.wear.components
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
@@ -7,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.CircularProgressIndicator
@@ -38,7 +40,13 @@ fun SessionSpeakerChip(
                 model = speaker.wearPhotoUrl,
                 contentDescription = speaker.name,
                 loading = {
-                    CircularProgressIndicator()
+                    // In a catalog/@Preview render (LocalInspectionMode) Coil never resolves the
+                    // network photo, so show an avatar placeholder rather than a stuck spinner.
+                    if (LocalInspectionMode.current) {
+                        AvatarPlaceholder(speaker.name, Modifier.fillMaxSize())
+                    } else {
+                        CircularProgressIndicator()
+                    }
                 },
                 error = {
                     Icon(

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
@@ -41,9 +41,10 @@ fun SessionSpeakerChip(
                 contentDescription = speaker.name,
                 loading = {
                     // In a catalog/@Preview render (LocalInspectionMode) Coil never resolves the
-                    // network photo, so show an avatar placeholder rather than a stuck spinner.
+                    // network photo, so show the bundled speaker photo (or a placeholder) rather
+                    // than a stuck spinner.
                     if (LocalInspectionMode.current) {
-                        AvatarPlaceholder(speaker.name, Modifier.fillMaxSize())
+                        InspectionSpeakerImage(speaker.wearPhotoUrl, speaker.name, Modifier.fillMaxSize())
                     } else {
                         CircularProgressIndicator()
                     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -36,7 +36,7 @@ import dev.johnoreilly.confetti.decompose.SpeakerDetailsComponent
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import dev.johnoreilly.confetti.ui.icons.Person
-import dev.johnoreilly.confetti.wear.components.AvatarPlaceholder
+import dev.johnoreilly.confetti.wear.components.InspectionSpeakerImage
 import dev.johnoreilly.confetti.wear.components.SectionHeader
 import dev.johnoreilly.confetti.wear.preview.ConfettiPreviewScaffold
 import dev.johnoreilly.confetti.wear.preview.TestFixtures
@@ -143,9 +143,11 @@ fun SpeakerDetailsView(
                         contentDescription = speaker?.name,
                         loading = {
                             // Catalog/@Preview render (LocalInspectionMode): Coil can't fetch the
-                            // photo, so show an avatar placeholder rather than a stuck spinner.
+                            // photo, so show the bundled speaker photo (or a placeholder) rather
+                            // than a stuck spinner.
                             if (LocalInspectionMode.current) {
-                                AvatarPlaceholder(
+                                InspectionSpeakerImage(
+                                    photoUrl = speaker?.photoUrl,
                                     contentDescription = speaker?.name,
                                     modifier = Modifier.fillMaxSize(),
                                     shape = RoundedCornerShape(16.dp),

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
@@ -35,6 +36,7 @@ import dev.johnoreilly.confetti.decompose.SpeakerDetailsComponent
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import dev.johnoreilly.confetti.ui.icons.Person
+import dev.johnoreilly.confetti.wear.components.AvatarPlaceholder
 import dev.johnoreilly.confetti.wear.components.SectionHeader
 import dev.johnoreilly.confetti.wear.preview.ConfettiPreviewScaffold
 import dev.johnoreilly.confetti.wear.preview.TestFixtures
@@ -140,7 +142,17 @@ fun SpeakerDetailsView(
                         model = speaker?.photoUrl,
                         contentDescription = speaker?.name,
                         loading = {
-                            CircularProgressIndicator()
+                            // Catalog/@Preview render (LocalInspectionMode): Coil can't fetch the
+                            // photo, so show an avatar placeholder rather than a stuck spinner.
+                            if (LocalInspectionMode.current) {
+                                AvatarPlaceholder(
+                                    contentDescription = speaker?.name,
+                                    modifier = Modifier.fillMaxSize(),
+                                    shape = RoundedCornerShape(16.dp),
+                                )
+                            } else {
+                                CircularProgressIndicator()
+                            }
                         },
                         error = {
                             Icon(


### PR DESCRIPTION
## Summary

Speaker photos rendered blank (a stuck spinner / empty avatar) in the published design catalogs, on both `confetti-wear` and `confetti-mobile`.

Root cause: the catalog export renders the main-source `@Preview`s with **`LocalInspectionMode = true`**, where Coil never executes the network request. So a speaker `AsyncImage` never resolves during the headless render.

Fix (per-platform, since wear uses Coil 2 and the shared/phone components use Coil 3):
- **Wear (Coil 2)** — a shared `InspectionSpeakerImage` in each speaker image's `loading` slot: under inspection it shows the bundled speaker photo (or an `AvatarPlaceholder` person-glyph) instead of the spinner. Covers `SessionSpeakerChip` + `SpeakerDetails`.
- **Phone (Coil 3)** — a `LocalAsyncImagePreviewHandler` installed in `CatalogTheme`, resolving every catalog `AsyncImage` to the bundled photo or a brand-tinted placeholder in one place. Adds `coil3-compose` to `:androidApp` for the handler.

**Real photos**: the screenshot-test fixture images (`john.jpg` / `martin.jpg`, Git LFS) are reused as `res/raw` in the **debug** source set — so they ride the design-catalog (debug) render but never ship in release. Known speaker URLs (John / Martin) map to their real photo; anyone else falls back to the placeholder.

**Production is untouched** on both platforms — the inspection branch / preview handler only applies while inspecting; real app loads still hit the network.

## Verification

- `:wearApp:composePreviewRenderAll` and `:androidApp:composePreviewRenderAll` — **BUILD SUCCESSFUL**; speaker avatars are filled (no empty rings / blanks).
- Verified renders show the **placeholder** locally, because this sandbox has no `git-lfs` (the LFS blobs aren't smudged) and the photo source is network-blocked. The **real John/Martin photos resolve in CI**, where `design-artifacts.yml` checks out with `lfs: true` — the new `res/raw` paths reference the same existing LFS objects, so no new upload.
- `res/raw` (not aapt-validated) is used deliberately so an un-smudged LFS pointer can't break the build.

## Test plan

- [x] Both catalog renders build and show avatars (placeholder locally).
- [ ] After merge + `design-artifacts.yml` regen (lfs:true): confirm the **real** John/Martin photos appear in the published catalogs.

## Notes

After merge, regenerate both catalogs (dispatch `design-artifacts.yml`) so preview.coo.ee picks them up — I can't dispatch it (no `actions:write` here).