### PR TITLE
ci: modernise core CI workflows

### DIFF
--- a/.github/workflows/android_wear_jvm.yml
+++ b/.github/workflows/android_wear_jvm.yml
@@ -14,9 +14,13 @@ concurrency:
   group: android-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   build-android:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       # BuildFetch remote cache (see settings.gradle.kts). On main-branch pushes this job is a
       # writer: ON_CI=true + the read-write token seed the debug-variant task outputs so PR runs of
@@ -25,17 +29,17 @@ jobs:
       BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         lfs: 'true'
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 21
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3.5.0
+      uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
@@ -47,21 +51,22 @@ jobs:
 
   build-jvm:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       # See build-android: writer (RW token + ON_CI) on main to seed :shared JVM task outputs,
       # read-only (RO token) on PRs.
       BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       ON_CI: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.5.0
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -7,24 +7,28 @@ concurrency:
   group: backend-test-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-backend:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     env:
       # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
       # PR job only reads from the cache. Absent on fork PRs, which disables the cache there.
       BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 17
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3.5.0
+      uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 

--- a/.github/workflows/build-and-publish-web.yml
+++ b/.github/workflows/build-and-publish-web.yml
@@ -4,26 +4,30 @@ name: Build and Publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Test and Build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so this
       # manual build only reads from the cache. Absent on fork PRs, which disables the cache there.
       BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
     steps:
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v7
 
-      # Setup Java 1.8 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17
 
-      # Check out current repository
-      - name: Fetch Sources
-        uses: actions/checkout@v4
+      - uses: gradle/actions/setup-gradle@v6
 
       # Build application
       - name: Build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,15 +2,19 @@ name: Github CI
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         lfs: 'true'
 
-    - uses: gradle/wrapper-validation-action@v3
+    - uses: gradle/actions/wrapper-validation@v6
 
     - name: Validate Renovate
       uses: rinchsan/renovate-config-validator@v0.2.1


### PR DESCRIPTION
## Summary

Light-touch modernisation of Confetti's core CI workflows, part of a cross-sample standardisation. Confetti already uses most best practices (remote BuildFetch cache, concurrency, JDK split), so this only closes the gaps:

- Replace the **deprecated** `gradle/gradle-build-action@v3.5.0` → `gradle/actions/setup-gradle@v6` (`android_wear_jvm.yml`, `backend-test.yml`).
- Replace the **deprecated** `gradle/wrapper-validation-action@v3` → `gradle/actions/wrapper-validation@v6` (`verify.yml`).
- Bump `checkout@v4`→`v7`, `setup-java@v4`→`v5` across these workflows.
- Add least-privilege `permissions:` (`contents: read`; `contents: write` for the gh-pages web publish) and `timeout-minutes` to each job.

**Deliberately unchanged:** the BuildFetch remote-cache RW/RO token + `ON_CI` logic, the JDK 21 (Android/Wear) / 17 (JVM/backend) split, `zulu`, LFS, and concurrency semantics. `compose-preview.yml` and the publish/deploy/junie/kmmbridge workflows are already modern or special-purpose and left alone.

## Test plan

- [ ] Android/Wear/JVM CI green
- [ ] Backend Test green
- [ ] Github CI (verify) green — wrapper validation + renovate + LFS check

🤖 Generated with [Claude Code](https://claude.com/claude-code)