### PR TITLE
chore(deps): bump compose-ai-tools to 0.17.9

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -58,7 +58,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.2
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.9
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -95,7 +95,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.2
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.9
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -73,7 +73,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.2
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.9
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.69.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.17.2"
+composeai-preview = "0.17.9"
 koogAgents = "1.0.0"
 koogPromptExecutorAll = "1.0.0-beta"
 


### PR DESCRIPTION
## Summary

Freshen the compose-ai-tools design-preview tooling to the latest release (**v0.17.9**).

- `composeai-preview` 0.17.2 → 0.17.9 — the single version var driving both the `ee.schimke.composeai.preview` Gradle plugin and the `ee.schimke.composeai:preview-annotations` module.
- `apply@` / `install@` GitHub actions v0.17.2 → v0.17.9 (`compose-preview.yml`, `design-artifacts.yml`).

## Test plan

CI: the `compose-preview` render and `design-artifacts` jobs exercise the bumped renderer + actions end-to-end against the phone catalog.


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_