### PR TITLE
chore(deps): update compose-ai-tools to v0.19.25

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.18
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.25
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.18
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.25
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.18
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.25
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.19.18"
+composeai-preview = "0.19.25"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "description": "compose-ai-tools ships the preview CLI, the ee.schimke.composeai Gradle plugin, and the reusable CI composite actions as a single release, and this repo pins BOTH halves: the composeai-preview catalog key and the @v0.19.x action refs in design-artifacts.yml / compose-preview.yml. Without this rule they are separate updates and land in separate PRs, so the CLI and the action code that drives it skew apart between merges. Group them into one PR and skip the batching window so the published catalog tracks the renderer it was rendered with.",
+      "matchPackageNames": [
+        "yschimke/compose-ai-tools",
+        "/^ee\\.schimke\\.composeai($|[.:])/"
+      ],
+      "groupName": "compose-ai-tools",
+      "schedule": [
+        "at any time"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Bumps compose-ai-tools from `0.19.18` to `0.19.25` — the renderer behind the published `/confetti-mobile/` and `/confetti-wear/` design catalogs.

## Changes

- `gradle/libs.versions.toml`: `composeai-preview = "0.19.25"`
- `.github/workflows/design-artifacts.yml`: `install@v0.19.25`
- `.github/workflows/compose-preview.yml`: both `apply@` refs to `v0.19.25`

## Renovate grouping

This repo pins compose-ai-tools in **two** places — the `composeai-preview` catalog key and the `@v0.19.x` action refs — but `renovate.json` has no rule tying them together. They're separate updates to Renovate, so they land in separate PRs and the CLI can sit at one release while the action code driving it sits at another. compose-ai-tools ships the CLI, the Gradle plugin and the composite actions as one release, so that skew isn't harmless.

Added a `packageRules` entry grouping both under `compose-ai-tools`, matching what the sibling repos publishing to preview.coo.ee already do. Automerge is deliberately left off — that's your call on this repo, not something I wanted to switch on.

Happy to drop the renovate.json change and keep this to the version bump if you'd rather keep the config untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEAnP7catuBrUzog96WT1C)_