### PR TITLE
fix(catalog): declare Wear device breakpoints

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,10 +1,14 @@
 {
-  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, so the single mode is the large-round breakpoint. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog, and the per-conference theme foundations in dev.johnoreilly.confetti.wear.ui.ThemeFoundationPreviews (the Wear app themes itself per conference — seed colour plus, for KotlinConf/DevFest, a brand type family — so the Themes tab carries one sticker per identity, not just the stock scheme; the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them). The Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
+  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, with standard small- and large-round device breakpoints. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog, and the per-conference theme foundations in dev.johnoreilly.confetti.wear.ui.ThemeFoundationPreviews (the Wear app themes itself per conference — seed colour plus, for KotlinConf/DevFest, a brand type family — so the Themes tab carries one sticker per identity, not just the stock scheme; the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them). The Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
   "system": "confetti-wear",
   "title": "Confetti Wear",
   "library": ["androidx.wear.compose:compose-material3"],
   "module": "wearApp",
-  "modes": ["largeRound"],
+  "modes": ["dark"],
+  "breakpoints": [
+    { "size": "smallRound", "widthDp": 192 },
+    { "size": "largeRound", "widthDp": 227 }
+  ],
   "groups": [
     {
       "name": "Theme",


### PR DESCRIPTION
## Summary

- declare the standard Wear small-round (192 dp) and large-round (227 dp) breakpoints
- describe the catalog's theme mode as `dark` instead of using a device-size name
- update the catalog comment to distinguish theme mode from device breakpoints

## Root cause

The Wear bundle contains renders for both standard round device widths. Without named breakpoints, the catalog reader classifies both as Material `compact`, so component `Home` produces duplicate output axes and export aborts.

The explicit breakpoint mapping retags those images as `smallRound` and `largeRound` before the duplicate-axis guard runs.

Fixes the failure in https://github.com/joreilly/Confetti/actions/runs/30737837868/job/91469766825

## Validation

- `jq empty catalog.spec.json`
- `git diff --check`
