### PR TITLE
chore(deps): update compose-ai-tools to 0.19.40

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.30
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.40
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.30
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.40
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.30
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.40
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.19.30"
+composeai-preview = "0.19.40"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 


### PR DESCRIPTION
Bumps the composeai-preview catalog version (which drives both the Gradle
plugin and the preview-annotations dependency) from 0.19.30 to 0.19.40, and
pins the shared compose-ai-tools GitHub actions to the matching tag:

  - .github/workflows/compose-preview.yml   apply@v0.19.40   (both jobs)
  - .github/workflows/design-artifacts.yml  install@v0.19.40

Coordinates and plugin id are unchanged. Verified locally that the plugin
resolves and applies at 0.19.40 and that the composePreview* tasks still
register.