### PR TITLE
Fix theme foundation preview overrides

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ConfettiThemeCatalogs.kt
@@ -9,13 +9,13 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * `@ThemeCatalog` providers — the phone app's **alternative themes**, declared so the preview
  * server can re-render *any* preview under any of them.
  *
- * Where [ThemeFoundationPreviews] bakes one static specimen sticker per theme, these providers make
- * the axis interactive: `compose-preview serve` lifts every `@ThemeCatalog`-annotated
- * [PreviewWrapperProvider] into the viewer's **Theme** select, and picking one re-renders the
- * currently open preview through that provider's `Wrap` — so you can open `ScheduleScreenPreview`
- * and flip it between the brand purple, the Android green, Material You and a conference seed, and
- * see the live result rather than a pre-baked PNG. (Daemon-backed: the control is live on a local
- * `serve` session, disabled on a published static bundle.)
+ * Where [ThemeFoundationPreviews] bakes fixed reference stickers plus one live "Current Theme"
+ * specimen, these providers make the axis interactive: `compose-preview serve` lifts every
+ * `@ThemeCatalog`-annotated [PreviewWrapperProvider] into the viewer's **Theme** select, and picking
+ * one re-renders the currently open preview through that provider's `Wrap` — so you can open
+ * `ScheduleScreenPreview` and flip it between the brand purple, the Android green, Material You and
+ * a conference seed, and see the live result rather than a pre-baked PNG. (Daemon-backed: the
+ * control is live on a local `serve` session, disabled on a published static bundle.)
  *
  * Light and dark are declared as separate providers rather than left to `isSystemInDarkTheme()`:
  * the theme select is a *discrete* axis applied on top of whatever `uiMode` the preview renders

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ThemeFoundationPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ThemeFoundationPreviews.kt
@@ -36,12 +36,15 @@ import androidx.compose.ui.unit.dp
  *    ([dev.johnoreilly.confetti.ui.App]) actually installs: a scheme generated from the active
  *    **conference's seed colour**, so the app re-tints per conference the way the Wear app does.
  *
- * Every preview below goes through the production theme function rather than re-declaring a
- * scheme, so a swatch here is by construction the colour the app paints. Kept in the **main**
- * source set for the `ee.schimke.composeai.preview` plugin, registered in
- * `catalog.mobile.spec.json`, and mirrored by the `@ThemeCatalog` providers in
- * [ConfettiThemeCatalogs] so `compose-preview serve` can re-render any preview live under any of
- * them.
+ * The four named-theme previews below go through the production theme function rather than
+ * re-declaring a scheme, so a swatch here is by construction the colour the app paints. They also
+ * clear any preview-server theme override before installing their theme: these are reference
+ * specimens, so selecting a different theme in the viewer must not change their identity. The
+ * separate [ThemeFoundationCurrentPreview] deliberately does yield to that selector and shows the
+ * currently selected theme instead.
+ *
+ * Kept in the **main** source set for the `ee.schimke.composeai.preview` plugin and registered in
+ * `catalog.mobile.spec.json`.
  */
 
 /** A colour-role swatch: the role colour carrying its on-role label, token name beneath. */
@@ -142,39 +145,67 @@ private fun ThemeFoundation(title: String, tagline: String) {
  */
 private const val CONFERENCE_SEED = "0xFF7F52FF"
 
+/**
+ * Keeps an identity specimen independent from the preview viewer's selected theme.
+ *
+ * Theme-catalog providers set [LocalPreviewThemeOverride] so ordinary preview bodies yield to the
+ * viewer. Clearing it outside the specimen's production theme makes that theme install normally,
+ * preserving the named reference swatches while leaving the rest of the catalog override-aware.
+ */
+@Composable
+private fun FixedTheme(content: @Composable () -> Unit) {
+    ConsumePreviewThemeOverride(content)
+}
+
 @CatalogModes
 @Composable
 fun ThemeFoundationDefaultPreview() {
-    // Dynamic explicitly off → the Confetti brand scheme, whatever the render host's wallpaper is.
-    ConfettiTheme(disableDynamicTheming = true) {
-        ThemeFoundation("Confetti brand", "Purple / orange / blue · the default scheme")
+    FixedTheme {
+        // Dynamic explicitly off → the brand scheme, whatever the render host's wallpaper is.
+        ConfettiTheme(disableDynamicTheming = true) {
+            ThemeFoundation("Confetti brand", "Purple / orange / blue · the default scheme")
+        }
     }
 }
 
 @CatalogModes
 @Composable
 fun ThemeFoundationAndroidPreview() {
-    ConfettiTheme(androidTheme = true) {
-        ThemeFoundation("Android", "Green / teal · the Android-branded scheme")
+    FixedTheme {
+        ConfettiTheme(androidTheme = true, disableDynamicTheming = true) {
+            ThemeFoundation("Android", "Green / teal · the Android-branded scheme")
+        }
     }
 }
 
 @CatalogModes
 @Composable
 fun ThemeFoundationDynamicPreview() {
-    // Material You: `colorScheme()` resolves `dynamic{Light,Dark}ColorScheme(context)` on API 31+,
-    // and falls back to the brand scheme below that — so on an older render host this sticker is
-    // the brand scheme, which is exactly what the app would show there too.
-    ConfettiTheme(disableDynamicTheming = false) {
-        ThemeFoundation("Dynamic (Material You)", "Wallpaper-derived on Android 12+")
+    FixedTheme {
+        // Material You resolves the host wallpaper on API 31+, with the brand scheme as fallback.
+        ConfettiTheme(disableDynamicTheming = false) {
+            ThemeFoundation("Dynamic (Material You)", "Wallpaper-derived on Android 12+")
+        }
     }
 }
 
 @CatalogModes
 @Composable
 fun ThemeFoundationConferenceSeedPreview() {
-    // The real app-root theme: a scheme generated from the active conference's seed colour.
-    ConferenceMaterialTheme(seedColorString = CONFERENCE_SEED) {
-        ThemeFoundation("Conference seed", "Generated from conference.themeColor · #7F52FF")
+    FixedTheme {
+        // The real app-root theme: a scheme generated from the active conference's seed colour.
+        ConferenceMaterialTheme(seedColorString = CONFERENCE_SEED) {
+            ThemeFoundation("Conference seed", "Generated from conference.themeColor · #7F52FF")
+        }
+    }
+}
+
+/** The live specimen: unlike the four references above, this follows the viewer's Theme selector. */
+@CatalogModes
+@Composable
+fun ThemeFoundationCurrentPreview() {
+    // Supplies a useful brand default in Studio/plain renders, but yields to a catalog override.
+    ConfettiTheme(disableDynamicTheming = true) {
+        ThemeFoundation("Current Theme", "Follows the preview theme selector")
     }
 }

--- a/catalog.mobile.spec.json
+++ b/catalog.mobile.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the Confetti mobile (phone) app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :androidApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under androidApp/src/main/... . The mobile app is Material 3 and picks between several schemes — the Confetti brand purple, the Android green, dynamic (Material You), and the conference-seeded scheme the app root actually installs — each in light + dark; the Theme foundations group carries one sticker per scheme (from dev.johnoreilly.confetti.ui.ThemeFoundationPreviews), and the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them. Theme + Component specimens are in dev.johnoreilly.confetti.ui.ComponentCatalog; the Screens are the full-screen @Preview entry points in that same file, built from the real shared screens + preview mock data. Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens. Mirrors catalog.spec.json (the Wear sheet).",
+  "$comment": "Design-catalog spec for the Confetti mobile (phone) app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :androidApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under androidApp/src/main/... . The mobile app is Material 3 and picks between several schemes — the Confetti brand purple, the Android green, dynamic (Material You), and the conference-seeded scheme the app root actually installs — each in light + dark. The Theme foundations group carries four fixed reference stickers plus a Current Theme sticker that follows the preview theme selector. Theme + Component specimens are in dev.johnoreilly.confetti.ui.ComponentCatalog; the Screens are the full-screen @Preview entry points in that same file, built from the real shared screens + preview mock data. Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens. Mirrors catalog.spec.json (the Wear sheet).",
   "system": "confetti-mobile",
   "title": "Confetti Mobile",
   "library": ["androidx.compose.material3:material3"],
@@ -45,6 +45,11 @@
           "componentId": "Theme/ConferenceSeed",
           "preview": "ThemeFoundationConferenceSeedPreview",
           "caption": "Conference-seeded scheme — what the app root actually installs, generated from conference.themeColor (shown with KotlinConf's #7F52FF)."
+        },
+        {
+          "componentId": "Theme/Current",
+          "preview": "ThemeFoundationCurrentPreview",
+          "caption": "Current Theme — follows the theme selected in the preview viewer; defaults to the Confetti brand scheme in static renders."
         }
       ]
     },


### PR DESCRIPTION
## Summary

- keep the Confetti, Android, Dynamic, and Conference Seed foundation previews fixed when the preview viewer theme changes
- add a **Current Theme** foundation preview that follows the selected viewer theme
- explicitly disable dynamic color for the fixed Android specimen and register the new preview in the mobile catalog

## Why

The catalog theme wrapper marks its selected theme as an override. The production theme functions inside the four foundation previews therefore stepped aside, causing reference specimens to change identity when the viewer theme changed. The fixed specimens now consume that override before installing their named production theme; only the new Current Theme specimen remains override-aware.

## Validation

- `git diff --check`
- `jq empty catalog.mobile.spec.json`
- rendered and visually inspected all ten light/dark theme foundation previews with Compose Preview

The aggregate preview render still reports the pre-existing `activity__MainActivity` failure because Koin is not started; every affected foundation preview produced a valid PNG.
