### PR TITLE
fix: add R8 keep rule for ktor's java.lang.management reference

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -8,6 +8,9 @@
 # Referenced by ktor
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
+# ktor's IntellijIdeaDebugDetector references java.lang.management, which is absent on Android.
+-dontwarn java.lang.management.**
+
 -keep class com.squareup.wire.** { *; }
 -keep class dev.johnoreilly.confetti.wear.proto.** { *; }
 -keep class androidx.car.app.** { *; }


### PR DESCRIPTION
## Summary

With the Gradle 9.6.1 bootstrap crash fixed in #1724, `Publish Android` now gets all the way into the release build — and reveals the next (previously masked) failure in `:androidApp:minifyGithubReleaseWithR8`:

```
ERROR: Missing classes detected while running R8. ...
ERROR: R8: Missing class java.lang.management.ManagementFactory
        (referenced from: io.ktor.util.debug.IntellijIdeaDebugDetector...)
Missing class java.lang.management.RuntimeMXBean (referenced from: ...IntellijIdeaDebugDetector...)
```

Ktor's `IntellijIdeaDebugDetector` references `java.lang.management.*`, which doesn't exist on Android. R8's missing-class check hard-fails the release build unless the reference is explicitly ignored.

## Fix

Add `-dontwarn java.lang.management.**` to the existing "Referenced by ktor" section of `androidApp/proguard-rules.pro`, matching the adjacent `-dontwarn org.slf4j.impl.StaticLoggerBinder` / `-dontwarn io.ktor.client.network.sockets.SocketTimeoutException` entries. A `-dontwarn` only silences the shrink-time missing-class check — no app behavior changes. It applies to both `release` and `githubRelease` (both use this rules file).

## Context

- The BuildFetch remote cache is confirmed working: the failing run already showed `53 from cache` task hits.
- The R8 failure isn't caused by BuildFetch or #1724 — it was hidden behind the ~6s Gradle-bootstrap crash that #1724 fixed, so `Publish Android` never reached R8 before.

## Test plan

- [ ] `Publish Android` only runs `on: push` to `main` (paths include `androidApp/**`), and the debug builds on PRs aren't minified — so R8 runs only post-merge. Verify the merge run completes `:androidApp:minifyGithubReleaseWithR8` and produces the APK artifact. I'm tracking it and will report the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ukt5gTkDxSYdzrsfG6npM)_