### PR TITLE
Update to Apollo Kotlin 5.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,8 @@ agp = "9.1.1"
 activity-compose = "1.13.0"
 androidx-lifecycle = "2.11.0"
 androidx-datastore = "1.2.1"
-apollo = "4.4.3"
+apollo = "5.0.1"
+apollo-adapters = "0.7.0"
 apollo-cache = "1.0.6"
 compose = "1.11.4"
 composeLifecyleRuntime="2.11.0"
@@ -82,7 +83,7 @@ androidx-wear-phone-interactions = { module = "androidx.wear:wear-phone-interact
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-runtime-ktx" }
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "work-runtime-ktx" }
 lifecyle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecyleRuntime" }
-apollo-adapters = { module = "com.apollographql.apollo:apollo-adapters" }
+apollo-adapters = { module = "com.apollographql.adapters:apollo-adapters-kotlinx-datetime", version.ref = "apollo-adapters" }
 apollo-normalized-cache-in-memory = { module = "com.apollographql.cache:normalized-cache", version.ref = "apollo-cache" }
 apollo-normalized-cache-sqlite = { module = "com.apollographql.cache:normalized-cache-sqlite", version.ref = "apollo-cache" }
 apollo-normalized-cache-compiler-plugin = { module = "com.apollographql.cache:normalized-cache-apollo-compiler-plugin", version.ref = "apollo-cache" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -204,16 +204,21 @@ apollo {
         generateDataBuilders.set(true)
         generateFragmentImplementations.set(true)
         generateSchema.set(true)
+        // Apollo 5 emits data builders to the test source set by default;
+        // ConfettiRepository uses them in main (optimistic mutation responses)
+        dataBuildersOutputDirConnection {
+            connectToKotlinSourceSet("commonMain")
+        }
         mapScalar(
             "LocalDateTime",
             "kotlinx.datetime.LocalDateTime",
-            "com.apollographql.apollo.adapter.KotlinxLocalDateTimeAdapter"
+            "com.apollographql.adapter.datetime.KotlinxLocalDateTimeAdapter"
         )
 
         mapScalar(
             "LocalDate",
             "kotlinx.datetime.LocalDate",
-            "com.apollographql.apollo.adapter.KotlinxLocalDateAdapter"
+            "com.apollographql.adapter.datetime.KotlinxLocalDateAdapter"
         )
 
         introspection {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -10,7 +10,8 @@ import com.apollographql.cache.normalized.apolloStore
 import com.apollographql.cache.normalized.optimisticUpdates
 import com.apollographql.cache.normalized.watch
 import com.benasher44.uuid.uuid4
-import dev.johnoreilly.confetti.type.buildBookmarks
+import dev.johnoreilly.confetti.builder.Data
+import dev.johnoreilly.confetti.builder.buildBookmarks
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter

--- a/shared/src/jvmMain/kotlin/Main.kt
+++ b/shared/src/jvmMain/kotlin/Main.kt
@@ -2,13 +2,13 @@ package dev.johnoreilly.confetti
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ApolloResponse
-import com.apollographql.apollo.api.DefaultFakeResolver
 import com.apollographql.apollo.api.FakeResolverContext
 import com.apollographql.apollo.testing.MapTestNetworkTransport
 import com.apollographql.cache.normalized.FetchPolicy
 import com.benasher44.uuid.uuid4
+import dev.johnoreilly.confetti.builder.Data
+import dev.johnoreilly.confetti.builder.resolver.DefaultFakeResolver
 import dev.johnoreilly.confetti.di.initKoin
-import dev.johnoreilly.confetti.schema.__Schema
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.LocalDateTime
@@ -22,10 +22,13 @@ private fun testModule() = module {
                 register(GetSessionsQuery(), ApolloResponse.Builder(
                     GetSessionsQuery(),
                     uuid4(),
-                    GetSessionsQuery.Data(object: DefaultFakeResolver(__Schema.all) {
+                ).data(
+                    GetSessionsQuery.Data(object: DefaultFakeResolver() {
                         override fun resolveLeaf(context: FakeResolverContext): Any {
                             return when(context.mergedField.type.rawType().name) {
-                                "LocalDateTime" -> return LocalDateTime(1970, 1, 1, 1, 1, 1)
+                                // Apollo 5 data builders serialize leaf values through the
+                                // response adapter, so return the scalar's wire form (String)
+                                "LocalDateTime" -> return LocalDateTime(1970, 1, 1, 1, 1, 1).toString()
                                 else -> super.resolveLeaf(context)
                             }
                         }


### PR DESCRIPTION
## Summary
Migrates Confetti from Apollo Kotlin 4.4.3 → 5.0.1. This brings Confetti in line with StarWars and MortyComposeKMM (already on 5.0.1). Apollo 5 has several breaking changes, so it's more than a version bump:

- **Core:** `apollo` 4.4.3 → 5.0.1.
- **Adapters:** `apollo-adapters` was removed from the core artifacts in v5 and moved to a separate library — repointed to `com.apollographql.adapters:apollo-adapters-kotlinx-datetime:0.7.0`, and updated the `mapScalar` adapter classes (`com.apollographql.apollo.adapter.*` → `com.apollographql.adapter.datetime.*`).
- **Data builders:** now generated into a separate `.builder` package, and emitted to the *test* source set by default. Confetti uses them in production (`ConfettiRepository`, optimistic bookmark mutations), so added `dataBuildersOutputDirConnection { connectToKotlinSourceSet("commonMain") }`.
- **FakeResolver (`Main.kt`):** `DefaultFakeResolver` is now generated (`…builder.resolver`, no-arg ctor); import the `.builder` `Data` DSL; use the 2-arg `ApolloResponse.Builder` + `.data()` (the 3-arg ctor is now an error-level deprecation).

The `com.apollographql.cache:normalized-cache` (1.0.6) and `com.apollographql.execution` (0.1.2) libraries both work with Apollo 5 — confirmed by the Apollo maintainer and verified building here.

## Test plan
- [x] `./gradlew :shared:jvmTest` (+ shared iOS & wasm compile)
- [x] `./gradlew :backend:service-graphql:build :backend:service-import:build` (apollo-execution)
- [x] `./gradlew :androidApp:assembleDebug :wearApp:assembleDebug`
- [x] `./gradlew :compose-web:wasmJsBrowserDistribution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)