### PR TITLE
Update Koog to 1.1.1 (executors 1.1.1-beta)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,8 +54,8 @@ buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
 composeai-preview = "0.17.27"
-koogAgents = "1.0.0"
-koogPromptExecutorAll = "1.0.0-beta"
+koogAgents = "1.1.1"
+koogPromptExecutorAll = "1.1.1-beta"
 
 
 [libraries]


### PR DESCRIPTION
## Summary
Bumps Koog to align with the other Koog samples (FantasyPremierLeague, ClimateTraceKMP):
- `koog-agents` 1.0.0 → **1.1.1**
- prompt-executor modules (`prompt-executor-llms-all`, `-google-client`, `rag-*`) 1.0.0-beta → **1.1.1-beta**

## Test plan
- [x] `./gradlew :shared:build` (all KMP targets + shared tests)
- [x] `./gradlew :androidApp:assembleDebug`
- [x] `./gradlew :androidApp:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)