### PR TITLE
fix(ci): stop compose-preview firing on non-UI PRs

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -19,11 +19,35 @@ name: Compose Preview
 # skipped (no write token to post a comment with anyway). On joreilly/Confetti
 # the default token already has contents:write, so its own PRs render + diff.
 
+# `paths-ignore` keeps the two 45-minute render jobs off changes that cannot
+# reach a Compose @Preview: the GraphQL/Ktor backend, the iOS app, the landing
+# page, and docs. Deliberately a denylist rather than an allowlist of UI paths
+# — previews render against shared Kotlin Multiplatform code and the version
+# catalog, so an allowlist would silently stop rendering the first time a
+# preview picked up a new transitive dependency. Note this does NOT cover
+# dependency bumps that touch `gradle/libs.versions.toml`, even backend-only
+# ones; those still render everything.
+#
+# The list is repeated rather than shared via a YAML anchor because GitHub
+# Actions does not support anchors/aliases in workflow files — keep the two
+# copies in sync.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'backend/**'
+      - 'iosApp/**'
+      - 'landing-page/**'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'backend/**'
+      - 'iosApp/**'
+      - 'landing-page/**'
+      - 'docs/**'
+      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -138,9 +138,15 @@ fun SpeakerDetailsView(
                 val speaker = (uiState as? SpeakerDetailsUiState.Success)?.details
 
                 item {
+                    // The photo is decorative: the SectionHeader immediately below already
+                    // announces the speaker's name, so labelling the image with it too made a
+                    // screen reader read the name twice — DuplicateSpeakableTextCheck flagged it.
+                    // Null on every slot also keeps the a11y tree stable: which of
+                    // loading/error/success has settled when the tree is scanned is a race, so a
+                    // name on only some of them made the finding appear and disappear between runs.
                     SubcomposeAsyncImage(
                         model = speaker?.photoUrl,
-                        contentDescription = speaker?.name,
+                        contentDescription = null,
                         loading = {
                             // Catalog/@Preview render (LocalInspectionMode): Coil can't fetch the
                             // photo, so show the bundled speaker photo (or a placeholder) rather
@@ -148,7 +154,7 @@ fun SpeakerDetailsView(
                             if (LocalInspectionMode.current) {
                                 InspectionSpeakerImage(
                                     photoUrl = speaker?.photoUrl,
-                                    contentDescription = speaker?.name,
+                                    contentDescription = null,
                                     modifier = Modifier.fillMaxSize(),
                                     shape = RoundedCornerShape(16.dp),
                                 )
@@ -159,7 +165,7 @@ fun SpeakerDetailsView(
                         error = {
                             Icon(
                                 imageVector = ConfettiIcons.Person,
-                                contentDescription = speaker?.name,
+                                contentDescription = null,
                                 modifier = Modifier
                                     .size(80.dp)
                                     .clip(RoundedCornerShape(16.dp)),


### PR DESCRIPTION
## Summary

Two independent reasons the preview + a11y jobs ran and commented on PRs that cannot affect a single `@Preview` — e.g. [#1738](https://github.com/joreilly/Confetti/pull/1738), a `scrimage-filters` bump used only by `backend/service-graphql`.

### 1. No path filter

The workflow ran both 45-minute jobs on every PR. Added `paths-ignore` for `backend/`, `iosApp/`, `landing-page/`, `docs/`, `**.md`.

Deliberately a denylist rather than an allowlist of UI paths: previews render against shared KMP code and the version catalog, so an allowlist would silently stop rendering the first time a preview picked up a new transitive dependency. Note this does **not** help dependency bumps that touch `gradle/libs.versions.toml`, even backend-only ones — those still render everything.

The list is duplicated across the `push` and `pull_request` triggers because GitHub Actions supports neither YAML anchors nor `!` negation in path filters.

### 2. One nondeterministic a11y finding

The a11y comment logic is already correct — `a11y.sh` fetches `compose-preview/a11y/main`, diffs, and stays silent when nothing changed. It simply had something to report.

The report is **bimodal**. Two stable `findings.json` blobs alternate, and whichever one a PR lands on decides whether the bot posts:

| blob | seen on |
|---|---|
| `1f5bdd25` | `compose-preview/a11y/main` (the baseline), PRs #1737, #1733 → silent |
| `23550c30` | PRs #1738, #1732, #1740 → full 74-preview report |

Diffing the two: **74 entries, 73 byte-identical, exactly one flaps.**

```
wearApp / SpeakerDetailsScreen_Devices - Large Round
  DuplicateSpeakableTextCheck (INFO) — present in one variant, absent in the other
  "This non-clickable item's speakable text: "John O'Reilly" is identical to
   that of 1 other item(s)."   ImageView desc="John O'Reilly"
```

`SubcomposeAsyncImage` labelled the speaker photo with the speaker's name, while the `SectionHeader` immediately below announces the same string — so a screen reader read it twice. Which of the `loading` / `error` / `success` slots has settled when the a11y tree is scanned is a race, and only some of them carried the label, hence the finding appearing and disappearing between runs on identical code.

The photo is decorative next to that header, so the label is dropped from all three slots. That removes a real finding *and* makes the flap structurally impossible rather than merely less likely.

## Test plan

- No behaviour change to rendered pixels — `contentDescription` is semantics-only, so the preview PNGs are unaffected.
- The a11y bot on this PR should now report the `SpeakerDetailsScreen` INFO as **resolved**, and subsequent unrelated PRs should stop getting the standing report.
- Workflow syntax: both triggers keep identical `paths-ignore` lists; this PR itself touches `wearApp/` so it is not skipped by its own filter.

## Not addressed here

The underlying renderer nondeterminism that also makes ~6 `wearApp` preview PNGs flap on unrelated PRs is a separate fix in `compose-ai-tools` (stitcher anchor selection + downloadable-font resolution), not something this repo can fix.

Two `MainActivity` previews are still masked by `missing-renders: warn` — a persistent render failure, not a transient one. Left alone here; it needs the CI render report to diagnose.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XYVcWMboPQeAHgw5Y7qCM)_