### PR TITLE
Disambiguate Confetti Wear breakpoint previews

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round, so the single mode is the large-round breakpoint. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog, and the per-conference theme foundations in dev.johnoreilly.confetti.wear.ui.ThemeFoundationPreviews (the Wear app themes itself per conference — seed colour plus, for KotlinConf/DevFest, a brand type family — so the Themes tab carries one sticker per identity, not just the stock scheme; the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them). The Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
+  "$comment": "Design-catalog spec for the Confetti Wear OS app. Code-led: it declares which @Preview composables (by exact function name) make up the published sticker sheet, their grouping, and captions. Consumed by the design-catalog export over a render of the :wearApp module, whose `ee.schimke.composeai.preview` Gradle plugin ONLY discovers @Preview functions in the MAIN source set (classes/kotlin/android/main), NOT screenshotTest — so every `preview` named here lives under wearApp/src/main/... . Wear is dark-first and round; screen entries publish explicit Small Round and Large Round breakpoint cards, while the generic live-rerender mode remains largeRound. Theme + Component specimens are in dev.johnoreilly.confetti.wear.ui.ComponentCatalog, and the per-conference theme foundations in dev.johnoreilly.confetti.wear.ui.ThemeFoundationPreviews (the Wear app themes itself per conference — seed colour plus, for KotlinConf/DevFest, a brand type family — so the Themes tab carries one sticker per identity, not just the stock scheme; the matching `@ThemeCatalog` providers in ConfettiThemeCatalogs let `compose-preview serve` re-render ANY preview live under any of them). The Screens are the in-main @Preview entry points next to each screen (HomeScreen, SessionsScreen, SessionDetailsView, SpeakerDetailsView, BookmarksScreen, ConferencesView, SettingsListView). Each group's `section` is the top-level tab the preview server buckets it under; groups follow this file's order, so tabs read Themes -> Components -> Screens.",
   "system": "confetti-wear",
   "title": "Confetti Wear",
   "library": ["androidx.wear.compose:compose-material3"],
@@ -111,14 +111,24 @@
       "section": "Screens",
       "components": [
         {
-          "componentId": "Home",
-          "preview": "HomeListViewPreview",
-          "caption": "Home screen — conference title, bookmarks and day list."
+          "componentId": "HomeSmall",
+          "preview": "HomeListViewSmallPreview",
+          "caption": "Home screen on the Small Round breakpoint — conference title, bookmarks and day list."
         },
         {
-          "componentId": "Sessions",
-          "preview": "SessionListViewPreview",
-          "caption": "Sessions schedule list grouped by start time."
+          "componentId": "HomeLarge",
+          "preview": "HomeListViewLargePreview",
+          "caption": "Home screen on the Large Round breakpoint — conference title, bookmarks and day list."
+        },
+        {
+          "componentId": "SessionsSmall",
+          "preview": "SessionListViewSmallPreview",
+          "caption": "Sessions schedule list on the Small Round breakpoint, grouped by start time."
+        },
+        {
+          "componentId": "SessionsLarge",
+          "preview": "SessionListViewLargePreview",
+          "caption": "Sessions schedule list on the Large Round breakpoint, grouped by start time."
         },
         {
           "componentId": "SessionDetails",
@@ -131,19 +141,34 @@
           "caption": "Speaker details — photo, name, tagline and bio."
         },
         {
-          "componentId": "Bookmarks",
-          "preview": "BookmarksPreview",
-          "caption": "Bookmarks screen — upcoming and past bookmarked sessions."
+          "componentId": "BookmarksSmall",
+          "preview": "BookmarksSmallPreview",
+          "caption": "Bookmarks screen on the Small Round breakpoint — upcoming and past bookmarked sessions."
         },
         {
-          "componentId": "Conferences",
-          "preview": "ConferencesViewPreview",
-          "caption": "Conference picker list."
+          "componentId": "BookmarksLarge",
+          "preview": "BookmarksLargePreview",
+          "caption": "Bookmarks screen on the Large Round breakpoint — upcoming and past bookmarked sessions."
         },
         {
-          "componentId": "Settings",
-          "preview": "SettingsListViewPreview",
-          "caption": "Settings screen."
+          "componentId": "ConferencesSmall",
+          "preview": "ConferencesViewSmallPreview",
+          "caption": "Conference picker list on the Small Round breakpoint."
+        },
+        {
+          "componentId": "ConferencesLarge",
+          "preview": "ConferencesViewLargePreview",
+          "caption": "Conference picker list on the Large Round breakpoint."
+        },
+        {
+          "componentId": "SettingsSmall",
+          "preview": "SettingsListViewSmallPreview",
+          "caption": "Settings screen on the Small Round breakpoint."
+        },
+        {
+          "componentId": "SettingsLarge",
+          "preview": "SettingsListViewLargePreview",
+          "caption": "Settings screen on the Large Round breakpoint."
         }
       ]
     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/bookmarks/BookmarksScreen.kt
@@ -23,6 +23,7 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.R
@@ -209,10 +210,20 @@ fun BookmarksScreen(
     }
 }
 
-@WearPreviewDevices
-@WearPreviewFontScales
+@WearPreviewSmallRound
 @Composable
-fun BookmarksPreview() {
+fun BookmarksSmallPreview() {
+    BookmarksPreviewContent()
+}
+
+@WearPreviewLargeRound
+@Composable
+fun BookmarksLargePreview() {
+    BookmarksPreviewContent()
+}
+
+@Composable
+private fun BookmarksPreviewContent() {
     ConfettiPreviewScaffold {
         BookmarksScreen(
             uiState = QueryResult.Success(
@@ -306,5 +317,4 @@ fun BookmarksPreviewLong() {
         )
     }
 }
-
 

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/conferences/ConferencesView.kt
@@ -33,6 +33,7 @@ import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
@@ -192,10 +193,20 @@ private fun ConferencesChip(
     }
 }
 
-@WearPreviewDevices
-@WearPreviewFontScales
+@WearPreviewSmallRound
 @Composable
-fun ConferencesViewPreview() {
+fun ConferencesViewSmallPreview() {
+    ConferencesViewPreviewContent()
+}
+
+@WearPreviewLargeRound
+@Composable
+fun ConferencesViewLargePreview() {
+    ConferencesViewPreviewContent()
+}
+
+@Composable
+private fun ConferencesViewPreviewContent() {
     ConfettiPreviewScaffold {
         ConferencesView(
             uiState = ConferencesComponent.Success(
@@ -255,4 +266,3 @@ fun ConferencesViewCuratedPreview() {
         )
     }
 }
-

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/home/HomeScreen.kt
@@ -43,9 +43,8 @@ import androidx.wear.compose.material3.lazy.transformedHeight
 import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.placeholderShimmer
 import androidx.wear.compose.material3.rememberPlaceholderState
-import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.R
@@ -346,10 +345,20 @@ fun DayChip(
     }
 }
 
-@WearPreviewDevices
-@WearPreviewFontScales
+@WearPreviewSmallRound
 @Composable
-fun HomeListViewPreview() {
+fun HomeListViewSmallPreview() {
+    HomeListViewPreviewContent()
+}
+
+@WearPreviewLargeRound
+@Composable
+fun HomeListViewLargePreview() {
+    HomeListViewPreviewContent()
+}
+
+@Composable
+private fun HomeListViewPreviewContent() {
     ConfettiPreviewScaffold {
         HomeScreen(
             uiState = QueryResult.Success(
@@ -486,4 +495,3 @@ fun HomeListViewDevFest() {
         )
     }
 }
-

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessions/SessionsScreen.kt
@@ -17,9 +17,8 @@ import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
-import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 import dev.johnoreilly.confetti.decompose.SessionsUiState
@@ -101,10 +100,20 @@ fun SessionsScreen(
     }
 }
 
-@WearPreviewDevices
-@WearPreviewFontScales
+@WearPreviewSmallRound
 @Composable
-fun SessionListViewPreview() {
+fun SessionListViewSmallPreview() {
+    SessionListViewPreviewContent()
+}
+
+@WearPreviewLargeRound
+@Composable
+fun SessionListViewLargePreview() {
+    SessionListViewPreviewContent()
+}
+
+@Composable
+private fun SessionListViewPreviewContent() {
     ConfettiPreviewScaffold {
         SessionsScreen(
             uiState = SessionsUiState.Success(
@@ -177,4 +186,3 @@ fun SessionListViewLongPreview() {
         )
     }
 }
-

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/settings/SettingsListView.kt
@@ -41,9 +41,8 @@ import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.lazy.TransformationSpec
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
-import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
-import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
+import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import coil.compose.AsyncImage
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
@@ -321,10 +320,20 @@ private fun TransformingLazyColumnScope.developerModeOptions(
     }
 }
 
-@WearPreviewDevices
-@WearPreviewFontScales
+@WearPreviewSmallRound
 @Composable
-fun SettingsListViewPreview() {
+fun SettingsListViewSmallPreview() {
+    SettingsListViewPreviewContent()
+}
+
+@WearPreviewLargeRound
+@Composable
+fun SettingsListViewLargePreview() {
+    SettingsListViewPreviewContent()
+}
+
+@Composable
+private fun SettingsListViewPreviewContent() {
     ConfettiPreviewScaffold {
         SettingsListView(
             conferenceCleared = {},
@@ -354,4 +363,3 @@ fun SettingsListViewLongPreview() {
         )
     }
 }
-


### PR DESCRIPTION
## Goal

Fix the Confetti issues from [compose-ai-tools#3267](https://github.com/yschimke/compose-ai-tools/issues/3267), without changing other app catalogs.

## Summary

- Split the five cataloged Wear screens into explicit Small Round and Large Round preview entry points while sharing each screen fixture.
- Update `catalog.spec.json` with ten breakpoint-qualified component IDs and captions, removing indistinguishable duplicate card labels.
- Preserve Confetti Wear's intentional dark-only conference theme behavior; mobile and other catalogs are unchanged.
- Root cause: each catalog entry targeted one `@WearPreviewDevices` function, so Small/Large artifacts inherited the same visible component label.
- No abandoned implementation remains; the shared private preview content avoids duplicating fixture setup.
- Known gap: the aggregate renderer still reports the pre-existing optional `activity__MainActivity` Koin startup failure; all ten changed previews rendered successfully.
- Generated catalog output is intentionally not tracked on this branch; `design-artifacts.yml` publishes it from `main` to the separate delivery branches after merge.

## Verification

- `./gradlew :wearApp:compileDebugKotlin`
- `git diff --check` and `jq empty catalog.spec.json`
- Rendered and visually inspected:
  - `dev.johnoreilly.confetti.wear.home.HomeScreenKt.HomeListViewSmallPreview_Devices - Small Round`
  - `dev.johnoreilly.confetti.wear.home.HomeScreenKt.HomeListViewLargePreview_Devices - Large Round`
  - `dev.johnoreilly.confetti.wear.sessions.SessionsScreenKt.SessionListViewSmallPreview_Devices - Small Round`
  - `dev.johnoreilly.confetti.wear.sessions.SessionsScreenKt.SessionListViewLargePreview_Devices - Large Round`
  - `dev.johnoreilly.confetti.wear.bookmarks.BookmarksScreenKt.BookmarksSmallPreview_Devices - Small Round`
  - `dev.johnoreilly.confetti.wear.bookmarks.BookmarksScreenKt.BookmarksLargePreview_Devices - Large Round`
  - `dev.johnoreilly.confetti.wear.conferences.ConferencesViewKt.ConferencesViewSmallPreview_Devices - Small Round`
  - `dev.johnoreilly.confetti.wear.conferences.ConferencesViewKt.ConferencesViewLargePreview_Devices - Large Round`
  - `dev.johnoreilly.confetti.wear.settings.SettingsListViewKt.SettingsListViewSmallPreview_Devices - Small Round`
  - `dev.johnoreilly.confetti.wear.settings.SettingsListViewKt.SettingsListViewLargePreview_Devices - Large Round`
