### PR TITLE
Disable embeddings / semantic session search for now

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/agent/ConferenceAgentProvider.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/agent/ConferenceAgentProvider.kt
@@ -21,6 +21,9 @@ class ConferenceAgentProvider(
     private val promptExecutor: PromptExecutor,
     private val embedder: Embedder,
     private val embeddingCache: EmbeddingCache?,
+    // Embeddings/semantic search temporarily disabled. Flip to true to re-enable
+    // SearchSessionsTool and the semantic-search guidance in the system prompt.
+    private val embeddingsEnabled: Boolean = false,
 ) : AgentProvider {
 
     override val description: String =
@@ -33,19 +36,49 @@ class ConferenceAgentProvider(
         onAssistantMessage: suspend (String) -> String,
     ): AIAgent<String, String> {
 
-        val sessionIndex = SessionEmbeddingIndex(
-            repository = repository,
-            conference = conference,
-            embedder = embedder,
-            cache = embeddingCache,
-        )
+        val sessionIndex = if (embeddingsEnabled) {
+            SessionEmbeddingIndex(
+                repository = repository,
+                conference = conference,
+                embedder = embedder,
+                cache = embeddingCache,
+            )
+        } else {
+            null
+        }
 
         val toolRegistry = ToolRegistry {
             tool(GetSessionsTool(repository, conference))
-            tool(SearchSessionsTool(sessionIndex))
+            if (sessionIndex != null) {
+                tool(SearchSessionsTool(sessionIndex))
+            }
             tool(GetSessionByIdTool(repository, conference))
             tool(GetSpeakersTool(repository, conference))
             tool(GetSpeakerByIdTool(repository, conference))
+        }
+
+        val sessionToolGuidance = if (embeddingsEnabled) {
+            """
+
+            Choosing between session tools:
+            - Default to SearchSessionsTool whenever the user asks about a topic,
+              theme, or area of interest — including single-word topics like "AI",
+              "testing", "UI" or "performance". Semantic search finds related talks
+              even when they use different vocabulary.
+            - Each SearchSessionsTool result includes a similarity score. Treat
+              scores above ~0.5 as strong matches; consider including borderline
+              results (down to ~0.3) when the user asks for "all" related talks.
+            - Only use GetSessionsTool when the user explicitly wants a verbatim
+              string match (e.g. "find talks with 'Kotlin Multiplatform' in the
+              title").
+            """.trimIndent()
+        } else {
+            """
+
+            Use GetSessionsTool to find sessions by a word or phrase in their title
+            or description. Try a few relevant keywords when the user asks about a
+            topic or theme.
+            """.trimIndent()
         }
 
         val agentConfig = AIAgentConfig(
@@ -57,19 +90,7 @@ class ConferenceAgentProvider(
                     Use the provided tools to look up sessions and speakers — do not invent ids,
                     titles or any other details. When recommending sessions, reference them by
                     title and include their speakers, start time and room when available.
-
-                    Choosing between session tools:
-                    - Default to SearchSessionsTool whenever the user asks about a topic,
-                      theme, or area of interest — including single-word topics like "AI",
-                      "testing", "UI" or "performance". Semantic search finds related talks
-                      even when they use different vocabulary.
-                    - Each SearchSessionsTool result includes a similarity score. Treat
-                      scores above ~0.5 as strong matches; consider including borderline
-                      results (down to ~0.3) when the user asks for "all" related talks.
-                    - Only use GetSessionsTool when the user explicitly wants a verbatim
-                      string match (e.g. "find talks with 'Kotlin Multiplatform' in the
-                      title").
-                    """.trimIndent(),
+                    """.trimIndent() + "\n" + sessionToolGuidance,
                 )
             },
             model = llModel,


### PR DESCRIPTION
## Summary
- Gates the embedding-backed `SearchSessionsTool` behind an `embeddingsEnabled` flag (default `false`) in `ConferenceAgentProvider`.
- When off, the `SessionEmbeddingIndex` is never built and **no Gemini embedding API calls are made**.
- The agent falls back to keyword/regex matching via `GetSessionsTool`, and the system prompt is adjusted so it no longer references the (now unregistered) semantic-search tool.
- Embedder DI wiring (`ApiEmbedder` / `GeminiEmbedding001` / `EmbeddingCache`) and the `SessionEmbeddingIndex` / `SearchSessionsTool` classes are left intact — re-enabling is a one-line flag flip.

## Test plan
- [x] `./gradlew :shared:compileKotlinJvm` passes
- [ ] Verify agent still answers session/speaker queries (keyword search path)
- [ ] Confirm no embedding API calls occur at runtime with the flag off