### PR TITLE
ci: fix Publish Android on Gradle 9.6.1

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,7 +27,10 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.5.0
+        # setup-gradle@v6 (matches compose-preview.yml / design-artifacts.yml): the deprecated
+        # gradle-build-action@v3.5.0 fails on Gradle 9.6.1 in its cache-cleanup init script
+        # ("write-only property 'removeUnusedEntriesOlderThan'").
+        uses: gradle/actions/setup-gradle@v6
         with:
           gradle-home-cache-cleanup: true
 


### PR DESCRIPTION
## Summary

`Publish Android` has been red on `main` (independent of the BuildFetch change — it failed identically on `7d86f4b1` and earlier merges). The job dies during Gradle bootstrap on Gradle 9.6.1:

```
* Where: Initialization script '.../dummy-cleanup-project/init.gradle' line: 8
* What went wrong:
Cannot get the value of write-only property 'removeUnusedEntriesOlderThan'
for object of type ...DefaultCacheResourceConfiguration.
```

This is the cache-cleanup init script of the **deprecated** `gradle/gradle-build-action@v3.5.0` (setup-gradle v3), which is incompatible with Gradle 9.x. It fails before any build task runs.

## Fix

Upgrade the `Setup Gradle` step to `gradle/actions/setup-gradle@v6` — the version already used by `compose-preview.yml` and `design-artifacts.yml`, proven against Gradle 9.6.1 on this repo — while keeping `gradle-home-cache-cleanup: true`.

As a bonus this unblocks the third BuildFetch writer: once green, `Publish Android` seeds the remote cache for the `androidApp`/`shared` graph on `main` (it already carries the RW token + `ON_CI` from #1723).

## Test plan

- [x] `publish-android.yml` YAML validated.
- [ ] Confirm the `Publish Android` run on merge to `main` gets past Gradle bootstrap and completes `:androidApp:assembleGithubRelease` (the previous failure was at bootstrap, in ~6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ukt5gTkDxSYdzrsfG6npM)_