### PR TITLE
fix(catalog): annotate the Wear theme providers with @WearThemeCatalog

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -64,7 +64,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.26
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.27
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -107,7 +107,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.26
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.27
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.26
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.27
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/design/STYLE_GUIDE.md
+++ b/design/STYLE_GUIDE.md
@@ -173,7 +173,7 @@ catalog, rendered from
 [`ThemeFoundationPreviews.kt`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt)
 through the same [`ConfettiConferenceTheme`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt)
 call the app makes, so a swatch there is by construction a colour the app paints.
-Each is also declared as a `@ThemeCatalog` provider in
+Each is also declared as a `@WearThemeCatalog` provider in
 [`ConfettiThemeCatalogs.kt`](../wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt),
 which puts them in the **Theme** select of `compose-preview serve` — pick one and
 *any* preview (a session card, the whole Home screen) re-renders live under it.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.17.26"
+composeai-preview = "0.17.27"
 koogAgents = "1.0.0"
 koogPromptExecutorAll = "1.0.0-beta"
 

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConferenceTheme.kt
@@ -90,7 +90,7 @@ fun conferenceThemeFor(id: String?): ConferenceTheme? {
  * falls back to the stock Confetti Wear theme (Wear defaults + [ExpressiveTypography]).
  *
  * This is the single entry point the design catalog's theme specimens and the
- * `@ThemeCatalog` providers in [ConfettiThemeCatalogs] both go through, so a
+ * `@WearThemeCatalog` providers in [ConfettiThemeCatalogs] both go through, so a
  * catalog sticker can never drift from what the app actually renders.
  */
 @Composable

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
@@ -2,54 +2,60 @@ package dev.johnoreilly.confetti.wear.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
-import ee.schimke.composeai.preview.ThemeCatalog
+import ee.schimke.composeai.preview.WearThemeCatalog
 
 /**
- * `@ThemeCatalog` providers — Confetti Wear's **alternative themes**, declared so the preview
+ * `@WearThemeCatalog` providers — Confetti Wear's **alternative themes**, declared so the preview
  * server can re-render *any* preview under any of them.
  *
  * Where [ThemeFoundationPreviews] bakes one static specimen sticker per theme, these providers make
- * the axis interactive: `compose-preview serve` lifts every `@ThemeCatalog`-annotated
+ * the axis interactive: `compose-preview serve` lifts every `@WearThemeCatalog`-annotated
  * [PreviewWrapperProvider] into the viewer's **Theme** select, and picking one re-renders the
  * currently open preview through that provider's `Wrap` — so you can look at `SessionCard` or
  * `HomeScreen` in KotlinConf purple, then flip to DevFest blue, and see the live result rather than
  * a pre-baked PNG. (Daemon-backed: the control is live on a local `serve` session, disabled on a
  * published static bundle.)
  *
+ * The **Wear** annotation, not the mobile `@ThemeCatalog`: these providers install
+ * `androidx.wear.compose.material3.MaterialTheme`, so the auto-generated specimen sheet has to read
+ * the Wear `ColorScheme` (`primaryDim`, `surfaceContainer*`, no `surfaceVariant` ramp). Annotated
+ * with the mobile one, every sheet would silently report the baseline mobile M3 palette instead of
+ * the theme it declares.
+ *
  * Each wraps [ConfettiConferenceTheme] with a real conference id, so these are exactly the themes
  * the app resolves at runtime via [conferenceThemeFor] — the ids are prefix-matched, so a rolling
  * edition can't drift them. `group = "Conference"` buckets the four curated identities into their
  * own `<optgroup>` beneath the stock Confetti theme.
  */
-@ThemeCatalog(name = "Confetti (default)", group = "Confetti")
+@WearThemeCatalog(name = "Confetti (default)", group = "Confetti")
 class ConfettiDefaultThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
         ConfettiConferenceTheme(conferenceId = null, content = content)
 }
 
-@ThemeCatalog(name = "KotlinConf", group = "Conference")
+@WearThemeCatalog(name = "KotlinConf", group = "Conference")
 class KotlinConfThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
         ConfettiConferenceTheme(conferenceId = "kotlinconf2025", content = content)
 }
 
-@ThemeCatalog(name = "AndroidMakers", group = "Conference")
+@WearThemeCatalog(name = "AndroidMakers", group = "Conference")
 class AndroidMakersThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
         ConfettiConferenceTheme(conferenceId = "androidmakers2025", content = content)
 }
 
-@ThemeCatalog(name = "Droidcon", group = "Conference")
+@WearThemeCatalog(name = "Droidcon", group = "Conference")
 class DroidconThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
         ConfettiConferenceTheme(conferenceId = "droidconlondon2025", content = content)
 }
 
-@ThemeCatalog(name = "DevFest", group = "Conference")
+@WearThemeCatalog(name = "DevFest", group = "Conference")
 class DevFestThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ThemeFoundationPreviews.kt
@@ -40,7 +40,7 @@ import androidx.wear.compose.material3.Text
  *
  * Kept in the **main** source set so the `ee.schimke.composeai.preview` plugin discovers them for
  * the published design catalog; registered in `catalog.spec.json` under the Themes section. The
- * `@ThemeCatalog` providers in [ConfettiThemeCatalogs] expose the same five themes to
+ * `@WearThemeCatalog` providers in [ConfettiThemeCatalogs] expose the same five themes to
  * `compose-preview serve`, so any preview can be re-rendered live under any of them.
  */
 


### PR DESCRIPTION
## Summary

Follow-up to #1736. The five Wear theme providers were declared with `@ThemeCatalog`, whose auto-generated specimen sheet reads `androidx.compose.material3.MaterialTheme` — the **mobile** one. A Wear provider never installs that; `ConfettiConferenceTheme` sets `androidx.wear.compose.material3.MaterialTheme`. So each generated sheet silently reported the baseline mobile M3 palette instead of the theme it declares, with the wrong role set on top (Wear's `ColorScheme` carries `primaryDim` / `secondaryDim` / `surfaceContainer*` and has no `surfaceVariant` ramp).

compose-ai-tools 0.17.27 ships `@WearThemeCatalog` for exactly this case (yschimke/compose-ai-tools#2778); this switches the providers over and bumps the pin.

## Changes

- `wearApp/.../ConfettiThemeCatalogs.kt`: all five providers `@ThemeCatalog` → `@WearThemeCatalog`
- `gradle/libs.versions.toml`: `composeai-preview` `0.17.26` → `0.17.27` (one ref drives both the annotations dependency and the Gradle plugin)
- `compose-preview.yml` / `design-artifacts.yml`: `apply`/`install` action refs → `v0.17.27`. Required, not cosmetic — discovery at 0.17.26 doesn't know the new annotation, so leaving it pinned would drop all five Wear themes out of the preview server's Theme select
- Wear-side doc references updated (`STYLE_GUIDE.md`, `ThemeFoundationPreviews.kt`, `ConferenceTheme.kt`)

Mobile's `@ThemeCatalog` usage is untouched and correct — it really is mobile M3.

## Evidence

Rendered `:wearApp:composePreviewRenderAll` before and after. The generated sheets are `themecatalog__*.png` → `wearthemecatalog__*.png`.

**Before — all five sheets were byte-identical** (one md5 across `AndroidMakers`, `Confetti (default)`, `DevFest`, `Droidcon`, `KotlinConf`; 35219 bytes each). That is the bug in one line: five different themes, one rendered palette.

**After — all five are distinct** (five md5s, 33978–35109 bytes).

Role set on the KotlinConf sheet, before → after:

| Before (mobile M3) | After (Wear M3) |
| --- | --- |
| `primary #FF6750A4` — the stock M3 baseline purple, not KotlinConf's | `primary #FFCDBDFF` — seeded from KotlinConf's `0xFF7F52FF` |
| `surface #FFFEF7FF` (light) | `background #FF0F0D13` (dark, as Wear renders) |
| `surfaceVariant`, `outline` | `primaryDim`, `secondaryDim`, `surfaceContainerLow/Container/High` |

The remaining `@Preview` renders in the module are unchanged. `composePreviewRenderAll` reports one pre-existing failure, `activity__MainActivity` (`KoinApplication has not been started`), unrelated to this diff — CI runs `only: compose` with `missing-renders: warn`, so it doesn't gate.

The published catalog is unaffected either way: `catalog.spec.json` points at the explicit `ThemeFoundation*` previews, which were correct from the start. The live Theme select is unaffected too — it worked under either annotation.

## Test plan

- [x] `./gradlew :wearApp:composePreviewRenderAll` — 140/141 previews render; the five Wear theme sheets regenerate under the Wear `MaterialTheme`
- [x] Verified before/after sheets are identical-then-distinct by md5
- [ ] CI: Compose Preview + A11y jobs on this PR (the visual-diff bot will post the rendered before/after)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRDWM9eugX8V3AcskvK9VC)_