### PR TITLE
chore(deps): bump compose-ai-tools to 0.17.14

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -58,7 +58,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.9
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.14
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -95,7 +95,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.9
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.14
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -79,7 +79,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.9
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.14
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.69.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.17.9"
+composeai-preview = "0.17.14"
 koogAgents = "1.0.0"
 koogPromptExecutorAll = "1.0.0-beta"
 


### PR DESCRIPTION
Bumps `composeai-preview` 0.17.9 → 0.17.14, and the pinned `apply`/`install` action refs in `compose-preview.yml` / `design-artifacts.yml` in lockstep (the workflows pin the CLI to the catalog version as their single source of truth).

The headline for Confetti is [yschimke/compose-ai-tools#2691](https://github.com/yschimke/compose-ai-tools/pull/2691) (released in [v0.17.14](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.17.14)), which fixes two defects visible in the published Confetti catalogs at preview.coo.ee:

- **Speaker/session photos were missing from the layered SVG exports.** Coil's `AsyncImage` draws through a content-painter modifier the exporter didn't recognise, so `speakerdetails`, `sessiondetails`, and `speakeritem` stickers had empty holes where the images belong ([example](https://preview.coo.ee/confetti-mobile/render/speakerdetails__ideal__default__dark__compact.svg) vs its PNG). The photos now raster into the SVG from the frame capture — before/after renders are embedded in the upstream PR.
- **The SVG theme flipped between light and dark from run to run.** The render daemon dropped `@Preview(uiMode = …)` and inherited the previous render's night qualifier, so the `_Dark`/`_Light` variants' captured data products were byte-identical with a render-order-dependent theme. The daemon now derives the theme per variant from the preview manifest.

The published `design-artifacts/{confetti-mobile,confetti-wear}` branches pick this up on the next `design-artifacts.yml` run (weekly cron, or a manual dispatch after this merges).

## Test plan

- Version-only bump; no source changes. The `compose-preview` CI job on this PR exercises the new CLI/action pair end-to-end (render + diff vs baseline).
- After merge, dispatch `design-artifacts.yml` and spot-check the speakerdetails SVG for the restored photo and stable dark/light variants.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSeEHF4rWGX5Zst7NmerPE)_