### PR TITLE
feat(design-artifacts): publish live bundles for the Confetti catalogs

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -5,6 +5,12 @@ name: Design Artifacts
 # clean `design-artifacts/<system>` branch. The public preview server
 # (preview.coo.ee) fetches those branches and serves them at /<system>/.
 #
+# `--publish-live-bundle` also carries the executable render bundle onto the
+# branch under `bundle/` and records `liveBundle` in catalog.json, so the serve
+# box (which bakes the Android/Robolectric daemon) re-renders these previews
+# live — device/theme/knob controls work — instead of replaying baked PNGs.
+# Both modules are Android, so both get the live lane on the image-backed box.
+#
 # Two catalogs, one per row of the matrix below:
 #   * confetti-wear   — :wearApp,    catalog.spec.json
 #   * confetti-mobile — :androidApp, catalog.mobile.spec.json
@@ -117,6 +123,7 @@ jobs:
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-ref main \
             --source-module ${{ matrix.module }} \
+            --publish-live-bundle \
             ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_incomplete) && '--allow-incomplete' || '' }}
 
       - name: Publish to design-artifacts/${{ matrix.system }}


### PR DESCRIPTION
## Summary

`confetti-mobile` and `confetti-wear` currently serve **baked PNG snapshots only** on preview.coo.ee — their delivery branches publish no executable `liveBundle`, so the viewer's device/theme/knob controls can't re-render (degradation `catalog-baked-only`).

The export already **packs** an executable render bundle (`compose-preview bundle pack … -o <system>-bundle.png`) but never carries it onto the delivery branch. Adding **`--publish-live-bundle`** to the `generate-design-catalog.mjs` step lifts that bundle onto `design-artifacts/<system>` under `bundle/` and records `liveBundle` in `catalog.json` — the same thing the shared reusable pipeline does for `compose-m3` / `wear-m3` / `meshcore-mobile`.

Both `:androidApp` and `:wearApp` are Android/Robolectric, which the image-backed preview server renders (it bakes the Android daemon + SDK, and joreilly/Confetti's `design-artifacts/*` is in the server's branch-trust store), so both catalogs get a live daemon lane instead of static PNGs.

## Rollout (after merge)
1. Merge.
2. Dispatch **Actions → "Design Artifacts" → Run workflow** on `main` (or wait for the Monday schedule) so both branches republish with the `liveBundle`.
3. The preview server auto-refreshes each catalog branch (~10 min) and stands up the live daemon; `/{system}/api/previews` `degradations` clears from `catalog-baked-only` to empty.

## Test plan
Workflow-only change. Verified against the `generate-design-catalog.mjs` contract: `--publish-live-bundle` (boolean) writes `out/bundle/<file>` + `manifest.liveBundle = {path, file}`, and the alias/previewId mapping the live lane needs is already built (the step passes `--source-module`). No app code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_018B1heEfDkyWdqj4cgRuy2U)_