### PR TITLE
Layout Improvements

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/AndroidScreenPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/AndroidScreenPreviews.kt
@@ -44,7 +44,6 @@ internal fun AndroidSessionDetailPreview() {
             conference = "kotlinconf2023",
             session = sessionDetails,
             onSpeakerClick = {},
-            onSocialLinkClicked = {},
         )
     }
 }

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
@@ -254,7 +254,6 @@ fun SessionDetailsScreenPreview() {
             conference = "kotlinconf2023",
             session = sessionDetails,
             onSpeakerClick = {},
-            onSocialLinkClicked = {},
         )
     }
 }

--- a/iosApp/ConfettiTests/ConfettiTests.swift
+++ b/iosApp/ConfettiTests/ConfettiTests.swift
@@ -24,6 +24,7 @@ final class ConfettiTests: XCTestCase {
     func testGetConferences() async throws {
         let viewModel = DefaultConferencesComponent(
             componentContext: context,
+            onBack: nil,
             onConferenceSelected: { _ in }
         )
         

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -25,8 +25,10 @@
     <string name="dynamic_color_yes">Yes</string>
     <string name="dynamic_color_no">No</string>
     <string name="dismiss_dialog_button_text">OK</string>
-    <string name="use_experimental_features">Use Experimental Features</string>
     <string name="enable_notifications">Enable Notifications</string>
+    <string name="enable_notifications_desc">Get notifications for bookmarked talks.</string>
+    <string name="use_experimental_features">Use Experimental Features</string>
+    <string name="use_experimental_features_desc">Enable early features for testing.</string>
     <string name="settings_boolean_true">Yes</string>
     <string name="settings_boolean_false">No</string>
     <string name="developerSettings">Developer Settings\n</string>

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -5,6 +5,8 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.navigate
+import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.push
 import com.arkivanov.decompose.router.stack.replaceAll
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.AppSettings
@@ -127,6 +129,11 @@ class DefaultAppComponent(
                             }
                             showConference(conference = conference.id, conferenceThemeColor = conference.themeColor)
                         },
+                        onBack = if (config.isSwitching) {
+                            { navigation.pop() }
+                        } else {
+                            null
+                        }
                     )
                 )
 
@@ -137,7 +144,7 @@ class DefaultAppComponent(
                         user = user, 
                         conference = config.conference,
                         conferenceThemeColor = config.conferenceThemeColor,
-                        onSwitchConference = ::showConferences,
+                        onSwitchConference = ::switchConference,
                         onSignOut = {
                             onSignOut()
                             authentication.signOut()
@@ -149,7 +156,11 @@ class DefaultAppComponent(
         }
 
     private fun showConferences() {
-        navigation.replaceAll(Config.Conferences)
+        navigation.replaceAll(Config.Conferences())
+    }
+
+    private fun switchConference() {
+        navigation.push(Config.Conferences(isSwitching = true))
     }
 
     private fun showConference(conference: String, conferenceThemeColor: String?) {
@@ -162,7 +173,7 @@ class DefaultAppComponent(
         data object Loading : Config()
 
         @Serializable
-        data object Conferences : Config()
+        data class Conferences(val isSwitching: Boolean = false) : Config()
 
         @Serializable
         data class Conference(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -62,6 +62,7 @@ class DefaultAppComponent(
             source = navigation,
             serializer = Config.serializer(),
             initialConfiguration = Config.Loading,
+            handleBackButton = true,
             childFactory = ::child,
         )
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
@@ -3,6 +3,7 @@ package dev.johnoreilly.confetti.decompose
 import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
+import dev.johnoreilly.confetti.AppSettings
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.GetConferencesQuery
 import dev.johnoreilly.confetti.decompose.ConferencesComponent.Error
@@ -27,7 +28,10 @@ interface ConferencesComponent {
     sealed interface UiState
     object Loading : UiState
     object Error : UiState
-    class Success(val conferenceListByYear: Map<Int, List<GetConferencesQuery.Conference>>) : UiState {
+    class Success(
+        val conferenceListByYear: Map<Int, List<GetConferencesQuery.Conference>>,
+        val currentConference: String? = null
+    ) : UiState {
         val relevantConferences: List<GetConferencesQuery.Conference> by lazy { conferenceListByYear.values.flatten() }
     }
 }
@@ -59,17 +63,17 @@ class DefaultConferencesComponent(
     private fun refresh(initial: Boolean) {
         job?.cancel()
         job = coroutineScope.launch {
+            val currentConference = repository.getConference().takeIf { it != AppSettings.CONFERENCE_NOT_SET }
             var hasConferences = false
             if (initial) {
                 repository.conferences(FetchPolicy.CacheFirst).data?.conferences?.let {
                     hasConferences = true
-                    val conferenceListByYear = it.groupBy { it.days[0].year }
-                    channel.send(Success(groupConferencesByYear(it)))
+                    channel.send(Success(groupConferencesByYear(it), currentConference))
                 }
             }
             repository.conferences(FetchPolicy.NetworkOnly).data?.conferences?.let {
                 hasConferences = true
-                channel.send(Success(groupConferencesByYear(it)))
+                channel.send(Success(groupConferencesByYear(it), currentConference))
             }
 
             if (!hasConferences) {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferencesComponent.kt
@@ -19,6 +19,7 @@ import org.koin.core.component.get
 interface ConferencesComponent {
 
     val uiState: Value<UiState>
+    val onBack: (() -> Unit)?
 
     fun refresh()
     fun onConferenceClicked(conference: GetConferencesQuery.Conference)
@@ -33,6 +34,7 @@ interface ConferencesComponent {
 
 class DefaultConferencesComponent(
     componentContext: ComponentContext,
+    override val onBack: (() -> Unit)? = null,
     private val onConferenceSelected: (conference: GetConferencesQuery.Conference) -> Unit,
 ) : ConferencesComponent, KoinComponent, ComponentContext by componentContext {
     private val coroutineScope = coroutineScope()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.BuildKonfig
 import dev.johnoreilly.confetti.auth.User
@@ -28,6 +29,7 @@ interface HomeComponent {
     fun onSignInClicked()
     fun onSignOutClicked()
     fun onShowSettingsClicked()
+    fun onBackClicked()
 
     sealed class Child {
         class Sessions(val component: SessionsComponent) : Child()
@@ -166,6 +168,10 @@ class DefaultHomeComponent(
 
     override fun onShowSettingsClicked() {
         onShowSettings()
+    }
+
+    override fun onBackClicked() {
+        navigation.pop()
     }
 
     @Serializable

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
@@ -26,6 +26,7 @@ interface SessionDetailsComponent {
     val removeErrorChannel: Channel<Int>
     val uiState: Value<SessionDetailsUiState>
     val isBookmarked: StateFlow<Boolean>
+    val isLoggedIn: Boolean
 
     fun addBookmark()
     fun removeBookmark()
@@ -52,6 +53,8 @@ class DefaultSessionDetailsComponent(
     private val repository: ConfettiRepository by inject()
     private val coroutineScope = coroutineScope()
     private val defaultFetchPolicy: FetchPolicy by inject()
+
+    override val isLoggedIn: Boolean = user != null
 
     private var addErrorCount = 1
     private var removeErrorCount = 1

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/AccountIcon.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/AccountIcon.kt
@@ -2,7 +2,12 @@ package dev.johnoreilly.confetti.ui
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Assistant
+import androidx.compose.material.icons.filled.MeetingRoom
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -76,6 +81,7 @@ fun AccountIcon(
         if (info != null) {
             DropdownMenuItem(
                 text = { Text(stringResource(Res.string.sign_out)) },
+                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Logout, contentDescription = null) },
                 onClick = {
                     onSignOut()
                     showMenu = false
@@ -84,6 +90,7 @@ fun AccountIcon(
         } else {
             DropdownMenuItem(
                 text = { Text(stringResource(Res.string.sign_in_lowercase)) },
+                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null) },
                 onClick = {
                     showMenu = false
                     onSignIn()
@@ -92,6 +99,7 @@ fun AccountIcon(
         }
         DropdownMenuItem(
             text = { Text(stringResource(Res.string.switch_conference)) },
+            leadingIcon = { Icon(Icons.Default.MeetingRoom, contentDescription = null) },
             onClick = {
                 showMenu = false
                 onSwitchConference()
@@ -101,6 +109,7 @@ fun AccountIcon(
         if (showAgentOption) {
             DropdownMenuItem(
                 text = { Text(stringResource(Res.string.agent_assistant)) },
+                leadingIcon = { Icon(Icons.Default.Assistant, contentDescription = null) },
                 onClick = {
                     showMenu = false
                     onOpenAgent()
@@ -110,6 +119,7 @@ fun AccountIcon(
 
         DropdownMenuItem(
             text = { Text(stringResource(Res.string.settings_title)) },
+            leadingIcon = { Icon(Icons.Default.Settings, contentDescription = null) },
             onClick = {
                 showMenu = false
                 onShowSettings()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -151,7 +151,13 @@ fun HomeView(component: HomeComponent) {
                                 snackbarHostState = snackbarHostState
                             )
 
-                        is HomeComponent.Child.Speakers -> SpeakersUI(child.component)
+                        is HomeComponent.Child.Speakers ->
+                            SpeakersUI(
+                                component = child.component,
+                                windowSizeClass = windowSizeClass,
+                                topBarNavigationIcon = topBarNavigationIcon,
+                                topBarActions = topBarActions,
+                            )
                         is HomeComponent.Child.Bookmarks ->
                             BookmarksUI(
                                 component = child.component,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -166,7 +166,13 @@ fun HomeView(component: HomeComponent) {
                                 topBarActions = topBarActions,
                             )
 
-                        is HomeComponent.Child.Venue -> VenueUI(child.component)
+                        is HomeComponent.Child.Venue ->
+                            VenueUI(
+                                component = child.component,
+                                windowSizeClass = windowSizeClass,
+                                topBarNavigationIcon = topBarNavigationIcon,
+                                topBarActions = topBarActions,
+                            )
 
                         is HomeComponent.Child.Search ->
                             SearchUI(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -179,12 +179,7 @@ fun HomeView(component: HomeComponent) {
                             SearchUI(
                                 component = child.component,
                                 windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = {
-                                    IconButton(onClick = { component.onBackClicked() }) {
-                                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                                    }
-                                },
-                                topBarActions = {}
+                                onBackClick = component::onBackClicked
                             )
 
                         is HomeComponent.Child.Agent -> ConferenceAgentView(child.component)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocationOn
@@ -178,8 +179,12 @@ fun HomeView(component: HomeComponent) {
                             SearchUI(
                                 component = child.component,
                                 windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = topBarNavigationIcon,
-                                topBarActions = topBarActions,
+                                topBarNavigationIcon = {
+                                    IconButton(onClick = { component.onBackClicked() }) {
+                                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                    }
+                                },
+                                topBarActions = {}
                             )
 
                         is HomeComponent.Child.Agent -> ConferenceAgentView(child.component)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -33,6 +34,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -82,41 +84,51 @@ fun ConferenceListView(component: ConferencesComponent) {
     Scaffold(
         topBar = {
             if (searchMode) {
-                CenterAlignedTopAppBar(
-                    title = {
-                        TextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
-                            placeholder = { Text("Search conferences...") },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .focusRequester(focusRequester),
-                            singleLine = true,
-                            colors = TextFieldDefaults.colors(
-                                focusedContainerColor = Color.Transparent,
-                                unfocusedContainerColor = Color.Transparent,
-                                disabledContainerColor = Color.Transparent,
-                                focusedIndicatorColor = Color.Transparent,
-                                unfocusedIndicatorColor = Color.Transparent
-                            )
-                        )
-                    },
-                    navigationIcon = {
-                        IconButton(onClick = {
-                            searchMode = false
-                            searchQuery = ""
-                        }) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                        }
-                    },
-                    actions = {
-                        if (searchQuery.isNotEmpty()) {
-                            IconButton(onClick = { searchQuery = "" }) {
-                                Icon(Icons.Filled.Close, contentDescription = "Clear")
-                            }
-                        }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .statusBarsPadding()
+                        .padding(vertical = 4.dp, horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = {
+                        searchMode = false
+                        searchQuery = ""
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                )
+                    TextField(
+                        modifier = Modifier
+                            .weight(1f)
+                            .focusRequester(focusRequester)
+                            .padding(horizontal = 8.dp),
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        placeholder = { Text("Search conferences...") },
+                        leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
+                        trailingIcon = {
+                            if (searchQuery.isNotEmpty()) {
+                                IconButton(onClick = { searchQuery = "" }) {
+                                    Icon(Icons.Filled.Close, contentDescription = "Clear")
+                                }
+                            }
+                        },
+                        colors = TextFieldDefaults.colors(
+                            focusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            focusedContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
+                            unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
+                            unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                        textStyle = MaterialTheme.typography.bodyLarge,
+                        shape = ShapeDefaults.Large,
+                        singleLine = true,
+                    )
+                }
             } else {
                 CenterAlignedTopAppBar(
                     title = { Text("Confetti") },

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -63,6 +63,7 @@ import dev.johnoreilly.confetti.decompose.ConferencesComponent
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.previewConferenceListState
 import dev.johnoreilly.confetti.preview.sampleConferences
+import dev.johnoreilly.confetti.ui.component.ConfettiSearch
 import dev.johnoreilly.confetti.ui.component.LoadingView
 import kotlinx.datetime.LocalDate
 
@@ -84,51 +85,15 @@ fun ConferenceListView(component: ConferencesComponent) {
     Scaffold(
         topBar = {
             if (searchMode) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .statusBarsPadding()
-                        .padding(vertical = 4.dp, horizontal = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = {
+                ConfettiSearch(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    onBackClick = {
                         searchMode = false
                         searchQuery = ""
-                    }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                    TextField(
-                        modifier = Modifier
-                            .weight(1f)
-                            .focusRequester(focusRequester)
-                            .padding(horizontal = 8.dp),
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        placeholder = { Text("Search conferences...") },
-                        leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
-                        trailingIcon = {
-                            if (searchQuery.isNotEmpty()) {
-                                IconButton(onClick = { searchQuery = "" }) {
-                                    Icon(Icons.Filled.Close, contentDescription = "Clear")
-                                }
-                            }
-                        },
-                        colors = TextFieldDefaults.colors(
-                            focusedIndicatorColor = Color.Transparent,
-                            disabledIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent,
-                            focusedContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
-                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                            focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
-                            unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
-                            unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        ),
-                        textStyle = MaterialTheme.typography.bodyLarge,
-                        shape = ShapeDefaults.Large,
-                        singleLine = true,
-                    )
-                }
+                    },
+                    placeholder = "Search conferences..."
+                )
             } else {
                 CenterAlignedTopAppBar(
                     title = { Text("Confetti") },

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -2,6 +2,7 @@
 
 package dev.johnoreilly.confetti.ui
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -169,9 +170,14 @@ fun ConferenceListView(component: ConferencesComponent) {
                                 }
 
                                 items(conferenceList) { conference ->
-                                    ConferenceCard(conference) {
-                                        component.onConferenceClicked(conference)
-                                    }
+                                    val isSelected = conference.id == uiState1.currentConference
+                                    ConferenceCard(
+                                        conference = conference,
+                                        isSelected = isSelected,
+                                        navigateToConference = {
+                                            component.onConferenceClicked(conference)
+                                        }
+                                    )
                                 }
                             }
                         }
@@ -186,6 +192,7 @@ fun ConferenceListView(component: ConferencesComponent) {
 @Composable
 fun ConferenceCard(
     conference: GetConferencesQuery.Conference,
+    isSelected: Boolean = false,
     navigateToConference: (GetConferencesQuery.Conference) -> Unit
 ) {
     ConferenceMaterialThemeFromSettings(conference.themeColor) {
@@ -197,7 +204,8 @@ fun ConferenceCard(
                     navigateToConference(conference)
                 })
                 .fillMaxWidth()
-                .testTag(conference.id)
+                .testTag(conference.id),
+            border = if (isSelected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null
         ) {
             Column(
                 modifier = Modifier
@@ -205,10 +213,31 @@ fun ConferenceCard(
                     .padding(16.dp),
                 horizontalAlignment = Alignment.Start
             ) {
-                Text(
-                    text = conference.name,
-                    style = MaterialTheme.typography.titleLarge
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = conference.name,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                    if (isSelected) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Surface(
+                            shape = MaterialTheme.shapes.small,
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ) {
+                            Text(
+                                text = "Selected",
+                                style = MaterialTheme.typography.labelSmall,
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -144,8 +144,12 @@ fun ConferenceListView(component: ConferencesComponent) {
                     val filteredConferenceListByYear = if (searchQuery.isBlank()) {
                         uiState1.conferenceListByYear
                     } else {
-                        uiState1.conferenceListByYear.mapValues { (_, list) ->
-                            list.filter { it.name.contains(searchQuery, ignoreCase = true) }
+                        uiState1.conferenceListByYear.mapValues { (year, list) ->
+                            list.filter { conference ->
+                                conference.name.contains(searchQuery, ignoreCase = true) ||
+                                    conference.timezone.contains(searchQuery, ignoreCase = true) ||
+                                    year.toString().contains(searchQuery)
+                            }
                         }.filterValues { it.isNotEmpty() }
                     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -5,13 +5,21 @@ package dev.johnoreilly.confetti.ui
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material3.Card
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
@@ -25,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,22 +57,7 @@ fun ConferenceListView(component: ConferencesComponent) {
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(title = { Text("Confetti")})
-            Surface(tonalElevation = 0.dp) {
-                MediumTopAppBar(
-                    title = {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 32.dp),
-                            maxLines = 2,
-                            textAlign = TextAlign.Center,
-                            text = "Confetti",
-                            fontSize = 32.sp,
-                        )
-                    }
-                )
-            }
+            CenterAlignedTopAppBar(title = { Text("Confetti") })
         }
     ) {
 
@@ -105,18 +99,41 @@ fun ConferenceCard(
     ConferenceMaterialThemeFromSettings(conference.themeColor) {
         Card(
             modifier = Modifier
-                .clip(shape = RoundedCornerShape(8.dp))
-                .padding(8.dp)
+                .clip(shape = RoundedCornerShape(12.dp))
+                .padding(horizontal = 16.dp, vertical = 8.dp)
                 .clickable(onClick = {
                     navigateToConference(conference)
                 })
                 .fillMaxWidth()
                 .testTag(conference.id)
         ) {
-            Column(Modifier.fillMaxWidth().padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(conference.name, style = MaterialTheme.typography.titleMedium)
-                Text(getConferenceDatesString(conference.days), style = MaterialTheme.typography.bodyLarge)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = conference.name,
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Event,
+                        contentDescription = "Event dates",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = getConferenceDatesString(conference.days),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }
@@ -140,13 +157,16 @@ fun YearHeader(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        color = MaterialTheme.colorScheme.surface,
+        color = MaterialTheme.colorScheme.background,
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
             text = text,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.titleLarge
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold
         )
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -35,11 +35,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
@@ -67,6 +70,13 @@ import kotlinx.datetime.LocalDate
 fun ConferenceListView(component: ConferencesComponent) {
     var searchQuery by remember { mutableStateOf("") }
     var searchMode by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(searchMode) {
+        if (searchMode) {
+            focusRequester.requestFocus()
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -77,7 +87,9 @@ fun ConferenceListView(component: ConferencesComponent) {
                             value = searchQuery,
                             onValueChange = { searchQuery = it },
                             placeholder = { Text("Search conferences...") },
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .focusRequester(focusRequester),
                             singleLine = true,
                             colors = TextFieldDefaults.colors(
                                 focusedContainerColor = Color.Transparent,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -119,6 +119,13 @@ fun ConferenceListView(component: ConferencesComponent) {
             } else {
                 CenterAlignedTopAppBar(
                     title = { Text("Confetti") },
+                    navigationIcon = {
+                        component.onBack?.let { onBack ->
+                            IconButton(onClick = onBack) {
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                            }
+                        }
+                    },
                     actions = {
                         IconButton(onClick = { searchMode = true }) {
                             Icon(Icons.Outlined.Search, contentDescription = "Search")
@@ -260,6 +267,7 @@ private class PreviewConferencesComponent(
     state: ConferencesComponent.UiState,
 ) : ConferencesComponent {
     override val uiState: Value<ConferencesComponent.UiState> = MutableValue(state)
+    override val onBack: (() -> Unit)? = null
     override fun refresh() {}
     override fun onConferenceClicked(conference: GetConferencesQuery.Conference) {}
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,10 +17,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
@@ -28,6 +36,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,32 +65,90 @@ import kotlinx.datetime.LocalDate
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ConferenceListView(component: ConferencesComponent) {
+    var searchQuery by remember { mutableStateOf("") }
+    var searchMode by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(title = { Text("Confetti") })
+            if (searchMode) {
+                CenterAlignedTopAppBar(
+                    title = {
+                        TextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            placeholder = { Text("Search conferences...") },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = Color.Transparent,
+                                unfocusedContainerColor = Color.Transparent,
+                                disabledContainerColor = Color.Transparent,
+                                focusedIndicatorColor = Color.Transparent,
+                                unfocusedIndicatorColor = Color.Transparent
+                            )
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = {
+                            searchMode = false
+                            searchQuery = ""
+                        }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    actions = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = { searchQuery = "" }) {
+                                Icon(Icons.Filled.Close, contentDescription = "Clear")
+                            }
+                        }
+                    }
+                )
+            } else {
+                CenterAlignedTopAppBar(
+                    title = { Text("Confetti") },
+                    actions = {
+                        IconButton(onClick = { searchMode = true }) {
+                            Icon(Icons.Outlined.Search, contentDescription = "Search")
+                        }
+                    }
+                )
+            }
         }
-    ) {
+    ) { paddingValues ->
 
         val uiState by component.uiState.subscribeAsState()
 
-        when (val uiState1 = uiState) {
-            ConferencesComponent.Error -> {} //ErrorView(component::refresh)
-            ConferencesComponent.Loading -> LoadingView()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            when (val uiState1 = uiState) {
+                ConferencesComponent.Error -> {} //ErrorView(component::refresh)
+                ConferencesComponent.Loading -> LoadingView()
 
-            is ConferencesComponent.Success -> {
-                LazyColumn(Modifier.padding(it)) {
-                    val conferenceListByYear = uiState1.conferenceListByYear
-                    conferenceListByYear.keys.sortedDescending().forEach { year ->
-                        val conferenceList = conferenceListByYear[year]
-                        conferenceList?.let {
-                            stickyHeader {
-                                YearHeader(year.toString())
-                            }
+                is ConferencesComponent.Success -> {
+                    val filteredConferenceListByYear = if (searchQuery.isBlank()) {
+                        uiState1.conferenceListByYear
+                    } else {
+                        uiState1.conferenceListByYear.mapValues { (_, list) ->
+                            list.filter { it.name.contains(searchQuery, ignoreCase = true) }
+                        }.filterValues { it.isNotEmpty() }
+                    }
 
-                            items(conferenceList) { conference ->
-                                ConferenceCard(conference) {
-                                    component.onConferenceClicked(conference)
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                        filteredConferenceListByYear.keys.sortedDescending().forEach { year ->
+                            val conferenceList = filteredConferenceListByYear[year]
+                            conferenceList?.let {
+                                stickyHeader {
+                                    YearHeader(year.toString())
+                                }
+
+                                items(conferenceList) { conference ->
+                                    ConferenceCard(conference) {
+                                        component.onConferenceClicked(conference)
+                                    }
                                 }
                             }
                         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/SigninDialog.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/SigninDialog.kt
@@ -1,16 +1,22 @@
 package dev.johnoreilly.confetti.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -27,15 +33,31 @@ import org.jetbrains.compose.resources.stringResource
 fun SignInDialog(onDismissRequest: () -> Unit, onSignInClicked: () -> Unit) {
     Dialog(onDismissRequest = onDismissRequest) {
 
-        Card {
-            Column(modifier = Modifier.padding(8.dp)) {
+        Card(
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .fillMaxWidth()
+            ) {
                 Text(
                     text = stringResource(Res.string.sign_in_for_bookmarks),
                     textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.fillMaxWidth()
                 )
-                Spacer(modifier = Modifier.height(16.dp))
-                Row(modifier = Modifier.align(CenterHorizontally)) {
-                    Button(onClick = onDismissRequest) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = onDismissRequest) {
                         Text(text = stringResource(Res.string.cancel))
                     }
                     Spacer(modifier = Modifier.width(16.dp))

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/BookmarksView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/BookmarksView.kt
@@ -10,7 +10,8 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -155,7 +156,7 @@ private fun BookmarksHorizontalPager(
                         )
                     }
 
-                    items(sessions) { session ->
+                    itemsIndexed(sessions) { index, session ->
                         SessionItemView(
                             session = session,
                             sessionSelected = navigateToSession,
@@ -165,6 +166,9 @@ private fun BookmarksHorizontalPager(
                             onNavigateToSignIn = onSignIn,
                             isLoggedIn = isLoggedIn,
                         )
+                        if (index < sessions.lastIndex) {
+                            HorizontalDivider()
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiSearch.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiSearch.kt
@@ -1,0 +1,116 @@
+package dev.johnoreilly.confetti.ui.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ShapeDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ConfettiSearch(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onBackClick: () -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusRequester = remember { FocusRequester() }
+
+    DisposableEffect(Unit) {
+        focusRequester.requestFocus()
+        onDispose { keyboardController?.hide() }
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(vertical = 4.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
+        TextField(
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester)
+                .interceptKey(Key.Enter) {
+                    keyboardController?.hide()
+                }
+                .padding(horizontal = 8.dp),
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = { Text(placeholder) },
+            leadingIcon = { Icon(Icons.Filled.Search, "Search") },
+            trailingIcon = {
+                if (value.isNotEmpty()) {
+                    IconButton(onClick = {
+                        keyboardController?.hide()
+                        onValueChange("")
+                    }) {
+                        Icon(Icons.Filled.Close, contentDescription = "Clear")
+                    }
+                }
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(
+                onSearch = { keyboardController?.hide() }
+            ),
+            colors = TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                focusedContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
+                unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
+                unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+            textStyle = MaterialTheme.typography.bodyLarge,
+            shape = ShapeDefaults.Large,
+            singleLine = true,
+        )
+    }
+}
+
+/**
+ * [Modifier] to intercept [key] events and fires [onKeyEvent] callback when the key is released.
+ */
+fun Modifier.interceptKey(key: Key, onKeyEvent: () -> Unit = {}): Modifier =
+    onPreviewKeyEvent { event ->
+        if (event.key == key && event.type == KeyEventType.KeyUp) {
+            onKeyEvent()
+        }
+        event.key == key
+    }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/FullScreenPhotoDialog.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/FullScreenPhotoDialog.kt
@@ -2,6 +2,7 @@ package dev.johnoreilly.confetti.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -14,9 +15,16 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -31,6 +39,9 @@ fun FullScreenPhotoDialog(
     onDismissRequest: () -> Unit,
 ) {
     if (photoUrl == null) return
+
+    var scale by remember { mutableStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
 
     Dialog(
         onDismissRequest = onDismissRequest,
@@ -52,7 +63,26 @@ fun FullScreenPhotoDialog(
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .fillMaxSize()
-                    .clickable { onDismissRequest() }
+                    .graphicsLayer(
+                        scaleX = scale.coerceIn(1f, 5f),
+                        scaleY = scale.coerceIn(1f, 5f),
+                        translationX = offset.x,
+                        translationY = offset.y
+                    )
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            scale = (scale * zoom).coerceIn(1f, 5f)
+                            if (scale > 1f) {
+                                offset = offset + pan
+                            } else {
+                                offset = Offset.Zero
+                            }
+                        }
+                    }
+                    .clickable(
+                        enabled = scale == 1f,
+                        onClick = onDismissRequest
+                    )
             )
             Scaffold(
                 containerColor = Color.Transparent,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/FullScreenPhotoDialog.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/FullScreenPhotoDialog.kt
@@ -1,0 +1,81 @@
+package dev.johnoreilly.confetti.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FullScreenPhotoDialog(
+    photoUrl: String?,
+    contentDescription: String?,
+    onDismissRequest: () -> Unit,
+) {
+    if (photoUrl == null) return
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black),
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = photoUrl,
+                contentDescription = contentDescription,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable { onDismissRequest() }
+            )
+            Scaffold(
+                containerColor = Color.Transparent,
+                topBar = {
+                    CenterAlignedTopAppBar(
+                        title = {},
+                        navigationIcon = {
+                            IconButton(onClick = onDismissRequest) {
+                                Icon(
+                                    imageVector = Icons.Filled.Close,
+                                    contentDescription = "Close",
+                                    tint = Color.White
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                            containerColor = Color.Transparent
+                        )
+                    )
+                }
+            ) { padding ->
+                Box(modifier = Modifier.padding(padding))
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchUI.kt
@@ -5,11 +5,7 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import confetti.shared.generated.resources.Res
-import confetti.shared.generated.resources.search
 import dev.johnoreilly.confetti.decompose.SearchComponent
-import dev.johnoreilly.confetti.ui.HomeScaffold
-import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun SearchUI(
@@ -24,25 +20,19 @@ fun SearchUI(
     val bookmarks by component.bookmarks.collectAsStateWithLifecycle(initialValue = emptySet())
     val speakers by component.speakers.collectAsStateWithLifecycle(initialValue = emptyList())
 
-    HomeScaffold(
-        title = stringResource(Res.string.search),
-        windowSizeClass = windowSizeClass,
+    SearchView(
+        navigateToSession = component::onSessionClicked,
+        navigateToSpeaker = component::onSpeakerClicked,
+        onSignIn = component::onSignInClicked,
+        sessions = sessions,
+        speakers = speakers,
+        search = search,
+        onSearchChange = component::onSearchChange,
+        bookmarks = bookmarks,
+        addBookmark = component::addBookmark,
+        removeBookmark = component::removeBookmark,
+        loading = loading,
+        isLoggedIn = component.isLoggedIn,
         topBarNavigationIcon = topBarNavigationIcon,
-        topBarActions = topBarActions,
-    ) {
-        SearchView(
-            navigateToSession = component::onSessionClicked,
-            navigateToSpeaker = component::onSpeakerClicked,
-            onSignIn = component::onSignInClicked,
-            sessions = sessions,
-            speakers = speakers,
-            search = search,
-            onSearchChange = component::onSearchChange,
-            bookmarks = bookmarks,
-            addBookmark = component::addBookmark,
-            removeBookmark = component::removeBookmark,
-            loading = loading,
-            isLoggedIn = component.isLoggedIn,
-        )
-    }
+    )
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchUI.kt
@@ -1,6 +1,5 @@
 package dev.johnoreilly.confetti.ui.search
 
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -11,8 +10,7 @@ import dev.johnoreilly.confetti.decompose.SearchComponent
 fun SearchUI(
     component: SearchComponent,
     windowSizeClass: WindowSizeClass,
-    topBarNavigationIcon: @Composable () -> Unit = {},
-    topBarActions: @Composable RowScope.() -> Unit = {},
+    onBackClick: () -> Unit,
 ) {
     val search by component.search.collectAsStateWithLifecycle(initialValue = "")
     val loading by component.loading.collectAsStateWithLifecycle(initialValue = true)
@@ -33,6 +31,6 @@ fun SearchUI(
         removeBookmark = component::removeBookmark,
         loading = loading,
         isLoggedIn = component.isLoggedIn,
-        topBarNavigationIcon = topBarNavigationIcon,
+        onBackClick = onBackClick,
     )
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -6,8 +6,10 @@
 package dev.johnoreilly.confetti.ui.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
@@ -15,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.ui.Alignment
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
@@ -31,6 +35,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -81,37 +86,55 @@ fun SearchView(
     removeBookmark: (sessionId: String) -> Unit,
     loading: Boolean,
     isLoggedIn: Boolean,
+    topBarNavigationIcon: @Composable () -> Unit = {},
 ) {
-    Column {
-        SearchTextField(
-            modifier = Modifier
-                .padding(8.dp),
-            value = search,
-            onValueChange = onSearchChange,
-        )
-
-        if (loading) {
-            LoadingView()
-        } else if (search.isNotBlank()) {
-            LazyColumn(
-                //modifier = Modifier.imeNestedScroll(),
-                contentPadding = WindowInsets.safeDrawing
-                    .only(WindowInsetsSides.Bottom)
-                    .asPaddingValues()
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .statusBarsPadding()
+                    .padding(vertical = 4.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                sessionItems(
-                    sessions = sessions,
-                    navigateToSession = navigateToSession,
-                    bookmarks = bookmarks,
-                    addBookmark = addBookmark,
-                    removeBookmark = removeBookmark,
-                    onSignIn = onSignIn,
-                    isLoggedIn = isLoggedIn,
+                topBarNavigationIcon()
+                SearchTextField(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp),
+                    value = search,
+                    onValueChange = onSearchChange,
                 )
-                speakerItems(
-                    speakers = speakers,
-                    navigateToSpeaker = navigateToSpeaker,
-                )
+            }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+        ) {
+            if (loading) {
+                LoadingView()
+            } else if (search.isNotBlank()) {
+                LazyColumn(
+                    //modifier = Modifier.imeNestedScroll(),
+                    contentPadding = WindowInsets.safeDrawing
+                        .only(WindowInsetsSides.Bottom)
+                        .asPaddingValues()
+                ) {
+                    sessionItems(
+                        sessions = sessions,
+                        navigateToSession = navigateToSession,
+                        bookmarks = bookmarks,
+                        addBookmark = addBookmark,
+                        removeBookmark = removeBookmark,
+                        onSignIn = onSignIn,
+                        isLoggedIn = isLoggedIn,
+                    )
+                    speakerItems(
+                        speakers = speakers,
+                        navigateToSpeaker = navigateToSpeaker,
+                    )
+                }
             }
         }
     }
@@ -218,10 +241,15 @@ private fun SearchTextField(
             onSearch = { keyboardController?.hide() }
         ),
         colors = TextFieldDefaults.colors(
-            // hide the indicator
             focusedIndicatorColor = Color.Transparent,
             disabledIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent,
+            focusedContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
+            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+            focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
+            unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
+            unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
         ),
         textStyle = MaterialTheme.typography.bodyLarge,
         shape = ShapeDefaults.Large,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -155,7 +157,7 @@ private fun LazyListScope.sessionItems(
             )
         }
     }
-    items(sessions) { session ->
+    itemsIndexed(sessions) { index, session ->
         SessionItemView(
             session = session,
             sessionSelected = navigateToSession,
@@ -165,6 +167,9 @@ private fun LazyListScope.sessionItems(
             onNavigateToSignIn = onSignIn,
             isLoggedIn = isLoggedIn,
         )
+        if (index < sessions.lastIndex) {
+            HorizontalDivider()
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -67,6 +67,7 @@ import dev.johnoreilly.confetti.preview.lightningSession
 import dev.johnoreilly.confetti.preview.sampleSpeakers
 import dev.johnoreilly.confetti.preview.sessionDetails
 import dev.johnoreilly.confetti.ui.component.ConfettiHeader
+import dev.johnoreilly.confetti.ui.component.ConfettiSearch
 import dev.johnoreilly.confetti.ui.component.LoadingView
 import dev.johnoreilly.confetti.ui.sessions.SessionItemView
 import dev.johnoreilly.confetti.ui.speakers.SpeakerItemView
@@ -86,26 +87,16 @@ fun SearchView(
     removeBookmark: (sessionId: String) -> Unit,
     loading: Boolean,
     isLoggedIn: Boolean,
-    topBarNavigationIcon: @Composable () -> Unit = {},
+    onBackClick: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .statusBarsPadding()
-                    .padding(vertical = 4.dp, horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                topBarNavigationIcon()
-                SearchTextField(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = 8.dp),
-                    value = search,
-                    onValueChange = onSearchChange,
-                )
-            }
+            ConfettiSearch(
+                value = search,
+                onValueChange = onSearchChange,
+                onBackClick = onBackClick,
+                placeholder = stringResource(Res.string.search_placeholder)
+            )
         }
     ) { innerPadding ->
         Box(
@@ -196,82 +187,7 @@ private fun LazyListScope.sessionItems(
     }
 }
 
-@Composable
-private fun SearchTextField(
-    modifier: Modifier = Modifier,
-    value: String = "",
-    onValueChange: (String) -> Unit,
-    onCloseSearch: () -> Unit = {},
-) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val focusRequester = remember { FocusRequester() }
 
-    DisposableEffect(Unit) {
-        focusRequester.requestFocus()
-        onDispose { keyboardController?.hide() }
-    }
-
-    TextField(
-        modifier = modifier
-            .focusRequester(focusRequester)
-            .interceptKey(Key.Enter) {
-                keyboardController?.hide()
-            }
-            .fillMaxWidth(),
-        value = value,
-        onValueChange = onValueChange,
-        placeholder = { Text(stringResource(Res.string.search_placeholder)) },
-        leadingIcon = { Icon(Icons.Filled.Search, "Search") },
-        trailingIcon = {
-            if (value.isNotBlank()) {
-                IconButton(onClick = {
-                    keyboardController?.hide()
-                    onValueChange("")
-                    onCloseSearch()
-                }) {
-                    Icon(
-                        Icons.Filled.Close,
-                        contentDescription = "Close Search"
-                    )
-                }
-            }
-        },
-        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-        keyboardActions = KeyboardActions(
-            onSearch = { keyboardController?.hide() }
-        ),
-        colors = TextFieldDefaults.colors(
-            focusedIndicatorColor = Color.Transparent,
-            disabledIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            focusedContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f),
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-            focusedLeadingIconColor = MaterialTheme.colorScheme.primary,
-            unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
-            unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        ),
-        textStyle = MaterialTheme.typography.bodyLarge,
-        shape = ShapeDefaults.Large,
-        singleLine = true,
-    )
-}
-
-/**
- * [Modifier] to intercept [key] events and fires [onKeyEvent] callback when the key is released.
- *
- * The [key] parameter represents the key to be intercepted
- * The [onKeyEvent] listener is an optional listener to when the key event happens.
- *
- * The intercepted key is not passed to any child composable.
- */
-fun Modifier.interceptKey(key: Key, onKeyEvent: () -> Unit = {}): Modifier =
-    onPreviewKeyEvent { event ->
-        if (event.key == key && event.type == KeyEventType.KeyUp) {
-            onKeyEvent()
-        }
-        event.key == key
-    }
 
 @MobilePreviews
 @Composable

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -97,7 +97,8 @@ fun SearchView(
                 onBackClick = onBackClick,
                 placeholder = stringResource(Res.string.search_placeholder)
             )
-        }
+        },
+        contentWindowInsets = WindowInsets(0.dp)
     ) { innerPadding ->
         Box(
             modifier = Modifier
@@ -106,12 +107,7 @@ fun SearchView(
             if (loading) {
                 LoadingView()
             } else if (search.isNotBlank()) {
-                LazyColumn(
-                    //modifier = Modifier.imeNestedScroll(),
-                    contentPadding = WindowInsets.safeDrawing
-                        .only(WindowInsetsSides.Bottom)
-                        .asPaddingValues()
-                ) {
+                LazyColumn {
                     sessionItems(
                         sessions = sessions,
                         navigateToSession = navigateToSession,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -65,7 +66,6 @@ fun SessionDetailViewShared(
     conference: String,
     session: SessionDetails?,
     onSpeakerClick: (speakerId: String) -> Unit,
-    onSocialLinkClicked: (String) -> Unit
 ) {
     val scrollState = rememberScrollState()
 
@@ -81,7 +81,8 @@ fun SessionDetailViewShared(
                         Text(
                             text = session.title,
                             color = MaterialTheme.colorScheme.primary,
-                            style = MaterialTheme.typography.titleLarge
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold
                         )
                     }
 
@@ -134,7 +135,7 @@ fun SessionDetailViewShared(
 
                     Column(modifier = Modifier.padding(contentPadding)) {
                         session.speakers.forEach { speaker ->
-                            SessionSpeakerInfo(conference, speaker.speakerDetails, onSpeakerClick, onSocialLinkClicked)
+                            SessionSpeakerInfo(conference, speaker.speakerDetails, onSpeakerClick)
                         }
                     }
 
@@ -169,63 +170,54 @@ internal fun SessionSpeakerInfo(
     conference: String,
     speaker: SpeakerDetails,
     onSpeakerClick: (speakerId: String) -> Unit,
-    onSocialLinkClick: (String) -> Unit
 ) {
-    Column(Modifier
-        .padding(top = 16.dp)
-        .clickable(role = Role.Button) { onSpeakerClick(speaker.id) }
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+            .clickable(role = Role.Button) { onSpeakerClick(speaker.id) },
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
     ) {
-        Row {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             speaker.photoUrl?.let {
-                val url = speaker.photoUrl //"https://confetti-app.dev/images/avatar/${conference}/${speaker.id}"
+                val url = speaker.photoUrl
                 SubcomposeAsyncImage(
                     model = url,
                     contentDescription = speaker.name,
                     loading = {
-                        CircularProgressIndicator()
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp
+                        )
                     },
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .size(64.dp)
+                        .size(56.dp)
                         .clip(CircleShape)
                 )
             }
 
-            Column(Modifier.padding(horizontal = 8.dp)) {
+            Spacer(modifier = Modifier.size(12.dp))
+
+            Column(Modifier.weight(1f)) {
                 Text(
                     text = speaker.fullNameAndCompany(),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
                 speaker.tagline?.let { tagline ->
+                    Spacer(modifier = Modifier.size(2.dp))
                     Text(
                         text = tagline,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Bold
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
                     )
-                }
-
-                speaker.bio?.let { bio ->
-                    Text(
-                        modifier = Modifier.padding(top = 12.dp),
-                        text = bio,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-
-
-                Row(
-                    Modifier.padding(top = 0.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    speaker.socials.forEach { socialsItem ->
-                        SocialIcon(
-                            modifier = Modifier.size(28.dp),
-                            socialItem = socialsItem,
-                            onClick = { onSocialLinkClick(socialsItem.url) }
-                        )
-                    }
                 }
             }
         }
@@ -302,12 +294,12 @@ internal fun Chip(name: String) {
     Surface(
         modifier = Modifier.padding(end = 10.dp),
         shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.primary
+        color = MaterialTheme.colorScheme.secondaryContainer
     ) {
         Text(
             text = name,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onPrimary,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
             modifier = Modifier.padding(10.dp)
         )
     }
@@ -328,7 +320,6 @@ internal fun SessionDetailViewLoadedPreview() {
             conference = "kotlinconf2023",
             session = sessionDetails,
             onSpeakerClick = {},
-            onSocialLinkClicked = {},
         )
     }
 }
@@ -341,7 +332,6 @@ internal fun SessionDetailViewEmptyPreview() {
             conference = "kotlinconf2023",
             session = null,
             onSpeakerClick = {},
-            onSocialLinkClicked = {},
         )
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -29,7 +29,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -172,6 +176,8 @@ internal fun SessionSpeakerInfo(
     speaker: SpeakerDetails,
     onSpeakerClick: (speakerId: String) -> Unit,
 ) {
+    var showFullScreenPhoto by remember { mutableStateOf(false) }
+
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
@@ -210,10 +216,19 @@ internal fun SessionSpeakerInfo(
                     modifier = Modifier
                         .size(56.dp)
                         .clip(CircleShape)
+                        .clickable { showFullScreenPhoto = true }
                 )
             }
         }
     )
+
+    if (showFullScreenPhoto) {
+        FullScreenPhotoDialog(
+            photoUrl = speaker.photoUrl,
+            contentDescription = speaker.name,
+            onDismissRequest = { showFullScreenPhoto = false }
+        )
+    }
 }
 
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -171,18 +172,29 @@ internal fun SessionSpeakerInfo(
     speaker: SpeakerDetails,
     onSpeakerClick: (speakerId: String) -> Unit,
 ) {
-    Surface(
+    ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp)
             .clickable(role = Role.Button) { onSpeakerClick(speaker.id) },
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        headlineContent = {
+            Text(
+                text = speaker.fullNameAndCompany(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        supportingContent = if (speaker.tagline != null) {
+            {
+                Text(
+                    text = speaker.tagline,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            null
+        },
+        leadingContent = {
             speaker.photoUrl?.let {
                 val url = speaker.photoUrl
                 SubcomposeAsyncImage(
@@ -200,28 +212,8 @@ internal fun SessionSpeakerInfo(
                         .clip(CircleShape)
                 )
             }
-
-            Spacer(modifier = Modifier.size(12.dp))
-
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = speaker.fullNameAndCompany(),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                speaker.tagline?.let { tagline ->
-                    Spacer(modifier = Modifier.size(2.dp))
-                    Text(
-                        text = tagline,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
-                    )
-                }
-            }
         }
-    }
+    )
 }
 
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,48 +49,41 @@ fun SessionItemView(
     isLoggedIn: Boolean,
 ) {
 
-    var modifier = Modifier.fillMaxSize()
+    var showDialog by remember { mutableStateOf(false) }
+
+    var modifier = Modifier.fillMaxWidth()
     if (!session.isService() && !session.isBreak()) {
         modifier = modifier.clickable(onClick = {
             sessionSelected(session.id)
         })
     }
 
-
-    Surface {
-        Row(modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-            Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+    ListItem(
+        modifier = modifier,
+        headlineContent = {
+            Text(
+                text = session.title,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+        },
+        supportingContent = {
+            Column {
+                val speakers = session.sessionSpeakers()
+                if (!speakers.isNullOrEmpty()) {
                     Text(
-                        text = session.title,
-                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                        text = speakers,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 4.dp)
                     )
                 }
 
                 session.room?.let { room ->
-                    Row(
-                        modifier = Modifier.padding(top = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            session.sessionSpeakers() ?: "",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    }
-
-                    Row(
-                        modifier = Modifier.padding(top = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            room.name,
-                            style = MaterialTheme.typography.bodyMedium,
-                            // Was a hardcoded Color.Gray, which stayed #888888 in both modes:
-                            // ~3.5:1 on the light surface (below the 4.5:1 WCAG AA floor for body
-                            // text) and unable to respond to the theme at all.
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                    Text(
+                        text = room.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
                 }
 
                 if (session.isLightning()) {
@@ -96,18 +92,26 @@ fun SessionItemView(
                         shape = MaterialTheme.shapes.small,
                         color = MaterialTheme.colorScheme.primaryContainer,
                     ) {
-                        Row(Modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
-                            Icon(Icons.Default.Bolt, "lightning")
+                        Row(
+                            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Bolt,
+                                contentDescription = "lightning",
+                                modifier = Modifier.size(16.dp)
+                            )
                             Spacer(Modifier.width(4.dp))
-                            Text("Lightning / ${session.startsAt.time}-${session.endsAt.time}")
+                            Text(
+                                text = "Lightning / ${session.startsAt.time}-${session.endsAt.time}",
+                                style = MaterialTheme.typography.labelSmall
+                            )
                         }
                     }
                 }
             }
-
-
-            var showDialog by remember { mutableStateOf(false) }
-
+        },
+        trailingContent = {
             if (!session.isBreak() && !session.isService()) {
                 Bookmark(
                     isBookmarked = isBookmarked,
@@ -124,14 +128,14 @@ fun SessionItemView(
                     }
                 )
             }
-
-            if (showDialog) {
-                SignInDialog(
-                    onDismissRequest = { showDialog = false },
-                    onSignInClicked = onNavigateToSignIn
-                )
-            }
         }
+    )
+
+    if (showDialog) {
+        SignInDialog(
+            onDismissRequest = { showDialog = false },
+            onSignInClicked = onNavigateToSignIn
+        )
     }
 
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
@@ -6,7 +6,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -118,7 +119,7 @@ fun SessionListView(
 
                                 val sortedSessions =
                                     sessions.sortedBy { session -> uiState.rooms.indexOfFirst { it.name == session.room?.name } }
-                                items(sortedSessions) { session ->
+                                itemsIndexed(sortedSessions) { index, session ->
                                     SessionItemView(
                                         session = session,
                                         sessionSelected = sessionSelected,
@@ -128,6 +129,9 @@ fun SessionListView(
                                         onNavigateToSignIn = onNavigateToSignIn,
                                         isLoggedIn = isLoggedIn,
                                     )
+                                    if (index < sortedSessions.lastIndex) {
+                                        HorizontalDivider()
+                                    }
                                 }
                             }
                         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -12,11 +12,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import dev.johnoreilly.confetti.decompose.SessionDetailsComponent
 import dev.johnoreilly.confetti.decompose.SessionDetailsUiState
+import dev.johnoreilly.confetti.ui.SignInDialog
 import dev.johnoreilly.confetti.ui.bookmarks.Bookmark
 import dev.johnoreilly.confetti.ui.component.ErrorView
 import dev.johnoreilly.confetti.ui.component.LoadingView
@@ -26,6 +30,7 @@ import dev.johnoreilly.confetti.ui.component.LoadingView
 @Composable
 fun SessionDetailsUI(component: SessionDetailsComponent) {
     val uriHandler = LocalUriHandler.current
+    var showDialog by remember { mutableStateOf(false) }
 
     val uiState by component.uiState.subscribeAsState()
     val isBookmarked by component.isBookmarked.collectAsState()
@@ -39,18 +44,13 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
                 }
             },
             actions = {
-//                IconButton(onClick = {
-//                    share()
-//                }) {
-//                    Icon(Icons.Filled.Share, contentDescription = "Share")
-//                }
                 Bookmark(
                     isBookmarked = isBookmarked,
                     onBookmarkChange = { shouldAdd ->
-//                        if (!isUserLoggedIn) {
-//                            showDialog = true
-//                            return@Bookmark
-//                        }
+                        if (!component.isLoggedIn) {
+                            showDialog = true
+                            return@Bookmark
+                        }
                         if (shouldAdd) {
                             component.addBookmark()
                         } else {
@@ -74,5 +74,12 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
                     )
             }
         }
+    }
+
+    if (showDialog) {
+        SignInDialog(
+            onDismissRequest = { showDialog = false },
+            onSignInClicked = component::onSignInClicked
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -71,9 +71,7 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
                     SessionDetailViewShared(
                         state.conference, state.sessionDetails,
                         component::onSpeakerClicked
-                    ) { url ->
-                        uriHandler.openUri(url)
-                    }
+                    )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -15,6 +16,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -24,12 +26,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -41,16 +46,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import confetti.shared.generated.resources.Res
+import confetti.shared.generated.resources.cancel
 import confetti.shared.generated.resources.dark_mode_config_dark
 import confetti.shared.generated.resources.dark_mode_config_light
 import confetti.shared.generated.resources.dark_mode_config_system_default
 import confetti.shared.generated.resources.dark_mode_preference
 import confetti.shared.generated.resources.developerSettings
 import confetti.shared.generated.resources.enable_notifications
+import confetti.shared.generated.resources.enable_notifications_desc
 import confetti.shared.generated.resources.settings_boolean_false
 import confetti.shared.generated.resources.settings_boolean_true
 import confetti.shared.generated.resources.settings_title
 import confetti.shared.generated.resources.use_experimental_features
+import confetti.shared.generated.resources.use_experimental_features_desc
 import dev.johnoreilly.confetti.appconfig.ApplicationInfo
 import dev.johnoreilly.confetti.decompose.DarkThemeConfig
 import dev.johnoreilly.confetti.decompose.DeveloperSettings
@@ -133,21 +141,23 @@ fun SettingsUI(
 
             LazyColumn(modifier = Modifier.weight(1f)) {
                 item {
-                    Column(modifier = Modifier.padding(horizontal = 8.dp)) {
-                        SettingsPanel(
-                            settings = userEditableSettings,
-                            onChangeDarkThemeConfig = onChangeDarkThemeConfig,
-                            onChangeUseExperimentalFeatures = onChangeUseExperimentalFeatures,
-                            onChangeNotificationsEnabled = onNotificationsEnabled,
-                            supportsNotifications = supportsNotifications,
-                        )
-                    }
+                    SettingsPanel(
+                        settings = userEditableSettings,
+                        onChangeDarkThemeConfig = onChangeDarkThemeConfig,
+                        onChangeUseExperimentalFeatures = onChangeUseExperimentalFeatures,
+                        onChangeNotificationsEnabled = onNotificationsEnabled,
+                        supportsNotifications = supportsNotifications,
+                    )
                 }
 
                 if (developerSettings != null) {
                     item {
-                        Column(modifier = Modifier.padding(8.dp)) {
-                            SettingsDialogSectionTitle(text = stringResource(Res.string.developerSettings))
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                            Text(
+                                text = stringResource(Res.string.developerSettings),
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                            )
                             Text(
                                 "Token: ${developerSettings.token}",
                                 maxLines = 1,
@@ -165,7 +175,7 @@ fun SettingsUI(
                         val notificationPermissionState =
                             rememberNotificationPermissionState(userEditableSettings?.useExperimentalFeatures)
 
-                        Column(modifier = Modifier.padding(8.dp)) {
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                             Button(
                                 onClick = { notificationPermissionState.maybeRequest() },
                             ) {
@@ -224,70 +234,160 @@ private fun SettingsPanel(
     onChangeNotificationsEnabled: (value: Boolean) -> Unit,
 ) {
     if (settings != null) {
-        BooleanSettings(
+        var showThemeDialog by remember { mutableStateOf(false) }
+
+        SwitchSettingsRow(
             title = stringResource(Res.string.enable_notifications),
+            description = stringResource(Res.string.enable_notifications_desc),
             value = settings.notificationsEnabled,
-            onValueChange = { value -> onChangeNotificationsEnabled(value) },
+            onValueChange = onChangeNotificationsEnabled,
             enabled = supportsNotifications
         )
 
-        BooleanSettings(
+        SwitchSettingsRow(
             title = stringResource(Res.string.use_experimental_features),
+            description = stringResource(Res.string.use_experimental_features_desc),
             value = settings.useExperimentalFeatures,
-            onValueChange = { value -> onChangeUseExperimentalFeatures(value) }
+            onValueChange = onChangeUseExperimentalFeatures
         )
 
-        SettingsDialogSectionTitle(text = stringResource(Res.string.dark_mode_preference))
-        Column(Modifier.selectableGroup()) {
-            SettingsDialogThemeChooserRow(
-                text = stringResource(Res.string.dark_mode_config_system_default),
-                selected = settings.darkThemeConfig == DarkThemeConfig.FOLLOW_SYSTEM,
-                onClick = { onChangeDarkThemeConfig(DarkThemeConfig.FOLLOW_SYSTEM) },
-            )
-            SettingsDialogThemeChooserRow(
-                text = stringResource(Res.string.dark_mode_config_light),
-                selected = settings.darkThemeConfig == DarkThemeConfig.LIGHT,
-                onClick = { onChangeDarkThemeConfig(DarkThemeConfig.LIGHT) },
-            )
-            SettingsDialogThemeChooserRow(
-                text = stringResource(Res.string.dark_mode_config_dark),
-                selected = settings.darkThemeConfig == DarkThemeConfig.DARK,
-                onClick = { onChangeDarkThemeConfig(DarkThemeConfig.DARK) },
+        val themeLabel = when (settings.darkThemeConfig) {
+            DarkThemeConfig.FOLLOW_SYSTEM -> stringResource(Res.string.dark_mode_config_system_default)
+            DarkThemeConfig.LIGHT -> stringResource(Res.string.dark_mode_config_light)
+            DarkThemeConfig.DARK -> stringResource(Res.string.dark_mode_config_dark)
+        }
+
+        SelectionSettingsRow(
+            title = stringResource(Res.string.dark_mode_preference),
+            selectedValue = themeLabel,
+            onClick = { showThemeDialog = true }
+        )
+
+        if (showThemeDialog) {
+            DarkThemeConfigDialog(
+                currentConfig = settings.darkThemeConfig,
+                onConfigSelected = onChangeDarkThemeConfig,
+                onDismissRequest = { showThemeDialog = false }
             )
         }
     }
 }
 
 @Composable
-private fun BooleanSettings(
+private fun SwitchSettingsRow(
     title: String,
+    description: String? = null,
     value: Boolean,
     onValueChange: (Boolean) -> Unit,
     enabled: Boolean = true,
 ) {
-    SettingsDialogSectionTitle(text = title)
-    Column(Modifier.selectableGroup()) {
-        SettingsDialogThemeChooserRow(
-            text = stringResource(Res.string.settings_boolean_true),
-            selected = value,
-            onClick = { onValueChange(true) },
-            enabled = enabled,
-        )
-        SettingsDialogThemeChooserRow(
-            text = stringResource(Res.string.settings_boolean_false),
-            selected = !value,
-            onClick = { onValueChange(false) },
-            enabled = enabled,
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, role = Role.Switch) { onValueChange(!value) }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            )
+            if (description != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                )
+            }
+        }
+        Switch(
+            checked = value,
+            onCheckedChange = null,
+            enabled = enabled
         )
     }
 }
 
 @Composable
-private fun SettingsDialogSectionTitle(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+private fun SelectionSettingsRow(
+    title: String,
+    selectedValue: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = selectedValue,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DarkThemeConfigDialog(
+    currentConfig: DarkThemeConfig,
+    onConfigSelected: (DarkThemeConfig) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = {
+            Text(
+                text = stringResource(Res.string.dark_mode_preference),
+                style = MaterialTheme.typography.titleLarge
+            )
+        },
+        text = {
+            Column(Modifier.selectableGroup()) {
+                SettingsDialogThemeChooserRow(
+                    text = stringResource(Res.string.dark_mode_config_system_default),
+                    selected = currentConfig == DarkThemeConfig.FOLLOW_SYSTEM,
+                    onClick = {
+                        onConfigSelected(DarkThemeConfig.FOLLOW_SYSTEM)
+                        onDismissRequest()
+                    }
+                )
+                SettingsDialogThemeChooserRow(
+                    text = stringResource(Res.string.dark_mode_config_light),
+                    selected = currentConfig == DarkThemeConfig.LIGHT,
+                    onClick = {
+                        onConfigSelected(DarkThemeConfig.LIGHT)
+                        onDismissRequest()
+                    }
+                )
+                SettingsDialogThemeChooserRow(
+                    text = stringResource(Res.string.dark_mode_config_dark),
+                    selected = currentConfig == DarkThemeConfig.DARK,
+                    onClick = {
+                        onConfigSelected(DarkThemeConfig.DARK)
+                        onDismissRequest()
+                    }
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(Res.string.cancel))
+            }
+        }
     )
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -173,7 +173,7 @@ fun SettingsUI(
                 if (developerSettings != null && supportsNotifications) {
                     item {
                         val notificationPermissionState =
-                            rememberNotificationPermissionState(userEditableSettings?.useExperimentalFeatures)
+                            rememberNotificationPermissionState(userEditableSettings?.notificationsEnabled)
 
                         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                             Button(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -41,7 +41,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -152,45 +154,39 @@ fun SettingsUI(
 
                 if (developerSettings != null) {
                     item {
-                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                            Text(
-                                text = stringResource(Res.string.developerSettings),
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
-                            )
-                            Text(
-                                "Token: ${developerSettings.token}",
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Button(onClick = onSendNotifications, enabled = supportsNotifications) {
-                                Text("Send Notifications")
-                            }
+                        Text(
+                            text = stringResource(Res.string.developerSettings),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(top = 16.dp, bottom = 8.dp, start = 16.dp, end = 16.dp)
+                        )
+                    }
+
+                    developerSettings.token?.let { token ->
+                        item {
+                            TokenSettingsRow(token = token)
                         }
                     }
-                }
 
-                if (developerSettings != null && supportsNotifications) {
                     item {
-                        val notificationPermissionState =
-                            rememberNotificationPermissionState(userEditableSettings?.notificationsEnabled)
-
-                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                            Button(
-                                onClick = { notificationPermissionState.maybeRequest() },
-                            ) {
-                                Text("Request Notification Permission")
-                            }
-                        }
+                        ActionSettingsRow(
+                            title = "Send Test Notification",
+                            subtitle = "Trigger a mock session reminder alert",
+                            onClick = onSendNotifications,
+                            enabled = supportsNotifications
+                        )
                     }
 
-//                    item {
-//                        Column(modifier = Modifier.padding(8.dp)) {
-//                            Button(onClick = { controller.openAppSettings() }) {
-//                                Text("App Notification Settings")
-//                            }
-//                        }
-//                    }
+                    if (supportsNotifications) {
+                        item {
+                            val notificationPermissionState =
+                                rememberNotificationPermissionState(userEditableSettings?.notificationsEnabled)
+                            ActionSettingsRow(
+                                title = "Request Notification Permission",
+                                subtitle = "Prompt OS dialog to allow reminders",
+                                onClick = { notificationPermissionState.maybeRequest() }
+                            )
+                        }
+                    }
                 }
             }
 
@@ -417,6 +413,69 @@ fun SettingsDialogThemeChooserRow(
         )
         Spacer(Modifier.width(8.dp))
         Text(text)
+    }
+}
+
+@Composable
+private fun TokenSettingsRow(
+    token: String
+) {
+    val clipboardManager = LocalClipboardManager.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                clipboardManager.setText(AnnotatedString(token))
+            }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Developer Token",
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = token,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionSettingsRow(
+    title: String,
+    subtitle: String? = null,
+    onClick: () -> Unit,
+    enabled: Boolean = true
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            )
+            if (subtitle != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                )
+            }
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -1,17 +1,26 @@
 package dev.johnoreilly.confetti.ui.speakers
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
@@ -26,41 +35,64 @@ fun SpeakerItemView(
     speaker: SpeakerDetails,
     navigateToSpeaker: (id: String) -> Unit
 ) {
-    ListItem(
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = { navigateToSpeaker(speaker.id) }),
-        headlineContent = {
-            Text(text = speaker.name)
-        },
-        supportingContent = speaker.tagline?.let { company ->
-            {
-                Text(company)
-            }
-        },
-        leadingContent = {
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clickable(role = Role.Button) { navigateToSpeaker(speaker.id) },
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             SubcomposeAsyncImage(
                 model = speaker.photoUrl,
                 contentDescription = speaker.name,
                 loading = {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp
+                    )
                 },
                 error = {
                     Icon(
                         imageVector = ConfettiIcons.Person,
                         contentDescription = speaker.name,
                         modifier = Modifier
-                            .size(64.dp)
+                            .size(56.dp)
                             .clip(CircleShape),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 },
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .size(64.dp)
+                    .size(56.dp)
                     .clip(CircleShape)
             )
+
+            Spacer(modifier = Modifier.size(12.dp))
+
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = speaker.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                speaker.tagline?.let { tagline ->
+                    Spacer(modifier = Modifier.size(2.dp))
+                    Text(
+                        text = tagline,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    )
+                }
+            }
         }
-    )
+    }
 }
 
 @MobilePreviews

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -10,8 +10,13 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -29,6 +34,8 @@ fun SpeakerItemView(
     speaker: SpeakerDetails,
     navigateToSpeaker: (id: String) -> Unit
 ) {
+    var showFullScreenPhoto by remember { mutableStateOf(false) }
+
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
@@ -75,9 +82,18 @@ fun SpeakerItemView(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(CircleShape)
+                    .clickable { showFullScreenPhoto = true }
             )
         }
     )
+
+    if (showFullScreenPhoto) {
+        FullScreenPhotoDialog(
+            photoUrl = speaker.photoUrl,
+            contentDescription = speaker.name,
+            onDismissRequest = { showFullScreenPhoto = false }
+        )
+    }
 }
 
 @MobilePreviews

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -54,7 +54,7 @@ fun SpeakerItemView(
                             .clip(CircleShape),
                     )
                 },
-                contentScale = ContentScale.Fit,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(64.dp)
                     .clip(CircleShape)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -1,21 +1,15 @@
 package dev.johnoreilly.confetti.ui.speakers
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
@@ -35,18 +29,29 @@ fun SpeakerItemView(
     speaker: SpeakerDetails,
     navigateToSpeaker: (id: String) -> Unit
 ) {
-    Surface(
+    ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
             .clickable(role = Role.Button) { navigateToSpeaker(speaker.id) },
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        headlineContent = {
+            Text(
+                text = speaker.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        supportingContent = if (speaker.tagline != null) {
+            {
+                Text(
+                    text = speaker.tagline,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            null
+        },
+        leadingContent = {
             SubcomposeAsyncImage(
                 model = speaker.photoUrl,
                 contentDescription = speaker.name,
@@ -71,28 +76,8 @@ fun SpeakerItemView(
                     .size(56.dp)
                     .clip(CircleShape)
             )
-
-            Spacer(modifier = Modifier.size(12.dp))
-
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = speaker.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                speaker.tagline?.let { tagline ->
-                    Spacer(modifier = Modifier.size(2.dp))
-                    Text(
-                        text = tagline,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
-                    )
-                }
-            }
         }
-    }
+    )
 }
 
 @MobilePreviews

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -11,12 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -34,13 +35,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import androidx.compose.material3.CircularProgressIndicator
+import coil3.compose.SubcomposeAsyncImage
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.sessions
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.icons.Person
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.johnOreillySpeaker
 import dev.johnoreilly.confetti.preview.martinBonninSpeaker
@@ -62,15 +67,7 @@ fun SpeakerDetailsView(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = {
-                    SelectionContainer {
-                        Text(
-                            modifier = Modifier.padding(PaddingValues(start = 16.dp, end = 16.dp)),
-                            text = speaker.name,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                },
+                title = {},
                 navigationIcon = {
                     IconButton(onClick = { popBack() }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -96,51 +93,73 @@ fun SpeakerDetailsView(
                         .padding(contentPaddings),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    speaker.tagline?.let { city ->
-                        Text(
-                            text = city,
-                            textAlign = TextAlign.Center,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                    }
+                    val url = speaker.photoUrl
+                    SubcomposeAsyncImage(
+                        model = url,
+                        contentDescription = speaker.name,
+                        loading = {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp
+                            )
+                        },
+                        error = {
+                            Icon(
+                                imageVector = ConfettiIcons.Person,
+                                contentDescription = speaker.name,
+                                modifier = Modifier
+                                    .size(120.dp)
+                                    .clip(CircleShape),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(120.dp)
+                            .clip(CircleShape)
+                    )
 
                     Spacer(modifier = Modifier.size(16.dp))
 
-                    val url =  speaker.photoUrl // "https://confetti-app.dev/images/avatar/${conference}/${speaker.id}"
-                    AsyncImage(
-                        model = url,
-                        // Decorative: the speaker's name is already the screen title, so labelling the
-                        // photo with it makes a screen reader announce the name twice
-                        // (DuplicateSpeakableTextCheck). A null description lets TalkBack skip the image.
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .size(240.dp)
-                            .clip(RoundedCornerShape(16.dp)),
+                    Text(
+                        text = speaker.name,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center
                     )
 
-                    Spacer(modifier = Modifier.size(24.dp))
+                    speaker.tagline?.let { tagline ->
+                        Spacer(modifier = Modifier.size(4.dp))
+                        Text(
+                            text = tagline,
+                            textAlign = TextAlign.Center,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    if (speaker.socials.isNotEmpty()) {
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            speaker.socials.forEach { socialsItem ->
+                                SocialIcon(
+                                    modifier = Modifier.size(24.dp),
+                                    socialItem = socialsItem,
+                                    onClick = { onSocialLinkClicked(socialsItem.url) }
+                                )
+                            }
+                        }
+                    }
 
                     speaker.bio?.let { bio ->
+                        Spacer(modifier = Modifier.size(24.dp))
                         Text(
                             text = bio,
                             style = MaterialTheme.typography.bodyLarge
                         )
-
-                        Spacer(modifier = Modifier.size(16.dp))
-                    }
-
-                    Row(
-                        Modifier.padding(top = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        speaker.socials.forEach { socialsItem ->
-                            SocialIcon(
-                                modifier = Modifier.size(24.dp),
-                                socialItem = socialsItem,
-                                onClick = { onSocialLinkClicked(socialsItem.url) }
-                            )
-                        }
                     }
                 }
             }
@@ -164,7 +183,7 @@ fun SpeakerTalks(
 ) {
     Column(Modifier.fillMaxWidth()) {
 
-        ConfettiHeader(icon = Icons.Filled.Person, text = stringResource(Res.string.sessions))
+        ConfettiHeader(icon = Icons.Filled.Event, text = stringResource(Res.string.sessions))
 
         Spacer(modifier = Modifier.size(8.dp))
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -47,9 +47,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import coil3.compose.AsyncImage
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import coil3.compose.SubcomposeAsyncImage
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.sessions
@@ -187,52 +185,11 @@ fun SpeakerDetailsView(
     }
 
     if (showFullScreenPhoto) {
-        Dialog(
-            onDismissRequest = { showFullScreenPhoto = false },
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = true,
-                dismissOnClickOutside = true
-            )
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                AsyncImage(
-                    model = speaker.photoUrl,
-                    contentDescription = speaker.name,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable { showFullScreenPhoto = false }
-                )
-                Scaffold(
-                    containerColor = Color.Transparent,
-                    topBar = {
-                        CenterAlignedTopAppBar(
-                            title = {},
-                            navigationIcon = {
-                                IconButton(onClick = { showFullScreenPhoto = false }) {
-                                    Icon(
-                                        imageVector = Icons.Filled.Close,
-                                        contentDescription = "Close",
-                                        tint = Color.White
-                                    )
-                                }
-                            },
-                            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                                containerColor = Color.Transparent
-                            )
-                        )
-                    }
-                ) { padding ->
-                    Box(modifier = Modifier.padding(padding))
-                }
-            }
-        }
+        FullScreenPhotoDialog(
+            photoUrl = speaker.photoUrl,
+            contentDescription = speaker.name,
+            onDismissRequest = { showFullScreenPhoto = false }
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -179,7 +179,7 @@ fun SpeakerDetailsView(
             Spacer(modifier = Modifier.size(16.dp))
 
             SpeakerTalks(
-                modifier = Modifier.padding(contentPaddings),
+                modifier = Modifier.padding(vertical = 8.dp),
                 sessions = speaker.sessions,
                 navigateToSession = navigateToSession,
             )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -19,8 +19,10 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -167,16 +169,20 @@ fun SpeakerTalks(
         Spacer(modifier = Modifier.size(8.dp))
 
         Column(modifier) {
-            sessions.forEach { session ->
-                Row(
-                    Modifier
-                        .padding()
+            sessions.forEachIndexed { index, session ->
+                ListItem(
+                    modifier = Modifier
                         .fillMaxWidth()
-                        .clickable {
-                            navigateToSession(session.id)
-                        }
-                        .padding(vertical = 8.dp)) {
-                    Text(session.title, style = MaterialTheme.typography.bodyLarge)
+                        .clickable { navigateToSession(session.id) },
+                    headlineContent = {
+                        Text(
+                            text = session.title,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                )
+                if (index < sessions.lastIndex) {
+                    HorizontalDivider()
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -108,14 +108,14 @@ fun SpeakerDetailsView(
                                 imageVector = ConfettiIcons.Person,
                                 contentDescription = speaker.name,
                                 modifier = Modifier
-                                    .size(120.dp)
+                                    .size(200.dp)
                                     .clip(CircleShape),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         },
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
-                            .size(120.dp)
+                            .size(200.dp)
                             .clip(CircleShape)
                     )
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -198,28 +198,38 @@ fun SpeakerDetailsView(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black)
-                    .clickable { showFullScreenPhoto = false },
+                    .background(Color.Black),
                 contentAlignment = Alignment.Center
             ) {
                 AsyncImage(
                     model = speaker.photoUrl,
                     contentDescription = speaker.name,
                     contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-                IconButton(
-                    onClick = { showFullScreenPhoto = false },
                     modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .statusBarsPadding()
-                        .padding(16.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = "Close",
-                        tint = Color.White
-                    )
+                        .fillMaxSize()
+                        .clickable { showFullScreenPhoto = false }
+                )
+                Scaffold(
+                    containerColor = Color.Transparent,
+                    topBar = {
+                        CenterAlignedTopAppBar(
+                            title = {},
+                            navigationIcon = {
+                                IconButton(onClick = { showFullScreenPhoto = false }) {
+                                    Icon(
+                                        imageVector = Icons.Filled.Close,
+                                        contentDescription = "Close",
+                                        tint = Color.White
+                                    )
+                                }
+                            },
+                            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                                containerColor = Color.Transparent
+                            )
+                        )
+                    }
+                ) { padding ->
+                    Box(modifier = Modifier.padding(padding))
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -1,7 +1,9 @@
 package dev.johnoreilly.confetti.ui.speakers
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,6 +32,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +45,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
 import coil3.compose.SubcomposeAsyncImage
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.sessions
@@ -63,6 +73,7 @@ fun SpeakerDetailsView(
     onSocialLinkClicked: (String) -> Unit
 ) {
     val scrollState = rememberScrollState()
+    var showFullScreenPhoto by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -117,6 +128,7 @@ fun SpeakerDetailsView(
                         modifier = Modifier
                             .size(200.dp)
                             .clip(CircleShape)
+                            .clickable { showFullScreenPhoto = true }
                     )
 
                     Spacer(modifier = Modifier.size(16.dp))
@@ -171,6 +183,45 @@ fun SpeakerDetailsView(
                 sessions = speaker.sessions,
                 navigateToSession = navigateToSession,
             )
+        }
+    }
+
+    if (showFullScreenPhoto) {
+        Dialog(
+            onDismissRequest = { showFullScreenPhoto = false },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .clickable { showFullScreenPhoto = false },
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = speaker.photoUrl,
+                    contentDescription = speaker.name,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize()
+                )
+                IconButton(
+                    onClick = { showFullScreenPhoto = false },
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .statusBarsPadding()
+                        .padding(16.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Close",
+                        tint = Color.White
+                    )
+                }
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -113,7 +113,7 @@ fun SpeakerDetailsView(
                         // photo with it makes a screen reader announce the name twice
                         // (DuplicateSpeakableTextCheck). A null description lets TalkBack skip the image.
                         contentDescription = null,
-                        contentScale = ContentScale.Fit,
+                        contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .size(240.dp)
                             .clip(RoundedCornerShape(16.dp)),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
@@ -3,13 +3,19 @@ package dev.johnoreilly.confetti.ui.speakers
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -25,6 +32,8 @@ import coil3.compose.SubcomposeAsyncImage
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.sampleSpeakers
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.icons.Person
 
 
 @Composable
@@ -38,33 +47,63 @@ fun SpeakerGridView(
         contentPadding = PaddingValues(12.dp),
         content = {
             items(speakers) { speaker ->
-                Column(
+                Card(
                     modifier = Modifier
-                        .clickable { navigateToSpeaker(speaker.id) }
-                        .padding(12.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                        .padding(8.dp)
+                        .fillMaxWidth()
+                        .clickable { navigateToSpeaker(speaker.id) },
+                    shape = MaterialTheme.shapes.medium,
                 ) {
-
-                    // proxy image requests through backend
-                    val url = speaker.photoUrl //"https://confetti-app.dev/images/avatar/${conference}/${speaker.id}"
-                    SubcomposeAsyncImage(
-                        model = url,
-                        contentDescription = speaker.name,
-                        loading = {
-                            CircularProgressIndicator()
-                        },
-                        contentScale = ContentScale.Fit,
+                    Column(
                         modifier = Modifier
-                            .size(150.dp)
-                            .clip(RoundedCornerShape(16.dp)),
-                    )
-                    Text(
-                        text = speaker.name,
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(16.dp)
-                    )
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        SubcomposeAsyncImage(
+                            model = speaker.photoUrl,
+                            contentDescription = speaker.name,
+                            loading = {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            },
+                            error = {
+                                Icon(
+                                    imageVector = ConfettiIcons.Person,
+                                    contentDescription = speaker.name,
+                                    modifier = Modifier
+                                        .size(80.dp)
+                                        .clip(CircleShape),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(80.dp)
+                                .clip(CircleShape)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = speaker.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            textAlign = TextAlign.Center,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        speaker.tagline?.let { company ->
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = company,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersUI.kt
@@ -1,16 +1,19 @@
 package dev.johnoreilly.confetti.ui.speakers
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import dev.johnoreilly.confetti.ui.HomeScaffold
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.speakers
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsComponent
@@ -23,22 +26,26 @@ import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SpeakersUI(component: SpeakersComponent) {
+fun SpeakersUI(
+    component: SpeakersComponent,
+    windowSizeClass: WindowSizeClass,
+    topBarNavigationIcon: @Composable () -> Unit = {},
+    topBarActions: @Composable RowScope.() -> Unit = {},
+) {
     val uiState by component.uiState.subscribeAsState()
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(title = { Text(stringResource(Res.string.speakers)) })
-        }
+    HomeScaffold(
+        title = stringResource(Res.string.speakers),
+        windowSizeClass = windowSizeClass,
+        topBarNavigationIcon = topBarNavigationIcon,
+        topBarActions = topBarActions,
     ) {
-        Column(Modifier.padding(it)) {
-            when (val state = uiState) {
-                is SpeakersUiState.Success -> {
-                    SpeakerGridView(state.conference, state.speakers, component::onSpeakerClicked)
-                }
-                is SpeakersUiState.Loading -> LoadingView()
-                is SpeakersUiState.Error -> ErrorView {}
+        when (val state = uiState) {
+            is SpeakersUiState.Success -> {
+                SpeakerGridView(state.conference, state.speakers, component::onSpeakerClicked)
             }
+            is SpeakersUiState.Loading -> LoadingView()
+            is SpeakersUiState.Error -> ErrorView {}
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueUI.kt
@@ -1,35 +1,42 @@
 package dev.johnoreilly.confetti.ui.venue
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import dev.johnoreilly.confetti.decompose.VenueComponent
+import dev.johnoreilly.confetti.ui.HomeScaffold
 import dev.johnoreilly.confetti.ui.component.ErrorView
 import dev.johnoreilly.confetti.ui.component.LoadingView
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VenueUI(component: VenueComponent) {
+fun VenueUI(
+    component: VenueComponent,
+    windowSizeClass: WindowSizeClass,
+    topBarNavigationIcon: @Composable () -> Unit = {},
+    topBarActions: @Composable RowScope.() -> Unit = {},
+) {
     val uiState by component.uiState.subscribeAsState()
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(title = { Text("Venue")})
-        }
+    HomeScaffold(
+        title = "Venue",
+        windowSizeClass = windowSizeClass,
+        topBarNavigationIcon = topBarNavigationIcon,
+        topBarActions = topBarActions,
     ) {
-        Column(Modifier.padding(it)) {
-            when (val state = uiState) {
-                is VenueComponent.Success -> VenueView(state.data)
-                is VenueComponent.Loading -> LoadingView()
-                is VenueComponent.Error -> ErrorView {}
-            }
+        when (val state = uiState) {
+            is VenueComponent.Success -> VenueView(state.data)
+            is VenueComponent.Loading -> LoadingView()
+            is VenueComponent.Error -> ErrorView {}
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.ui.venue
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -53,7 +54,14 @@ fun VenueView(venue: Venue) {
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(200.dp),
+                    .height(200.dp)
+                    .then(
+                        if (!venue.mapLink.isNullOrBlank()) {
+                            Modifier.clickable { uriHandler.openUri(venue.mapLink) }
+                        } else {
+                            Modifier
+                        }
+                    ),
                 shape = RoundedCornerShape(16.dp)
             ) {
                 AsyncImage(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
@@ -25,10 +25,15 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -148,10 +153,13 @@ fun VenueFloorPlanButton(
     modifier: Modifier = Modifier,
     venue: Venue
 ) {
+    var showFullScreenMap by remember { mutableStateOf(false) }
+
     OutlinedCard(
         modifier = modifier
             .fillMaxWidth()
-            .height(250.dp),
+            .height(250.dp)
+            .clickable { showFullScreenMap = true },
         colors = CardDefaults.cardColors()
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {
@@ -162,6 +170,14 @@ fun VenueFloorPlanButton(
                 modifier = Modifier.fillMaxWidth()
             )
         }
+    }
+
+    if (showFullScreenMap) {
+        FullScreenPhotoDialog(
+            photoUrl = venue.floorPlanUrl,
+            contentDescription = venue.name,
+            onDismissRequest = { showFullScreenMap = false }
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
@@ -2,18 +2,33 @@ package dev.johnoreilly.confetti.ui.venue
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -24,29 +39,97 @@ import dev.johnoreilly.confetti.preview.sampleVenue
 
 @Composable
 fun VenueView(venue: Venue) {
+    val uriHandler = LocalUriHandler.current
+
     Column(
-        Modifier
-            .fillMaxWidth()
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.Start
     ) {
-        Text(venue.name, style = MaterialTheme.typography.titleLarge)
-        Spacer(modifier = Modifier.height(8.dp))
-        val mapLink = venue.mapLink
-        val address = venue.address
-        Text(venue.address.toString(), style = MaterialTheme.typography.titleSmall)
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(venue.description)
-        Spacer(modifier = Modifier.height(16.dp))
+        // 1. Venue Image Banner
+        if (!venue.imageUrl.isNullOrBlank()) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                AsyncImage(
+                    model = venue.imageUrl,
+                    contentDescription = venue.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
 
-        AsyncImage(
-            modifier = Modifier.height(300.dp),
-            model = venue.imageUrl,
-            contentDescription = venue.name,
+        // 2. Venue Name
+        Text(
+            text = venue.name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
         )
+        Spacer(modifier = Modifier.height(8.dp))
 
-        Spacer(modifier = Modifier.height(16.dp))
-        venue.floorPlanUrl?.let {
+        // 3. Venue Address with Location Icon & Map Button
+        venue.address?.let { address ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.LocationOn,
+                    contentDescription = "Location",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = address,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            if (!venue.mapLink.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = { uriHandler.openUri(venue.mapLink) },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Map,
+                        contentDescription = "Map"
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("View on Map")
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        // 4. Description
+        if (venue.description.isNotBlank()) {
+            Text(
+                text = venue.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        // 5. Floor Plan
+        venue.floorPlanUrl?.let { floorPlanUrl ->
+            Text(
+                text = "Floor Plan",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
             VenueFloorPlanButton(venue = venue)
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
@@ -46,6 +46,7 @@ import dev.johnoreilly.confetti.preview.sampleVenue
 @Composable
 fun VenueView(venue: Venue) {
     val uriHandler = LocalUriHandler.current
+    var showFullScreenPhoto by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -60,13 +61,7 @@ fun VenueView(venue: Venue) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(200.dp)
-                    .then(
-                        if (!venue.mapLink.isNullOrBlank()) {
-                            Modifier.clickable { uriHandler.openUri(venue.mapLink) }
-                        } else {
-                            Modifier
-                        }
-                    ),
+                    .clickable { showFullScreenPhoto = true },
                 shape = RoundedCornerShape(16.dp)
             ) {
                 AsyncImage(
@@ -145,6 +140,14 @@ fun VenueView(venue: Venue) {
             Spacer(modifier = Modifier.height(8.dp))
             VenueFloorPlanButton(venue = venue)
         }
+    }
+
+    if (showFullScreenPhoto) {
+        FullScreenPhotoDialog(
+            photoUrl = venue.imageUrl,
+            contentDescription = venue.name,
+            onDismissRequest = { showFullScreenPhoto = false }
+        )
     }
 }
 

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/ui/SharedViewControllers.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/ui/SharedViewControllers.kt
@@ -7,10 +7,10 @@ import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.ui.sessions.SessionDetailViewShared
 import platform.UIKit.UIViewController
 
-fun SessionDetailsViewController(conference: String, session: SessionDetails, conferenceThemeColor: String?, onSpeakerClick: (speakerId: String) -> Unit, onSocialLinkClicked: (String) -> Unit): UIViewController =
+fun SessionDetailsViewController(conference: String, session: SessionDetails, conferenceThemeColor: String?, onSpeakerClick: (speakerId: String) -> Unit): UIViewController =
     ComposeUIViewController {
         ConferenceMaterialThemeFromSettings(conferenceThemeColor) {
-            SessionDetailViewShared(conference, session, onSpeakerClick, onSocialLinkClicked)
+            SessionDetailViewShared(conference, session, onSpeakerClick)
         }
     }
 

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/ui/SessionDetailsViewSharedWrapper.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/ui/SessionDetailsViewSharedWrapper.kt
@@ -5,7 +5,7 @@ import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.ui.sessions.SessionDetailViewShared
 
 @Composable
-fun SessionDetailViewSharedWrapper(conference: String, session: SessionDetails?, onSpeakerClick: (speakerId: String) -> Unit, onSocialLinkClicked: (String) -> Unit) {
-    SessionDetailViewShared(conference, session, onSpeakerClick, onSocialLinkClicked)
+fun SessionDetailViewSharedWrapper(conference: String, session: SessionDetails?, onSpeakerClick: (speakerId: String) -> Unit) {
+    SessionDetailViewShared(conference, session, onSpeakerClick)
 }
 

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/ui/SessionDetailsViewSharedWrapper.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/ui/SessionDetailsViewSharedWrapper.kt
@@ -5,7 +5,7 @@ import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.ui.sessions.SessionDetailViewShared
 
 @Composable
-fun SessionDetailViewSharedWrapper(conference: String, session: SessionDetails?, onSpeakerClick: (speakerId: String) -> Unit, onSocialLinkClicked: (String) -> Unit) {
-    SessionDetailViewShared(conference, session, onSpeakerClick, onSocialLinkClicked)
+fun SessionDetailViewSharedWrapper(conference: String, session: SessionDetails?, onSpeakerClick: (speakerId: String) -> Unit) {
+    SessionDetailViewShared(conference, session, onSpeakerClick)
 }
 


### PR DESCRIPTION
Improved layout hierarchy and design on main screens. Speaker details view changes: removed horizontal margins on talks list for edge-to-edge dividers, and corrected calendar section icon. Session details view changes: increased session title text size, softened chip tag backgrounds, and hid detailed speaker biographies and social links to shorten layout. Unified speaker list item displays inside search and session details using standard `ListItem` with bold names and crop-scaled avatars.

Added new UI features. Extracted reusable `ConfettiSearch` bar component to unify search inputs. Created reusable `FullScreenPhotoDialog`. Aligned close button with screen top bar. Enabled tapping on speaker avatars, main venue image banner, and venue floor plan cards to launch full-screen viewer.

Fixed session details screen bug. Bookmark button now verifies user login state. Shows `SignInDialog` when signed-out user tries to bookmark a session, matching schedule screen behavior.

## Before & After

| Before | After |
| --- | --- |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/bf35e908-2f35-4c6b-9896-a079ca8ab0d4" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/cc55ddc2-7513-44d5-8c0e-9ca548789e90" /> |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/6f77949f-71ce-48fc-aacc-c1d85cc7bf4a" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/dd8064e9-7561-49d8-899f-9e7a2db642e3" /> |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/7fc3cb5e-da5b-42be-92df-606a7323d19b" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/a6d99cea-8f71-46b9-8942-b31f50155225" /> |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/f4dc4182-5e0f-4cb6-afd1-2dde0f1b0bce" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/a6ad2afb-c628-43d8-88e3-6698c0d0f4f9" /> |
| N/A | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/01e74fc8-a514-4171-b60a-1fe8f339b2e3" /> |
| N/A | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/8373fb8f-f17c-4863-af1f-71ecd6cd5b5a" /> |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/4a272f8b-314b-447e-8073-02252618f251" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/22c1be26-0c81-453e-9abb-0c2fbedb9f6d" /> |
| <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/a9279618-5bf4-4468-8167-daf441223713" /> | <img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/bc2e3346-adba-42bb-8513-04801ad4b23e" /> |