### PR TITLE
ci: set up BuildFetch remote Gradle build cache

### DIFF
--- a/.github/workflows/android_wear_jvm.yml
+++ b/.github/workflows/android_wear_jvm.yml
@@ -11,10 +11,9 @@ jobs:
   build-android:
     runs-on: ubuntu-22.04
     env:
-      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
-      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
-      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
-      ON_CI: ${{ github.ref == 'refs/heads/main' }}
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
+      # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -39,10 +38,9 @@ jobs:
   build-jvm:
     runs-on: ubuntu-22.04
     env:
-      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
-      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
-      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
-      ON_CI: ${{ github.ref == 'refs/heads/main' }}
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
+      # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/android_wear_jvm.yml
+++ b/.github/workflows/android_wear_jvm.yml
@@ -10,6 +10,11 @@ concurrency:
 jobs:
   build-android:
     runs-on: ubuntu-22.04
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
+      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -22,6 +27,8 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3.5.0
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
     - name: Wear Unit Tests
       run: ./gradlew :androidApp:testDebugUnitTest :wearApp:testDebugUnitTest
@@ -31,6 +38,11 @@ jobs:
 
   build-jvm:
     runs-on: ubuntu-22.04
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
+      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -41,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3.5.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Build
         run: ./gradlew :shared:runJvmMain

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'joreilly/Confetti'
 
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). This is a trusted main-branch run, so
+      # ON_CI=true and the RW token let it push freshly-executed backend task outputs to the remote,
+      # seeding the cache that PR builds read from.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
+
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -11,10 +11,9 @@ jobs:
   build-backend:
     runs-on: ubuntu-22.04
     env:
-      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
-      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
-      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
-      ON_CI: ${{ github.ref == 'refs/heads/main' }}
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
+      # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -10,6 +10,11 @@ concurrency:
 jobs:
   build-backend:
     runs-on: ubuntu-22.04
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). Token is absent on fork PRs, which
+      # disables the cache there. Writes happen only on trusted main-branch builds (ON_CI).
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -21,6 +26,8 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3.5.0
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
     - uses: hashicorp/setup-terraform@v3
 

--- a/.github/workflows/build-and-publish-web.yml
+++ b/.github/workflows/build-and-publish-web.yml
@@ -8,6 +8,10 @@ jobs:
   build:
     name: Test and Build
     runs-on: ubuntu-latest
+    env:
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
+      # manual build only reads from the cache. Absent on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     steps:
 
       # Setup Java 1.8 environment for the next steps

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -44,6 +44,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). On main-branch runs ON_CI=true and the RW
+      # token seed the cache from the render/compile task outputs; on PRs ON_CI is false so the same
+      # token is used read-only. Absent on forks, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -81,6 +87,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). On main-branch runs ON_CI=true and the RW
+      # token seed the cache from the render/compile task outputs; on PRs ON_CI is false so the same
+      # token is used read-only. Absent on forks, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -50,6 +50,10 @@ jobs:
     if: ${{ github.repository == 'joreilly/Confetti' || github.repository == 'yschimke/Confetti' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so the
+      # catalog render only reads from the cache. Absent on forks, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fixes.yml
+++ b/.github/workflows/fixes.yml
@@ -7,6 +7,11 @@ jobs:
   build-android:
     runs-on: ubuntu-22.04
 
+    env:
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
+      # manual screenshot-fix run only reads from the cache. Absent on fork PRs (cache disabled).
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,6 +10,11 @@ concurrency:
 jobs:
   build:
     runs-on: macos-latest
+    env:
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so the
+      # Kotlin/Native compile Gradle runs (invoked by xcodebuild) only read from the cache. Absent
+      # on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -12,6 +12,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      # BuildFetch remote cache (see settings.gradle.kts). This is a trusted main-branch run, so
+      # ON_CI=true: it pushes freshly-executed task outputs to the remote, seeding the cache that
+      # PR and developer builds read from.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,81 @@ pluginManagement {
 }
 
 rootProject.name = "Confetti"
+
+// BuildFetch remote Gradle build cache. Complements the local build cache (org.gradle.caching=true
+// in gradle.properties) by sharing task outputs across CI runs and developer machines.
+//
+// Auth: the token is resolved from the first non-blank of, in order:
+//   1. env  BUILDFETCH_CONFETTI_GRADLE_REMOTE_CACHE_TOKEN   (project-specific)
+//   2. prop BUILDFETCH_CONFETTI_GRADLE_REMOTE_CACHE_TOKEN
+//   3. env  BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN            (shared / general fallback)
+//   4. prop BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN
+// The project-specific name lets a developer hold a separate readonly token per BuildFetch project
+// in a single ~/.gradle/gradle.properties (sibling repos point at different caches, so one shared
+// token can't authenticate them all). The general name stays as a fallback — it's what CI exports
+// and what a single-project setup can use. Env wins over a gradle property of the same name so CI
+// overrides a stray local property.
+//
+// The token is treated as absent unless it is non-blank. CI declares the env var unconditionally
+// (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.… }}`), so an unprovisioned secret or a fork
+// PR exports it as an empty string — which Gradle's `environmentVariable(...)` still reports as
+// *present*. Filtering each source for blanks independently preserves the intended no-op (empty ⇒
+// cache disabled) and lets a later source take over even when an earlier one is present-but-empty.
+// When nothing resolves the cache disables itself (isEnabled below), so fork PRs and un-provisioned
+// checkouts fall back to the local cache with no error.
+//
+// Push: writes are restricted to trusted CI builds. CI sets ON_CI=true only on main-branch runs, so
+// PRs and developer machines are read-only. The gate is value-based (not env-var presence) so an
+// explicit ON_CI=false is honoured as read-only.
+val onCi = providers.environmentVariable("ON_CI").orElse("false").get().toBoolean()
+
+// Non-blank view of a single env var / gradle property: trims and drops empties so a
+// present-but-empty source doesn't shadow a later fallback (see the header comment).
+val nonBlank = { source: Provider<String> -> source.map { it.trim() }.filter { it.isNotEmpty() } }
+val cacheToken =
+    nonBlank(providers.environmentVariable("BUILDFETCH_CONFETTI_GRADLE_REMOTE_CACHE_TOKEN"))
+        .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_CONFETTI_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orElse(nonBlank(providers.environmentVariable("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orElse(nonBlank(providers.gradleProperty("BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN")))
+        .orNull
+
+// True only when this run will actually push to the remote: a trusted main-branch run (ON_CI)
+// with a usable token. Anything else (PRs, dev machines, or a main run whose token is
+// unprovisioned/blank) does not push, so it must keep the local cache.
+val remotePushEnabled = onCi && cacheToken != null
+
+buildCache {
+    // On the trusted main-branch runs, CI is the sole writer of the BuildFetch remote cache —
+    // and the only thing that populates it for every other consumer (PRs, developer machines).
+    // Gradle never re-uploads a *local* build-cache hit to the remote; it pushes to the remote
+    // only when a task actually executes. setup-gradle restores a warm local build cache
+    // (caches/build-cache-1) from the GitHub Actions cache, so with it in place every task
+    // resolves as FROM-CACHE (local), nothing is pushed, and the remote stays empty (dev
+    // machines then see 0 remote hits). Disabling the local cache on the pushing runs forces
+    // tasks to execute-and-push, or to hit the remote directly, so BuildFetch actually gets
+    // seeded.
+    //
+    // Gate this on remotePushEnabled, not just ON_CI: if the token is unprovisioned/blank the
+    // remote below disables itself, and disabling the local cache too would make that main run
+    // execute every cacheable task with *no* cache at all. Off-CI, on PRs, and on token-less
+    // main runs the local cache stays on.
+    local {
+        isEnabled = !remotePushEnabled
+    }
+    remote<HttpBuildCache> {
+        url = uri("https://cache.eu-central-a.buildfetch.com/xTXBBS/gradle/")
+
+        credentials {
+            username = "token-auth"
+            password = cacheToken
+        }
+
+        isPush = onCi
+
+        isEnabled = cacheToken != null
+    }
+}
+
 include(":androidApp")
 //include(":androidBenchmark")
 //include(":automotiveApp")


### PR DESCRIPTION
## Summary

Sets up the [BuildFetch](https://buildfetch.com) remote Gradle build cache for Confetti, mirroring the configuration used by sibling repos (meshcore-mobile, compose-ai-tools). Task outputs are shared across CI runs and developer machines, pointed at Confetti's own cache project (`xTXBBS`, EU Central A).

### `settings.gradle.kts`

Adds a `buildCache {}` block:

- **Auth**: token resolved from the first non-blank of `BUILDFETCH_CONFETTI_GRADLE_REMOTE_CACHE_TOKEN` (env → gradle prop, project-specific) then `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` (env → prop, shared fallback). The project-specific name lets a developer keep a separate token per BuildFetch project in one `~/.gradle/gradle.properties`.
- **Self-disabling**: the remote treats the token as absent unless non-blank, so fork PRs and un-provisioned checkouts fall back to the local cache with no error.
- **Push gating**: writes are restricted to trusted `main`-branch runs (`ON_CI=true`). On those pushing runs the local build cache is disabled so tasks execute-and-push and actually seed the remote (a warm local cache would otherwise resolve everything FROM-CACHE and leave the remote empty).

### CI wiring

Follows meshcore-mobile's read-only / read-write token split:

**Read-only consumers** — RO token (`BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO`), no `ON_CI`, so they can only read:
`android_wear_jvm`, `backend-test`, `ios`, `build-and-publish-web`, `fixes`, `design-artifacts`.

**Key writers** — RW token + `ON_CI=(ref==main)`, seeding the cache across the module graph:
- `publish-android` — androidApp release + shared
- `backend-deploy` — backend modules
- `compose-preview` — androidApp/wearApp render/compile graph (read-only on PRs, since `ON_CI` is false there)

`verify` (no Gradle build) and `junie` / `publish-kmmbridge` (call external reusable workflows) are left untouched.

## Test plan

- [x] Gradle evaluates `settings.gradle.kts` cleanly — an offline `./gradlew help` gets past settings evaluation and only fails later at `build-logic` plugin resolution (no cached artifacts in the sandbox), confirming the `buildCache` block parses and runs.
- [x] All nine edited workflow YAML files validated with `yaml.safe_load`.
- [ ] Requires two repo secrets to activate: `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN` (read-write) and `BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO` (read-only). Until provisioned, both export empty and every workflow transparently uses the local cache. The first `main`-branch writer run seeds the remote; PR reads land as hits thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ukt5gTkDxSYdzrsfG6npM)_