### PR TITLE
Persist desktop window size and position across launches

### DIFF
--- a/compose-desktop/src/jvmMain/kotlin/Main.kt
+++ b/compose-desktop/src/jvmMain/kotlin/Main.kt
@@ -1,7 +1,11 @@
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.apollographql.apollo.ApolloClient
@@ -9,9 +13,11 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.lifecycle.LifecycleController
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.russhwolf.settings.ObservableSettings
 import dev.johnoreilly.confetti.decompose.DefaultAppComponent
 import dev.johnoreilly.confetti.di.initKoin
 import dev.johnoreilly.confetti.ui.App
+import kotlinx.coroutines.flow.collectLatest
 import org.koin.dsl.module
 
 
@@ -38,11 +44,37 @@ fun main() {
             )
         }
 
+    val settings = koin.get<ObservableSettings>()
+
     application {
         val windowState = rememberWindowState(
-            width = 600.dp,
-            height = 800.dp
+            width = settings.getFloat(KEY_WINDOW_WIDTH, 600f).dp,
+            height = settings.getFloat(KEY_WINDOW_HEIGHT, 800f).dp,
+            position = if (settings.hasKey(KEY_WINDOW_X) && settings.hasKey(KEY_WINDOW_Y)) {
+                WindowPosition(
+                    x = settings.getFloat(KEY_WINDOW_X, 0f).dp,
+                    y = settings.getFloat(KEY_WINDOW_Y, 0f).dp,
+                )
+            } else {
+                WindowPosition.PlatformDefault
+            },
         )
+
+        // Persist size/position whenever the user resizes or moves the window,
+        // so it reopens where it was left.
+        LaunchedEffect(windowState) {
+            snapshotFlow { windowState.size to windowState.position }
+                .collectLatest { (size, position) ->
+                    if (size.isSpecified) {
+                        settings.putFloat(KEY_WINDOW_WIDTH, size.width.value)
+                        settings.putFloat(KEY_WINDOW_HEIGHT, size.height.value)
+                    }
+                    if (position.isSpecified) {
+                        settings.putFloat(KEY_WINDOW_X, position.x.value)
+                        settings.putFloat(KEY_WINDOW_Y, position.y.value)
+                    }
+                }
+        }
 
         Window(
             onCloseRequest = ::exitApplication,
@@ -61,5 +93,10 @@ fun main() {
         }
     }
 }
+
+private const val KEY_WINDOW_WIDTH = "window_width"
+private const val KEY_WINDOW_HEIGHT = "window_height"
+private const val KEY_WINDOW_X = "window_x"
+private const val KEY_WINDOW_Y = "window_y"
 
 


### PR DESCRIPTION
## Summary
- The desktop app previously reopened at a hardcoded **600×800** on every launch, discarding any resize.
- Now the window size and position are restored from `ObservableSettings` on startup and saved whenever the user resizes or moves the window, so it reopens as it was left.
- Falls back to the previous 600×800 default and platform-default position on first run (no saved state).

## Implementation
- Reuses the JVM-registered `ObservableSettings` (`PreferencesSettings` over `java.util.prefs`) already provided by the shared Koin module — no new dependency.
- Reads saved values into `rememberWindowState`, and a `snapshotFlow` on `windowState.size`/`position` persists changes.

## Test plan
- [x] `./gradlew :compose-desktop:compileKotlinJvm` passes
- [ ] Launch desktop app, resize/move window, close, relaunch → opens at same size/position
- [ ] First run with no saved state opens at 600×800 in platform-default position