### PR TITLE
Add theme foundation previews and catalog providers for design system

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -168,6 +168,9 @@ dependencies {
     implementation(libs.coil.compose)
     // coil3 (used by the shared CMP components) — needed for the design-catalog preview image handler.
     implementation(libs.coil3.compose)
+    // @ThemeCatalog, for the alternative-theme providers in ConfettiThemeCatalogs.kt — BINARY
+    // retention, scanned off the compiled classes by the preview plugin. Mirrors :wearApp.
+    implementation(libs.composeai.preview.annotations)
 
     implementation(libs.decompose.decompose)
     implementation(libs.decompose.extensions.compose)

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
@@ -1,0 +1,146 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import dev.johnoreilly.confetti.decompose.DarkThemeConfig
+import ee.schimke.composeai.preview.ThemeCatalog
+
+/**
+ * `@ThemeCatalog` providers — the phone app's **alternative themes**, declared so the preview
+ * server can re-render *any* preview under any of them.
+ *
+ * Where [ThemeFoundationPreviews] bakes one static specimen sticker per theme, these providers make
+ * the axis interactive: `compose-preview serve` lifts every `@ThemeCatalog`-annotated
+ * [PreviewWrapperProvider] into the viewer's **Theme** select, and picking one re-renders the
+ * currently open preview through that provider's `Wrap` — so you can open `ScheduleScreenPreview`
+ * and flip it between the brand purple, the Android green, Material You and a conference seed, and
+ * see the live result rather than a pre-baked PNG. (Daemon-backed: the control is live on a local
+ * `serve` session, disabled on a published static bundle.)
+ *
+ * Light and dark are declared as separate providers rather than left to `isSystemInDarkTheme()`:
+ * the theme select is a *discrete* axis applied on top of whatever `uiMode` the preview renders
+ * with, so a provider that read the ambient mode would make half the options no-ops. Each wraps a
+ * production theme function — [ConfettiTheme] for the three colour schemes, [ConferenceMaterialTheme]
+ * for the seeded app-root theme — so these can't drift from what the app renders.
+ */
+@ThemeCatalog(name = "Confetti brand Light", group = "Confetti")
+class ConfettiBrandLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = false, disableDynamicTheming = true, content = content)
+}
+
+@ThemeCatalog(name = "Confetti brand Dark", group = "Confetti")
+class ConfettiBrandDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = true, disableDynamicTheming = true, content = content)
+}
+
+@ThemeCatalog(name = "Android Light", group = "Android")
+class AndroidLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = false, androidTheme = true, content = content)
+}
+
+@ThemeCatalog(name = "Android Dark", group = "Android")
+class AndroidDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = true, androidTheme = true, content = content)
+}
+
+@ThemeCatalog(name = "Dynamic Light", group = "Material You")
+class DynamicLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = false, disableDynamicTheming = false, content = content)
+}
+
+@ThemeCatalog(name = "Dynamic Dark", group = "Material You")
+class DynamicDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiTheme(darkTheme = true, disableDynamicTheming = false, content = content)
+}
+
+/**
+ * Conference seed colours offered as themes. These are the identities the Wear app curates in
+ * `dev.johnoreilly.confetti.wear.ui.ConferenceTheme`; on the phone the same colours arrive as the
+ * backend's `conference.themeColor`, so wrapping [ConferenceMaterialTheme] with them previews
+ * exactly what a phone user sees for that conference. The `0x` prefix is part of the wire format.
+ */
+private const val KOTLINCONF_SEED = "0xFF7F52FF"
+private const val ANDROIDMAKERS_SEED = "0xFFE59A4F"
+private const val DROIDCON_SEED = "0xFF00D775"
+private const val DEVFEST_SEED = "0xFF4285F4"
+
+/**
+ * Shared body for the seeded providers. Written as a plain `@Composable` helper each provider calls
+ * rather than something the providers delegate to with `by`: Kotlin's interface delegation
+ * generates a bridge method, and a `@Composable` member is not safely delegable that way.
+ */
+@Composable
+private fun ConferenceSeed(seed: String, dark: Boolean, content: @Composable () -> Unit) =
+    ConferenceMaterialTheme(
+        seedColorString = seed,
+        darkThemeConfig = if (dark) DarkThemeConfig.DARK else DarkThemeConfig.LIGHT,
+        content = content,
+    )
+
+@ThemeCatalog(name = "KotlinConf Light", group = "Conference")
+class KotlinConfLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(KOTLINCONF_SEED, dark = false, content = content)
+}
+
+@ThemeCatalog(name = "KotlinConf Dark", group = "Conference")
+class KotlinConfDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(KOTLINCONF_SEED, dark = true, content = content)
+}
+
+@ThemeCatalog(name = "AndroidMakers Light", group = "Conference")
+class AndroidMakersLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(ANDROIDMAKERS_SEED, dark = false, content = content)
+}
+
+@ThemeCatalog(name = "AndroidMakers Dark", group = "Conference")
+class AndroidMakersDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(ANDROIDMAKERS_SEED, dark = true, content = content)
+}
+
+@ThemeCatalog(name = "Droidcon Light", group = "Conference")
+class DroidconLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(DROIDCON_SEED, dark = false, content = content)
+}
+
+@ThemeCatalog(name = "Droidcon Dark", group = "Conference")
+class DroidconDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(DROIDCON_SEED, dark = true, content = content)
+}
+
+@ThemeCatalog(name = "DevFest Light", group = "Conference")
+class DevFestLightThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(DEVFEST_SEED, dark = false, content = content)
+}
+
+@ThemeCatalog(name = "DevFest Dark", group = "Conference")
+class DevFestDarkThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConferenceSeed(DEVFEST_SEED, dark = true, content = content)
+}

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ThemeFoundationPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ThemeFoundationPreviews.kt
@@ -1,0 +1,180 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * **Theme foundations** for the phone catalog — one sticker per theme the mobile app can actually
+ * run in, each rendered light + dark by [CatalogModes].
+ *
+ * The mobile app has two independent theming mechanisms and the catalog previously published
+ * neither of them honestly — it pinned a single brand scheme with dynamic colour switched off, so
+ * the Themes tab implied Confetti had one look:
+ *
+ *  - [ConfettiTheme] picks between three colour schemes — the Confetti **brand** purple, the
+ *    **Android** green, and **dynamic** (Material You, wallpaper-derived on Android 12+) — with
+ *    precedence dynamic > Android > brand.
+ *  - [ConferenceMaterialTheme] is what the real app root
+ *    ([dev.johnoreilly.confetti.ui.App]) actually installs: a scheme generated from the active
+ *    **conference's seed colour**, so the app re-tints per conference the way the Wear app does.
+ *
+ * Every preview below goes through the production theme function rather than re-declaring a
+ * scheme, so a swatch here is by construction the colour the app paints. Kept in the **main**
+ * source set for the `ee.schimke.composeai.preview` plugin, registered in
+ * `catalog.mobile.spec.json`, and mirrored by the `@ThemeCatalog` providers in
+ * [ConfettiThemeCatalogs] so `compose-preview serve` can re-render any preview live under any of
+ * them.
+ */
+
+/** A colour-role swatch: the role colour carrying its on-role label, token name beneath. */
+@Composable
+private fun RowScope.RoleSwatch(label: String, token: String, color: Color, onColor: Color) {
+    Column(Modifier.weight(1f)) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(color),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(label, color = onColor, style = MaterialTheme.typography.labelSmall)
+        }
+        Text(
+            token,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+        )
+    }
+}
+
+/** One step of the surface ramp — outlined so adjacent near-identical tones stay readable. */
+@Composable
+private fun RowScope.SurfaceBand(label: String, color: Color) {
+    Box(
+        Modifier
+            .weight(1f)
+            .height(30.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(color)
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(6.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            label,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}
+
+/**
+ * The foundation sheet: colour roles, surface ramp and type ramp, all read from the enclosing
+ * [MaterialTheme] — i.e. whatever theme the caller wrapped this in.
+ */
+@Composable
+private fun ThemeFoundation(title: String, tagline: String) {
+    val cs = MaterialTheme.colorScheme
+    Surface(color = cs.background) {
+        Column(
+            Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column {
+                Text(title, style = MaterialTheme.typography.titleLarge, color = cs.primary)
+                Text(tagline, style = MaterialTheme.typography.labelMedium, color = cs.onSurfaceVariant)
+            }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                RoleSwatch("P", "primary", cs.primary, cs.onPrimary)
+                RoleSwatch("PC", "primCont", cs.primaryContainer, cs.onPrimaryContainer)
+                RoleSwatch("S", "secondary", cs.secondary, cs.onSecondary)
+                RoleSwatch("T", "tertiary", cs.tertiary, cs.onTertiary)
+                RoleSwatch("E", "error", cs.error, cs.onError)
+            }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                SurfaceBand("0", cs.surface)
+                SurfaceBand("1", cs.surfaceContainerLowest)
+                SurfaceBand("2", cs.surfaceContainerLow)
+                SurfaceBand("3", cs.surfaceContainer)
+                SurfaceBand("4", cs.surfaceContainerHigh)
+                SurfaceBand("5", cs.surfaceContainerHighest)
+            }
+            Column {
+                Text("Display", style = MaterialTheme.typography.displaySmall, color = cs.onBackground)
+                Text("Headline", style = MaterialTheme.typography.headlineSmall, color = cs.onBackground)
+                Text("Title", style = MaterialTheme.typography.titleMedium, color = cs.onBackground)
+                Text(
+                    "Body — the quick brown fox jumps over the lazy dog",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = cs.onSurfaceVariant,
+                )
+                Text("LABEL", style = MaterialTheme.typography.labelLarge, color = cs.primary)
+            }
+        }
+    }
+}
+
+/**
+ * Seed colour used for the conference-themed specimen — KotlinConf's JetBrains purple, the same
+ * `0xFF7F52FF` the Wear catalog curates for that conference, so the two sheets line up. The live
+ * app takes this string from the backend's `conference.themeColor`; the `0x` prefix is part of the
+ * wire format ([ConferenceMaterialTheme] parses with `HexFormat { number.prefix = "0x" }`, and a
+ * string without it silently falls back to the default green).
+ */
+private const val CONFERENCE_SEED = "0xFF7F52FF"
+
+@CatalogModes
+@Composable
+fun ThemeFoundationDefaultPreview() {
+    // Dynamic explicitly off → the Confetti brand scheme, whatever the render host's wallpaper is.
+    ConfettiTheme(disableDynamicTheming = true) {
+        ThemeFoundation("Confetti brand", "Purple / orange / blue · the default scheme")
+    }
+}
+
+@CatalogModes
+@Composable
+fun ThemeFoundationAndroidPreview() {
+    ConfettiTheme(androidTheme = true) {
+        ThemeFoundation("Android", "Green / teal · the Android-branded scheme")
+    }
+}
+
+@CatalogModes
+@Composable
+fun ThemeFoundationDynamicPreview() {
+    // Material You: `colorScheme()` resolves `dynamic{Light,Dark}ColorScheme(context)` on API 31+,
+    // and falls back to the brand scheme below that — so on an older render host this sticker is
+    // the brand scheme, which is exactly what the app would show there too.
+    ConfettiTheme(disableDynamicTheming = false) {
+        ThemeFoundation("Dynamic (Material You)", "Wallpaper-derived on Android 12+")
+    }
+}
+
+@CatalogModes
+@Composable
+fun ThemeFoundationConferenceSeedPreview() {
+    // The real app-root theme: a scheme generated from the active conference's seed colour.
+    ConferenceMaterialTheme(seedColorString = CONFERENCE_SEED) {
+        ThemeFoundation("Conference seed", "Generated from conference.themeColor · #7F52FF")
+    }
+}

--- a/catalog.mobile.spec.json
+++ b/catalog.mobile.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the Confetti mobile (phone) app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :androidApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under androidApp/src/main/... . The mobile app is Material 3 with a light/dark brand scheme. Theme + Component specimens are in dev.johnoreilly.confetti.ui.ComponentCatalog; the Screens are the full-screen @Preview entry points in that same file, built from the real shared screens + preview mock data. Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens. Mirrors catalog.spec.json (the Wear sheet).",
+  "$comment": "Design-catalog spec for the Confetti mobile (phone) app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :androidApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under androidApp/src/main/... . The mobile app is Material 3 and picks between several schemes — the Confetti brand purple, the Android green, dynamic (Material You), and the conference-seeded scheme the app root actually installs — each in light + dark; the Theme foundations group carries one sticker per scheme (from dev.johnoreilly.confetti.ui.ThemeFoundationPreviews), and the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them. Theme + Component specimens are in dev.johnoreilly.confetti.ui.ComponentCatalog; the Screens are the full-screen @Preview entry points in that same file, built from the real shared screens + preview mock data. Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens. Mirrors catalog.spec.json (the Wear sheet).",
   "system": "confetti-mobile",
   "title": "Confetti Mobile",
   "library": ["androidx.compose.material3:material3"],
@@ -19,6 +19,32 @@
           "componentId": "ColorScheme",
           "preview": "ColorSchemeSpecimenPreview",
           "caption": "Colour-role swatches read from MaterialTheme.colorScheme (the brand purple scheme)."
+        }
+      ]
+    },
+    {
+      "name": "Theme foundations",
+      "section": "Themes",
+      "components": [
+        {
+          "componentId": "Theme/Confetti",
+          "preview": "ThemeFoundationDefaultPreview",
+          "caption": "Confetti brand scheme — colour roles, surface ramp and type ramp. The default when dynamic colour is off."
+        },
+        {
+          "componentId": "Theme/Android",
+          "preview": "ThemeFoundationAndroidPreview",
+          "caption": "Android scheme — the green/teal alternative ConfettiTheme(androidTheme = true) selects."
+        },
+        {
+          "componentId": "Theme/Dynamic",
+          "preview": "ThemeFoundationDynamicPreview",
+          "caption": "Dynamic (Material You) — wallpaper-derived on Android 12+, falling back to the brand scheme below that."
+        },
+        {
+          "componentId": "Theme/ConferenceSeed",
+          "preview": "ThemeFoundationConferenceSeedPreview",
+          "caption": "Conference-seeded scheme — what the app root actually installs, generated from conference.themeColor (shown with KotlinConf's #7F52FF)."
         }
       ]
     },

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, so the single mode is the large-round breakpoint. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog; the Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
+  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, so the single mode is the large-round breakpoint. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog, and the per-conference theme foundations in dev.johnoreilly.confetti.wear.ui.ThemeFoundationPreviews (the Wear app themes itself per conference — seed colour plus, for KotlinConf/DevFest, a brand type family — so the Themes tab carries one sticker per identity, not just the stock scheme; the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them). The Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
   "system": "confetti-wear",
   "title": "Confetti Wear",
   "library": ["androidx.wear.compose:compose-material3"],
@@ -13,12 +13,43 @@
         {
           "componentId": "Typography",
           "preview": "TypographySpecimenPreview",
-          "caption": "A type ramp read from MaterialTheme.typography (Wear Material 3)."
+          "caption": "A type ramp read from MaterialTheme.typography — Confetti's ship stack, Roboto Flex (display/title) + Inter (body/label)."
         },
         {
           "componentId": "ColorScheme",
           "preview": "ColorSchemeSpecimenPreview",
           "caption": "Colour-role swatches read from MaterialTheme.colorScheme."
+        }
+      ]
+    },
+    {
+      "name": "Conference themes",
+      "section": "Themes",
+      "components": [
+        {
+          "componentId": "Theme/Confetti",
+          "preview": "ThemeFoundationConfettiPreview",
+          "caption": "Stock Confetti Wear theme — colour roles, surface ramp and type ramp. The look for any conference without a curated identity."
+        },
+        {
+          "componentId": "Theme/KotlinConf",
+          "preview": "ThemeFoundationKotlinConfPreview",
+          "caption": "KotlinConf — JetBrains purple seed, JetBrains Mono display/title."
+        },
+        {
+          "componentId": "Theme/AndroidMakers",
+          "preview": "ThemeFoundationAndroidMakersPreview",
+          "caption": "AndroidMakers — Parisian ochre seed."
+        },
+        {
+          "componentId": "Theme/Droidcon",
+          "preview": "ThemeFoundationDroidconPreview",
+          "caption": "Droidcon — Droidcon green seed."
+        },
+        {
+          "componentId": "Theme/DevFest",
+          "preview": "ThemeFoundationDevFestPreview",
+          "caption": "DevFest — Google blue seed, Google Sans Flex throughout."
         }
       ]
     },

--- a/design/STYLE_GUIDE.md
+++ b/design/STYLE_GUIDE.md
@@ -165,6 +165,21 @@ identity.
 3. [`HomeScreen`'s title section](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt) asks the same lookup for the current conference id and renders
    `theme.icon` above the name when one exists.
 
+### Where you can see them
+
+All five looks — the stock Confetti theme plus the four curated identities —
+are published as their own sticker in the **Themes** tab of the Wear design
+catalog, rendered from
+[`ThemeFoundationPreviews.kt`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt)
+through the same [`ConfettiConferenceTheme`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt)
+call the app makes, so a swatch there is by construction a colour the app paints.
+Each is also declared as a `@ThemeCatalog` provider in
+[`ConfettiThemeCatalogs.kt`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt),
+which puts them in the **Theme** select of `compose-preview serve` — pick one and
+*any* preview (a session card, the whole Home screen) re-renders live under it.
+The phone app does the same for its own set (brand / Android / dynamic /
+conference-seeded) from `androidApp/…/ui/ThemeFoundationPreviews.kt`.
+
 That's the full extent of the conference-aware code. No per-conference
 components, no custom drawables, no bespoke screens. The identity is
 carried entirely by tokens + a single icon + (for DevFest) a typography

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
@@ -160,6 +160,11 @@ fun DayChipPreview() {
 // from [MaterialTheme]. Kept deliberately fuller than a bare list so the published Themes
 // tab actually documents the scale and the colour roles (each labelled with its token and,
 // for colours, an on-role glyph proving contrast), mirroring the richer phone catalog.
+//
+// Wrapped in [ConfettiConferenceTheme] (not the bare [ConfettiThemeFixed] the component
+// stickers use): these two document *the app's own theme*, so they must show Confetti's ship
+// typography — Roboto Flex + Inter — rather than the stock Wear `Typography()` defaults.
+// The per-conference variants of the same sheet live in [ThemeFoundationPreviews].
 
 /** One labelled step of the type ramp: the sample rendered in [style], its token name muted below. */
 @Composable
@@ -178,7 +183,7 @@ private fun TypeRow(sample: String, token: String, style: androidx.compose.ui.te
 @Preview(widthDp = 227)
 @Composable
 fun TypographySpecimenPreview() {
-    ConfettiThemeFixed {
+    ConfettiConferenceTheme(conferenceId = null) {
         Column(
             verticalArrangement = Arrangement.spacedBy(6.dp),
             modifier = Modifier
@@ -224,8 +229,11 @@ private fun ColorSwatch(color: Color, onColor: Color, token: String) {
 @Preview(widthDp = 227)
 @Composable
 fun ColorSchemeSpecimenPreview() {
-    val scheme = MaterialTheme.colorScheme
-    ConfettiThemeFixed {
+    ConfettiConferenceTheme(conferenceId = null) {
+        // Read INSIDE the theme — hoisting this above the wrapper (as it used to be) resolves
+        // `MaterialTheme.colorScheme` from the ambient default, so every swatch rendered the Wear
+        // fallback palette instead of Confetti's.
+        val scheme = MaterialTheme.colorScheme
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Android
 import androidx.compose.material.icons.filled.Celebration
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.wear.compose.material3.Typography
@@ -80,6 +81,29 @@ fun conferenceThemeFor(id: String?): ConferenceTheme? {
         )
         else -> null
     }
+}
+
+/**
+ * Apply the curated identity for [conferenceId] — the seed colour *and* the
+ * typography override — exactly the way [dev.johnoreilly.confetti.wear.ui.ConfettiApp]
+ * does for the live app, minus the `appState` plumbing. A null / uncurated id
+ * falls back to the stock Confetti Wear theme (Wear defaults + [ExpressiveTypography]).
+ *
+ * This is the single entry point the design catalog's theme specimens and the
+ * `@ThemeCatalog` providers in [ConfettiThemeCatalogs] both go through, so a
+ * catalog sticker can never drift from what the app actually renders.
+ */
+@Composable
+fun ConfettiConferenceTheme(
+    conferenceId: String?,
+    content: @Composable () -> Unit,
+) {
+    val theme = conferenceThemeFor(conferenceId)
+    ConfettiTheme(
+        seedColor = theme?.seedColor,
+        typography = theme?.typography ?: ExpressiveTypography,
+        content = content,
+    )
 }
 
 /** Fallback icon for conferences without a curated theme — used when we still

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
@@ -1,0 +1,57 @@
+package dev.johnoreilly.confetti.wear.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import ee.schimke.composeai.preview.ThemeCatalog
+
+/**
+ * `@ThemeCatalog` providers — Confetti Wear's **alternative themes**, declared so the preview
+ * server can re-render *any* preview under any of them.
+ *
+ * Where [ThemeFoundationPreviews] bakes one static specimen sticker per theme, these providers make
+ * the axis interactive: `compose-preview serve` lifts every `@ThemeCatalog`-annotated
+ * [PreviewWrapperProvider] into the viewer's **Theme** select, and picking one re-renders the
+ * currently open preview through that provider's `Wrap` — so you can look at `SessionCard` or
+ * `HomeScreen` in KotlinConf purple, then flip to DevFest blue, and see the live result rather than
+ * a pre-baked PNG. (Daemon-backed: the control is live on a local `serve` session, disabled on a
+ * published static bundle.)
+ *
+ * Each wraps [ConfettiConferenceTheme] with a real conference id, so these are exactly the themes
+ * the app resolves at runtime via [conferenceThemeFor] — the ids are prefix-matched, so a rolling
+ * edition can't drift them. `group = "Conference"` buckets the four curated identities into their
+ * own `<optgroup>` beneath the stock Confetti theme.
+ */
+@ThemeCatalog(name = "Confetti (default)", group = "Confetti")
+class ConfettiDefaultThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiConferenceTheme(conferenceId = null, content = content)
+}
+
+@ThemeCatalog(name = "KotlinConf", group = "Conference")
+class KotlinConfThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiConferenceTheme(conferenceId = "kotlinconf2025", content = content)
+}
+
+@ThemeCatalog(name = "AndroidMakers", group = "Conference")
+class AndroidMakersThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiConferenceTheme(conferenceId = "androidmakers2025", content = content)
+}
+
+@ThemeCatalog(name = "Droidcon", group = "Conference")
+class DroidconThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiConferenceTheme(conferenceId = "droidconlondon2025", content = content)
+}
+
+@ThemeCatalog(name = "DevFest", group = "Conference")
+class DevFestThemeCatalog : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) =
+        ConfettiConferenceTheme(conferenceId = "devfest2025", content = content)
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt
@@ -1,0 +1,183 @@
+package dev.johnoreilly.confetti.wear.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+
+/**
+ * **Theme foundations** for the Wear catalog — one sticker per theme Confetti can actually run in.
+ *
+ * The Wear app doesn't have a single theme: [ConfettiApp] resolves a *per-conference* identity
+ * (seed colour + optional brand typography) from [conferenceThemeFor] and feeds it to
+ * [ConfettiTheme], so KotlinConf, AndroidMakers, Droidcon and DevFest each render the same
+ * components in their own palette (and, for KotlinConf / DevFest, their own type family). Only the
+ * stock scheme was published before, so the Themes tab claimed Confetti had one look when it has
+ * five.
+ *
+ * Each preview goes through [ConfettiConferenceTheme] — the same call the app makes — and shows the
+ * resolved `MaterialTheme.colorScheme` roles plus the type ramp, so a swatch here is by
+ * construction the colour the app paints. The five ids below are prefix-matched by
+ * [conferenceThemeFor], so they stay correct across rolling editions.
+ *
+ * Kept in the **main** source set so the `ee.schimke.composeai.preview` plugin discovers them for
+ * the published design catalog; registered in `catalog.spec.json` under the Themes section. The
+ * `@ThemeCatalog` providers in [ConfettiThemeCatalogs] expose the same five themes to
+ * `compose-preview serve`, so any preview can be re-rendered live under any of them.
+ */
+
+/** Watch-sized swatch: the role colour with its on-role glyph, token name beneath. */
+@Composable
+private fun RowScope.RoleSwatch(label: String, token: String, color: Color, onColor: Color) {
+    Column(Modifier.weight(1f)) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(30.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(color),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(label, color = onColor, style = MaterialTheme.typography.labelSmall)
+        }
+        Text(
+            token,
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/** One step of the surface ramp — outlined so adjacent near-black darks stay distinguishable. */
+@Composable
+private fun RowScope.SurfaceBand(label: String, color: Color) {
+    Box(
+        Modifier
+            .weight(1f)
+            .height(22.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(color)
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(6.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            label,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+        )
+    }
+}
+
+/**
+ * The foundation sheet itself: colour roles, the surface ramp and the type ramp, all read from the
+ * enclosing [MaterialTheme] — i.e. whatever theme the caller wrapped this in.
+ */
+@Composable
+private fun WearThemeFoundation(title: String, signature: String) {
+    val cs = MaterialTheme.colorScheme
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(cs.background)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+    ) {
+        Column {
+            Text(title, style = MaterialTheme.typography.titleMedium, color = cs.primary, maxLines = 1)
+            Text(
+                signature,
+                style = MaterialTheme.typography.labelSmall,
+                color = cs.onSurfaceVariant,
+                maxLines = 2,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            RoleSwatch("P", "primary", cs.primary, cs.onPrimary)
+            RoleSwatch("PC", "primCont", cs.primaryContainer, cs.onPrimaryContainer)
+            RoleSwatch("S", "secondary", cs.secondary, cs.onSecondary)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            RoleSwatch("T", "tertiary", cs.tertiary, cs.onTertiary)
+            RoleSwatch("TC", "tertCont", cs.tertiaryContainer, cs.onTertiaryContainer)
+            RoleSwatch("E", "error", cs.error, cs.onError)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            SurfaceBand("bg", cs.background)
+            SurfaceBand("low", cs.surfaceContainerLow)
+            SurfaceBand("con", cs.surfaceContainer)
+            SurfaceBand("high", cs.surfaceContainerHigh)
+        }
+        Column {
+            Text("Confetti", style = MaterialTheme.typography.displaySmall, color = cs.onBackground, maxLines = 1)
+            Text("Title Medium", style = MaterialTheme.typography.titleMedium, color = cs.onBackground, maxLines = 1)
+            Text(
+                "Body — quick brown fox",
+                style = MaterialTheme.typography.bodyMedium,
+                color = cs.onSurfaceVariant,
+                maxLines = 1,
+            )
+            Text("LABEL MEDIUM", style = MaterialTheme.typography.labelMedium, color = cs.primary, maxLines = 1)
+        }
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ThemeFoundationConfettiPreview() {
+    // No curated conference → the stock Confetti Wear theme: Wear M3 defaults + ExpressiveTypography.
+    ConfettiConferenceTheme(conferenceId = null) {
+        WearThemeFoundation("Confetti", "Default · Roboto Flex / Inter")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ThemeFoundationKotlinConfPreview() {
+    ConfettiConferenceTheme(conferenceId = "kotlinconf2025") {
+        WearThemeFoundation("KotlinConf", "JetBrains purple · JetBrains Mono titles")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ThemeFoundationAndroidMakersPreview() {
+    ConfettiConferenceTheme(conferenceId = "androidmakers2025") {
+        WearThemeFoundation("AndroidMakers", "Parisian ochre · Roboto Flex / Inter")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ThemeFoundationDroidconPreview() {
+    ConfettiConferenceTheme(conferenceId = "droidconlondon2025") {
+        WearThemeFoundation("Droidcon", "Droidcon green · Roboto Flex / Inter")
+    }
+}
+
+@Preview(widthDp = 227)
+@Composable
+fun ThemeFoundationDevFestPreview() {
+    ConfettiConferenceTheme(conferenceId = "devfest2025") {
+        WearThemeFoundation("DevFest", "Google blue · Google Sans Flex")
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive theme foundation previews and interactive theme catalog providers for both the Wear and mobile apps, enabling the design catalog to showcase all available themes and allowing the preview server to re-render any preview under any theme.

## Key Changes

### Wear App
- **`ThemeFoundationPreviews.kt`**: Added five preview stickers showing the complete theme foundation (colour roles, surface ramp, type ramp) for each of Confetti's themes:
  - Default Confetti theme (Wear M3 defaults + ExpressiveTypography)
  - KotlinConf (JetBrains purple + JetBrains Mono titles)
  - AndroidMakers (Parisian ochre + Roboto Flex/Inter)
  - Droidcon (Droidcon green + Roboto Flex/Inter)
  - DevFest (Google blue + Google Sans Flex)
- **`ConfettiThemeCatalogs.kt`**: Added `@ThemeCatalog` providers for all five themes, enabling live theme switching in `compose-preview serve`
- **`ConferenceTheme.kt`**: Added `ConfettiConferenceTheme()` composable function that applies the curated identity (seed colour + typography) for a given conference, serving as the single entry point for both catalog specimens and the live app
- **`ComponentCatalog.kt`**: Updated comments to clarify that the type ramp preview now uses `ConfettiConferenceTheme` to show the app's actual typography

### Mobile App
- **`ThemeFoundationPreviews.kt`**: Added four preview stickers showing theme foundations for each colour scheme:
  - Confetti brand (purple/orange/blue)
  - Android (green/teal)
  - Dynamic/Material You (wallpaper-derived)
  - Conference seed (generated from conference.themeColor)
- **`ConfettiThemeCatalogs.kt`**: Added `@ThemeCatalog` providers for all schemes in light and dark variants (10 total), enabling theme switching in `compose-preview serve`

### Documentation
- **`catalog.spec.json`** and **`catalog.mobile.spec.json`**: Updated comments to reference the new theme foundation previews and catalog providers
- **`STYLE_GUIDE.md`**: Added "Where you can see them" section documenting how to view the themes in the design catalog and preview server

## Implementation Details

- All previews read from the enclosing `MaterialTheme` to ensure swatches are by construction the colours the app actually paints
- Wear previews use `ConfettiConferenceTheme()` to apply both seed colours and typography overrides
- Mobile previews use production theme functions (`ConfettiTheme`, `ConferenceMaterialTheme`) rather than re-declaring schemes
- Conference seed colours are consistent between Wear and mobile apps (e.g., KotlinConf's `0xFF7F52FF`)
- Theme catalog providers are grouped by theme family for better organization in the preview server UI

https://claude.ai/code/session_01HRDWM9eugX8V3AcskvK9VC