### PR TITLE
chore(deps): bump compose-preview to 0.19.6

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.27
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.6
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.17.27
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.6
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.17.27
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.6
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.17.27"
+composeai-preview = "0.19.6"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 


### PR DESCRIPTION
Bumps `compose-preview` from `0.17.27` to `0.19.6`.

**No longer blocked** — [yschimke/compose-ai-tools#2925](https://github.com/yschimke/compose-ai-tools/pull/2925) merged, `v0.19.6` is tagged, and the Maven artifacts are live on Central (both the plugin marker and `preview-annotations` resolve). CI has been re-triggered against the published version.

## What moves

Four pins, from `0.17.27`:

| where | what |
|---|---|
| `gradle/libs.versions.toml` | `composeai-preview` — drives both the plugin id and `preview-annotations` via `version.ref` |
| `.github/workflows/compose-preview.yml` ×2 | `.github/actions/apply@v…` |
| `.github/workflows/design-artifacts.yml` | `.github/actions/install@v…` |

The workflow pins are separate from the catalog version but both carry comments saying the CLI and plugin must "stay lockstep … so preview discovery doesn't break on a minor skew". Bumping only `libs.versions.toml` would leave a 0.17.27 action driving a 0.19.6 plugin — exactly the skew those comments guard against — so all four move together.

## Why 0.19.6 specifically

0.19.5 was tagged at `a199cd3`, **before** the two fixes this bump exists to pick up. `git log a199cd3..main` puts both after it:

* `79a45bd` — `fix(render): showBackground respects the preview's night uiMode` (#2922)
* `32c2055` — `fix(serve): reject a themeProvider the catalog never declared` (#2923)

Without the first, every dark-mode sticker in the published catalog renders on a white sheet — so regenerating `design-artifacts` on 0.19.5 would spend the render and change nothing.

## Verification

Rendered the full catalog locally on **0.19.5** to prove the 0.17.27 → 0.19.x jump on its own: discovery and rendering both work, all previews produced PNGs, and the renderer now shards (`RobolectricRenderTest_Shard1`, new since 0.17.27). The only local failure was Gradle's HTML test-report writer choking on the em-dash in `AndroidSessionDetailPreview_Phone-—-light` against this container's `POSIX` default charset — the PNGs are all written before that step, and CI runs UTF-8, so it does not reproduce there.

0.19.6 is one patch release on top of that, and is what CI is now exercising.

## Note on the earlier red CI

The first two runs failed entirely on the unpublished version, in two layers: the preview jobs died at GitHub action resolution (`unable to resolve action yschimke/compose-ai-tools@v0.19.6`), and the build jobs at Gradle plugin resolution from the **root** `build.gradle.kts` — which is why even `:backend:*` and the iOS `build` (via Xcode's run-script phase) went red. All of it was the one missing version, and it clears now that the artifacts are published.