### PR TITLE
fix(screenshotTest): drop removed onSocialLinkClicked argument

### DIFF
--- a/androidApp/src/screenshotTest/kotlin/ScreenshotTest.kt
+++ b/androidApp/src/screenshotTest/kotlin/ScreenshotTest.kt
@@ -14,7 +14,6 @@ class ScreenshotTest {
                 conference = "kotlinconf2023",
                 session = sessionDetails,
                 onSpeakerClick = {},
-                onSocialLinkClicked = {}
             )
         }
     }


### PR DESCRIPTION
Fixes the **Compose Preview** workflow, which has been red on `main` since [#1773](https://github.com/joreilly/Confetti/pull/1773).

## The failure

```
e: androidApp/src/screenshotTest/kotlin/ScreenshotTest.kt:17:17
   No parameter with name 'onSocialLinkClicked' found.

Execution failed for task ':androidApp:compileDebugScreenshotTestKotlin'
```

#1773 removed the `onSocialLinkClicked` parameter from `SessionDetailViewShared`. Its own commit message records the follow-up — *"Remove the unused onSocialLinkClicked parameter from the JVM, WebAssembly, and iOS UI wrappers"* — and those three were updated. `androidApp/src/screenshotTest/` was the one caller that wasn't.

## Why it slipped through

Nothing in the normal build compiles that source set. `:androidApp:assemble*` doesn't, and neither does the `./gradlew :androidApp:testDebugUnitTest` that #1773 was tested with — `screenshotTest` is a separate source set registered by AGP. The only thing that pulls it in is the preview pipeline's `composePreviewDiscover`, so the break was invisible until Compose Preview ran, and then it took the whole render job down: discovery failed for all six modules, `_previews.json` came back empty, and no renders or diffs were produced at all.

## The fix

Drop the stale argument so the call matches the current signature:

```kotlin
SessionDetailViewShared(
    conference = "kotlinconf2023",
    session = sessionDetails,
    onSpeakerClick = {},
)
```

The remaining `onSocialLinkClicked` references in the tree all belong to `SpeakersDetailsView`, which still declares that parameter — they're unaffected.

Verified by inspection against the declaration in `shared/src/commonMain/.../SessionDetailsViewShared.kt`; I have not compiled it locally (no Android SDK in this environment), so CI on this PR is the real check. Given the compiler named the parameter explicitly, the risk is low.

Once this is green, the render diffs on future PRs become meaningful again — worth noting the renderer just moved from 0.19.18 to 0.19.25 in #1774, a span that is mostly theme-rendering changes, so the first post-fix baseline will likely show real movement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEAnP7catuBrUzog96WT1C)_