### PR TITLE
fix(previews): let an overridden preview theme turn the app's own theme off

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
@@ -22,47 +22,67 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * with, so a provider that read the ambient mode would make half the options no-ops. Each wraps a
  * production theme function — [ConfettiTheme] for the three colour schemes, [ConferenceMaterialTheme]
  * for the seeded app-root theme — so these can't drift from what the app renders.
+ *
+ * Every provider goes through [Scheme] or [ConferenceSeed], both of which mark the theme they
+ * installed as an override so the preview body's own theme stands down instead of shadowing it —
+ * see [PreviewThemeOverrideInstalled]. Without that mark the switcher renders identical pixels for
+ * every entry here, which is exactly the bug this indirection exists to prevent.
  */
+
+/** One of [ConfettiTheme]'s three colour schemes, installed as a preview theme override. */
+@Composable
+private fun Scheme(
+    dark: Boolean,
+    androidTheme: Boolean = false,
+    disableDynamicTheming: Boolean = true,
+    content: @Composable () -> Unit,
+) =
+    ConfettiTheme(
+        darkTheme = dark,
+        androidTheme = androidTheme,
+        disableDynamicTheming = disableDynamicTheming,
+    ) {
+        PreviewThemeOverrideInstalled(content)
+    }
+
 @ThemeCatalog(name = "Confetti brand Light", group = "Confetti")
 class ConfettiBrandLightThemeCatalog : PreviewWrapperProvider {
     @Composable
-    override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = false, disableDynamicTheming = true, content = content)
+    override fun Wrap(content: @Composable () -> Unit) = Scheme(dark = false, content = content)
 }
 
 @ThemeCatalog(name = "Confetti brand Dark", group = "Confetti")
 class ConfettiBrandDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
-    override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = true, disableDynamicTheming = true, content = content)
+    override fun Wrap(content: @Composable () -> Unit) = Scheme(dark = true, content = content)
 }
 
 @ThemeCatalog(name = "Android Light", group = "Android")
 class AndroidLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = false, androidTheme = true, content = content)
+        Scheme(dark = false, androidTheme = true, content = content)
 }
 
 @ThemeCatalog(name = "Android Dark", group = "Android")
 class AndroidDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = true, androidTheme = true, content = content)
+        Scheme(dark = true, androidTheme = true, content = content)
 }
 
 @ThemeCatalog(name = "Dynamic Light", group = "Material You")
 class DynamicLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = false, disableDynamicTheming = false, content = content)
+        Scheme(dark = false, disableDynamicTheming = false, content = content)
 }
 
 @ThemeCatalog(name = "Dynamic Dark", group = "Material You")
 class DynamicDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiTheme(darkTheme = true, disableDynamicTheming = false, content = content)
+        Scheme(dark = true, disableDynamicTheming = false, content = content)
 }
 
 /**
@@ -86,8 +106,9 @@ private fun ConferenceSeed(seed: String, dark: Boolean, content: @Composable () 
     ConferenceMaterialTheme(
         seedColorString = seed,
         darkThemeConfig = if (dark) DarkThemeConfig.DARK else DarkThemeConfig.LIGHT,
-        content = content,
-    )
+    ) {
+        PreviewThemeOverrideInstalled(content)
+    }
 
 @ThemeCatalog(name = "KotlinConf Light", group = "Conference")
 class KotlinConfLightThemeCatalog : PreviewWrapperProvider {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/Theme.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/Theme.kt
@@ -168,6 +168,15 @@ fun ConfettiTheme(
     disableDynamicTheming: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    // A `@ThemeCatalog` provider has already installed the theme the preview viewer asked for;
+    // installing ours over the top would shadow it and pin every theme in the switcher to identical
+    // pixels. Stand down, clearing the flag so deliberately nested theming still applies. Always
+    // false in production. See `PreviewThemeOverride` in `:shared`.
+    if (LocalPreviewThemeOverride.current) {
+        ConsumePreviewThemeOverride(content)
+        return
+    }
+
     val (colorScheme, backgroundTheme) = mobileThemes(androidTheme, darkTheme, disableDynamicTheming)
 
     CompositionLocalProvider(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceMaterialTheme.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceMaterialTheme.kt
@@ -26,6 +26,15 @@ fun ConferenceMaterialTheme(
         return
     }
 
+    // A `@ThemeCatalog` provider has already installed the theme the preview viewer asked for;
+    // installing ours over the top would shadow it and pin every theme in the switcher to identical
+    // pixels. Stand down, clearing the flag so deliberately nested theming still applies. Always
+    // false in production. See [LocalPreviewThemeOverride].
+    if (LocalPreviewThemeOverride.current) {
+        ConsumePreviewThemeOverride(content)
+        return
+    }
+
     val shouldUseDarkTheme = shouldUseDarkTheme(darkThemeConfig)
 
     var seedColor = Color(0xFF008000)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/PreviewThemeOverride.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/PreviewThemeOverride.kt
@@ -1,0 +1,60 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * The switch that lets preview tooling replace a preview's theme.
+ *
+ * **The problem this solves.** Every design-catalog `@Preview` installs Confetti's theme in its own
+ * body — `ConfettiThemeFixed { … }` on Wear, `CatalogTheme { … }` on the phone. That is deliberate:
+ * it is what makes the Android Studio preview pane and a plain `compose-preview` render show the
+ * real app theme with no annotation and no tooling in the loop. But `compose-preview serve` applies
+ * an alternative theme by *wrapping* the preview function in a `@ThemeCatalog` provider, and a theme
+ * installed in the body composes **inside** that wrapper and shadows it. Every entry in the viewer's
+ * **Theme** select therefore rendered byte-identical pixels — the switcher looked live and did
+ * nothing.
+ *
+ * **The mechanism.** The theme-catalog providers install their theme and then mark it as an override
+ * with [PreviewThemeOverrideInstalled]. Confetti's own theme functions check
+ * [LocalPreviewThemeOverride] and, when it is set, step aside rather than installing a second
+ * `MaterialTheme` over the top. The default theme stays exactly where it is — in the preview body —
+ * so nothing changes for Studio, for the CLI, or for the app itself; the theme only yields when
+ * something outside deliberately claimed it.
+ *
+ * **Yielding consumes the flag** ([ConsumePreviewThemeOverride]), so only the *outermost* app theme
+ * steps aside. A deliberately nested theme deeper in the tree — `ConferencesView` tinting each row
+ * with that conference's seed colour, say — still installs, so an override re-themes the base
+ * without flattening intentional per-item theming.
+ *
+ * In production nothing ever provides `true`: the default is `false`, so `ConfettiTheme` and friends
+ * install normally and this costs a single composition-local read.
+ *
+ * Adding a new theme function to the app? Give it the same two-line check, or the preview theme
+ * switcher will silently stop working for anything that uses it.
+ */
+val LocalPreviewThemeOverride: ProvidableCompositionLocal<Boolean> =
+    compositionLocalOf { false }
+
+/**
+ * Marks the theme installed by the enclosing `@ThemeCatalog` / `@WearThemeCatalog` provider as an
+ * override, so the app theme inside [content] stands down instead of shadowing it.
+ *
+ * Call this **inside** the provider's own theme, wrapping the preview content — not around the
+ * provider's theme call, which would make that theme stand down too.
+ */
+@Composable
+fun PreviewThemeOverrideInstalled(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+}
+
+/**
+ * Runs [content] with the override flag cleared — what an app theme function calls when it stands
+ * down, so that only the outermost one does and deliberate nested theming still applies.
+ */
+@Composable
+fun ConsumePreviewThemeOverride(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalPreviewThemeOverride provides false, content = content)
+}

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeCatalogs.kt
@@ -2,6 +2,7 @@ package dev.johnoreilly.confetti.wear.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import dev.johnoreilly.confetti.ui.PreviewThemeOverrideInstalled
 import ee.schimke.composeai.preview.WearThemeCatalog
 
 /**
@@ -26,38 +27,49 @@ import ee.schimke.composeai.preview.WearThemeCatalog
  * the app resolves at runtime via [conferenceThemeFor] — the ids are prefix-matched, so a rolling
  * edition can't drift them. `group = "Conference"` buckets the four curated identities into their
  * own `<optgroup>` beneath the stock Confetti theme.
+ *
+ * Every provider goes through [ConferenceThemeOverride], which marks the theme it installed as an
+ * override so the preview body's own theme stands down instead of shadowing it — see
+ * `PreviewThemeOverride` in `:shared`. Without that mark the switcher renders identical pixels for
+ * every entry here, which is exactly the bug this indirection exists to prevent.
  */
+@Composable
+private fun ConferenceThemeOverride(conferenceId: String?, content: @Composable () -> Unit) =
+    ConfettiConferenceTheme(conferenceId = conferenceId) {
+        PreviewThemeOverrideInstalled(content)
+    }
+
 @WearThemeCatalog(name = "Confetti (default)", group = "Confetti")
 class ConfettiDefaultThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiConferenceTheme(conferenceId = null, content = content)
+        ConferenceThemeOverride(conferenceId = null, content = content)
 }
 
 @WearThemeCatalog(name = "KotlinConf", group = "Conference")
 class KotlinConfThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiConferenceTheme(conferenceId = "kotlinconf2025", content = content)
+        ConferenceThemeOverride(conferenceId = "kotlinconf2025", content = content)
 }
 
 @WearThemeCatalog(name = "AndroidMakers", group = "Conference")
 class AndroidMakersThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiConferenceTheme(conferenceId = "androidmakers2025", content = content)
+        ConferenceThemeOverride(conferenceId = "androidmakers2025", content = content)
 }
 
 @WearThemeCatalog(name = "Droidcon", group = "Conference")
 class DroidconThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiConferenceTheme(conferenceId = "droidconlondon2025", content = content)
+        ConferenceThemeOverride(conferenceId = "droidconlondon2025", content = content)
 }
 
 @WearThemeCatalog(name = "DevFest", group = "Conference")
 class DevFestThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) =
-        ConfettiConferenceTheme(conferenceId = "devfest2025", content = content)
+        ConferenceThemeOverride(conferenceId = "devfest2025", content = content)
 }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeFixed.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ConfettiThemeFixed.kt
@@ -4,13 +4,29 @@ import androidx.compose.runtime.Composable
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Typography
+import dev.johnoreilly.confetti.ui.ConsumePreviewThemeOverride
+import dev.johnoreilly.confetti.ui.LocalPreviewThemeOverride
 
+/**
+ * The single funnel every Confetti Wear theme goes through — [ConfettiTheme] and the preview
+ * scaffold both end up here, so it is also the one place that has to honour a preview theme
+ * override.
+ *
+ * When [LocalPreviewThemeOverride] is set, a `@WearThemeCatalog` provider has already installed the
+ * theme the viewer asked for; installing ours on top would shadow it and pin every theme in the
+ * switcher to identical pixels. Stand down instead, clearing the flag so a deliberately nested
+ * theme deeper in the tree still applies. See `PreviewThemeOverride` in `:shared`.
+ */
 @Composable
 fun ConfettiThemeFixed(
     colors: ColorScheme = ColorScheme(),
     typography: Typography = Typography(),
     content: @Composable () -> Unit,
 ) {
+    if (LocalPreviewThemeOverride.current) {
+        ConsumePreviewThemeOverride(content)
+        return
+    }
     MaterialTheme(colorScheme = colors, typography = typography) {
         content()
     }

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/ui/PreviewThemeOverrideTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/ui/PreviewThemeOverrideTest.kt
@@ -1,0 +1,114 @@
+package dev.johnoreilly.confetti.wear.ui
+
+import android.app.Application
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.wear.compose.material3.MaterialTheme
+import dev.johnoreilly.confetti.ui.PreviewThemeOverrideInstalled
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Guards the preview theme override switch — see `PreviewThemeOverride` in `:shared`.
+ *
+ * The design catalog's previews install Confetti's theme in their own body, which is what makes the
+ * Android Studio preview pane and a plain `compose-preview` render show the real app theme. The
+ * preview server applies an alternative theme by *wrapping* the preview, so without the opt-out that
+ * body theme composes inside the wrapper and shadows it — and every entry in the viewer's Theme
+ * select renders identical pixels. These tests pin the three behaviours that stops.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    // A bare Application: the real ConfettiApplication configures notification bridging, which
+    // throws off a wearable device, and the Koin test app can't be started once per test in a
+    // class. Nothing here needs either — these tests only read a resolved MaterialTheme.
+    application = Application::class,
+    sdk = [34],
+)
+class PreviewThemeOverrideTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    /**
+     * Composes each of [cases] once and returns the `MaterialTheme.colorScheme.primary` each one
+     * resolves to. They all go through a single `setContent` — the rule allows only one per test —
+     * as sibling subtrees, which is fine because the probe emits no UI, it just reads the theme.
+     */
+    private fun primariesOf(
+        vararg cases: @Composable (@Composable () -> Unit) -> Unit,
+    ): List<Color> {
+        val captured = arrayOfNulls<Color>(cases.size)
+        composeRule.setContent {
+            cases.forEachIndexed { i, case ->
+                case { captured[i] = MaterialTheme.colorScheme.primary }
+            }
+        }
+        composeRule.waitForIdle()
+        return captured.map { requireNotNull(it) { "a case never composed" } }
+    }
+
+    /** A preview body that installs the app theme itself, as every catalog preview does. */
+    @Composable
+    private fun BodyTheme(probe: @Composable () -> Unit) {
+        ConfettiThemeFixed { probe() }
+    }
+
+    /** What a `@WearThemeCatalog` provider wraps a preview in. */
+    @Composable
+    private fun Override(conferenceId: String?, content: @Composable () -> Unit) {
+        ConfettiConferenceTheme(conferenceId = conferenceId) {
+            PreviewThemeOverrideInstalled(content)
+        }
+    }
+
+    @Test
+    fun `body theme stands down under an override`() {
+        val (overrideOnly, overrideThenBody) = primariesOf(
+            // The override alone — the look the viewer asked for.
+            { probe -> Override("kotlinconf2025") { probe() } },
+            // The same override, with a preview body that also installs the app theme. The body
+            // must yield, so this has to land on exactly the same colour.
+            { probe -> Override("kotlinconf2025") { BodyTheme(probe) } },
+        )
+
+        assertEquals(overrideOnly, overrideThenBody)
+    }
+
+    @Test
+    fun `body theme still applies with no override`() {
+        val (overrideOnly, bodyOnly) = primariesOf(
+            { probe -> Override("kotlinconf2025") { probe() } },
+            { probe -> BodyTheme(probe) },
+        )
+
+        // Nothing claimed the theme, so the body's own theme is what renders — the Android Studio /
+        // CLI / production path, which must NOT look like the override.
+        assertNotEquals(overrideOnly, bodyOnly)
+    }
+
+    @Test
+    fun `deliberate nested theming survives an override`() {
+        val (nested, droidconAlone) = primariesOf(
+            // Standing down consumes the flag, so only the OUTERMOST app theme yields. A theme
+            // nested deeper on purpose — ConferencesView tinting each row by that conference's seed
+            // colour — still applies rather than being flattened into the override.
+            { probe ->
+                Override("kotlinconf2025") {
+                    ConfettiThemeFixed {
+                        ConfettiConferenceTheme(conferenceId = "droidconlondon2025") { probe() }
+                    }
+                }
+            },
+            { probe -> Override("droidconlondon2025") { probe() } },
+        )
+
+        assertEquals(droidconAlone, nested)
+    }
+}


### PR DESCRIPTION
## The bug

The **Theme** selector on the published design catalogs does nothing. Every entry renders byte-identical pixels.

Reproducible against the live server right now:

```
GET /confetti-wear/render/sessioncard__ideal__default__compact.png
  ?themeProvider=…KotlinConfThemeCatalog        → md5 801c6414…
  ?themeProvider=…DevFestThemeCatalog           → md5 801c6414…
  ?themeProvider=…ConfettiDefaultThemeCatalog   → md5 801c6414…
  ?themeProvider=com.bogus.NotAThemeCatalog     → 400
```

Same on `confetti-mobile`, where a **light** and a **dark** provider also return identical bytes. It's not the toolchain: the `wear-m3` sample catalog on the same box *does* differ per theme, and the `400` proves the real providers resolve and get invoked.

These two URLs are live and currently render the same image, which is the bug — after this lands and the catalog regenerates they should differ:

| KotlinConf | DevFest |
|---|---|
| [](https://preview.coo.ee/confetti-wear/render/typography__ideal__default__compact.png?themeProvider=dev.johnoreilly.confetti.wear.ui.KotlinConfThemeCatalog) | [](https://preview.coo.ee/confetti-wear/render/typography__ideal__default__compact.png?themeProvider=dev.johnoreilly.confetti.wear.ui.DevFestThemeCatalog) |

That's the *Typography* specimen, which is supposed to show JetBrains Mono for KotlinConf and Google Sans Flex for DevFest.

## Cause

Every catalog `@Preview` installs the theme in its own body — `ConfettiThemeFixed { … }` on Wear, `CatalogTheme { … }` on the phone. That's deliberate and worth keeping: it's what makes the Android Studio preview pane and a plain `compose-preview` render show the real app theme with no annotation and no tooling in the loop.

But the preview server applies an alternative theme by *wrapping* the preview function, so the body's `MaterialTheme` composes **inside** that wrapper and shadows it. `ConfettiThemeFixed` is `MaterialTheme(ColorScheme(), Typography())` — hardcoded Wear defaults, reading nothing from outside — so whatever the daemon wrapped around it contributes exactly nothing.

## Fix

Keep the theme where it is and give it an off switch.

`LocalPreviewThemeOverride` (in `:shared`, so Wear, phone and the CMP targets share one definition) defaults to `false`. Android Studio, the CLI, and the app itself are untouched — the default theme is still the one the preview body installs.

The `@ThemeCatalog` / `@WearThemeCatalog` providers mark the theme they install with `PreviewThemeOverrideInstalled`, and `ConfettiThemeFixed` / `ConfettiTheme` / `ConferenceMaterialTheme` stand down when they see it rather than installing a second theme on top.

Standing down **consumes** the flag, so only the outermost app theme yields. Deliberately nested theming still applies — `ConferencesView` keeps tinting each row with that conference's own seed colour under an override instead of the override flattening it.

Two things fall out of putting this in the theme functions rather than on each preview: it covers previews an annotation-based fix would have missed (`AndroidScreenPreviews` among them), and `CatalogTheme`'s Coil preview handler survives an override for free — only the theme yields, not the rest of the preview environment.

**Tradeoff worth flagging:** the coupling is implicit. A new theme function that forgets the two-line check silently breaks the switcher again. There's a note in the `LocalPreviewThemeOverride` KDoc, but it's a convention, not a gate. The alternative — declaring the theme per-preview via androidx's `@PreviewWrapper` — is explicit and machine-readable, but needs an annotation on ~30 previews and shifts 15 Wear stickers onto a different type ramp.

## Test plan

- `:wearApp` + `:androidApp` + `:shared` compile clean.
- `PreviewThemeOverrideTest` (new, 3 tests, all pass) pins: the body theme stands down under an override; it still applies with no override; nested theming survives an override.
- Re-rendered the whole Wear catalog via `:wearApp:composePreviewRender` — **129/129 PNGs byte-identical to `main`**. No pixel movement in the default renders.
- Probed the real override path with a throwaway preview carrying `@PreviewWrapper(KotlinConfThemeCatalog::class)` — the same daemon code path (`InvokeWithOptionalWrapper`) that `?themeProvider=` takes. Three-way comparison:
  - wrapper + body theme **==** wrapper alone (the body yielded)
  - wrapper + body theme **!=** body theme alone (the override won)

  It rendered in KotlinConf purple and JetBrains Mono instead of the body's stock Wear theme. Probe deleted afterwards; the unit test is the permanent guard.

Note the switcher only becomes live on the published site once `design-artifacts/confetti-wear` re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhWssk26QYPNjkx7vcbKC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhWssk26QYPNjkx7vcbKC6)_