### PR TITLE
ci: improve BuildFetch cache hit rate for the Android CI target

### DIFF
--- a/.github/workflows/android_wear_jvm.yml
+++ b/.github/workflows/android_wear_jvm.yml
@@ -1,19 +1,29 @@
 name: Android, Wear and JVM CI
 
-on: pull_request
+on:
+  pull_request:
+  # Also run on main so this job SEEDS the BuildFetch remote cache with the debug-variant task
+  # outputs. Without a main-branch writer building assembleDebug/testDebugUnitTest, PR runs of the
+  # same target can only reuse whatever overlaps with the release build that publish-android seeds,
+  # capping the hit rate. Running here on main pushes the debug tasks so PRs hit them.
+  push:
+    branches: [main]
 
-# Cancel any current or previous job from the same PR
+# Cancel superseded PR runs; never cancel the main-branch seeding run.
 concurrency:
-  group: android-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: android-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-android:
     runs-on: ubuntu-22.04
     env:
-      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
-      # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
-      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      # BuildFetch remote cache (see settings.gradle.kts). On main-branch pushes this job is a
+      # writer: ON_CI=true + the read-write token seed the debug-variant task outputs so PR runs of
+      # this same target get cache hits. On PRs it uses the read-only token with ON_CI=false, so it
+      # only reads. Absent on fork PRs, which disables the cache there.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -38,9 +48,10 @@ jobs:
   build-jvm:
     runs-on: ubuntu-22.04
     env:
-      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
-      # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
-      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      # See build-android: writer (RW token + ON_CI) on main to seed :shared JVM task outputs,
+      # read-only (RO token) on PRs.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,8 @@
+// Explicit root project name for the included build. Without it Gradle warns that the
+// generated type-safe project accessors depend on the checkout folder name, which changes
+// the build-logic buildscript classpath across machines/CI and breaks build-cache reuse.
+rootProject.name = "build-logic"
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
## What & why

Profiled the Android CI target (`:androidApp`/`:wearApp` `assembleDebug` + `testDebugUnitTest`) against the seeded BuildFetch remote to see how much is actually cached, and how close we can get to a 95% hit rate. Two fixes came out of it.

## Measurements (local, JDK 21 to match CI)

| Run | Scenario | Result |
|-----|----------|--------|
| **1** | Cold local cache, **real** remote (seeded only by `publish-android` release + backend + previews) | 158 tasks → **57 from cache / 101 executed = 36% hit** |
| **2** | Warm local, no changes (incremental) | 149 → 11 executed, 138 up-to-date |
| **3** | `clean` + warm local cache = *fresh runner w/ fully-seeded remote* | 149 → **76 from cache / 68 executed = ~53% ceiling** |

### Can we hit 95%?
**Not as "95% of all tasks from cache"** — run 3 shows that even with a perfectly seeded cache, **~47% of this target's tasks are non-cacheable by AGP design**: `dexBuilderDebug`, `mergeLibDexDebug`/`mergeProjectDexDebug`, `packageDebug`, `stripDebugDebugSymbols`, `merge*Assets`/`merge*JniLibFolders`, `write*AarMetadata`, `process*JavaRes`, `injectCrashlyticsMappingFileId*`, `createDebugApkListingFileRedirect`, KMP dependency-checkers, etc. Those always execute, so the all-task ceiling for an *assemble* target is ~53%.

**Yes as "95–100% of *cacheable* tasks"** (the metric Develocity/BuildFetch dashboards report) — but only once the debug variant is actually seeded on `main`.

## The fixes

**1. Seed the debug variant (`android_wear_jvm.yml`)** — the target now also runs on `push: main` as a cache **writer** (RW token + `ON_CI=true`), read-only on PRs (RO token). Previously *no* main-branch writer built `assembleDebug`/`testDebugUnitTest` — the remote only had the `githubRelease` outputs from `publish-android` — so PR runs measured just 36%. Seeding the debug tasks lets PRs pull them, moving the hit rate from **36% → the full ~53% cacheable set (≈100% of cacheable tasks)**.

**2. `build-logic/settings.gradle.kts`: `rootProject.name = "build-logic"`** — Gradle was warning at config time that the missing name makes the type-safe project accessors (and the build-logic buildscript classpath) depend on the checkout folder name, *"breaking caching"*. Confirmed the warning disappears after the fix.

## Trade-off to be aware of

Fix 1 adds one full Android build on every push to `main` (the seeding run). That's the cost of a warm PR cache. If that's too heavy, alternatives are a scheduled seed (e.g. a few times a day) or seeding only `assembleDebug` without the unit tests — happy to adjust.

## Test plan

- [x] `android_wear_jvm.yml` YAML validated.
- [x] `build-logic` fix verified locally: `./gradlew help` is `BUILD SUCCESSFUL` and the "breaking caching" warning is gone.
- [ ] After merge, the `main` seeding run populates the debug tasks; the next PR touching this target should show the jump toward the ~53% all-task / ~100%-of-cacheable hit rate in the Gradle summary line.

Note: unrelated to this change, the `:wearApp:testDebugUnitTest` Roborazzi screenshot tests can't run in a headless sandbox without the LFS reference images (null-bitmap NPE); they run fine on CI which checks out LFS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ukt5gTkDxSYdzrsfG6npM)_