### PR TITLE
Request notification permission when enabling notifications in settings

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
@@ -3,4 +3,7 @@ package dev.johnoreilly.confetti.permissions
 import androidx.compose.runtime.Composable
 
 @Composable
-expect fun rememberNotificationPermissionState(notificationsActive: Boolean?): NotificationPermissionState
+expect fun rememberNotificationPermissionState(
+    notificationsActive: Boolean?,
+    onPermissionStatus: (hasPermission: Boolean) -> Unit = {}
+): NotificationPermissionState

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -104,6 +104,15 @@ fun SettingsUI(
     onNotificationsEnabled: (value: Boolean) -> Unit,
     popBack: () -> Unit
 ) {
+    val notificationPermissionState = rememberNotificationPermissionState(
+        notificationsActive = userEditableSettings?.notificationsEnabled,
+        onPermissionStatus = { hasPermission ->
+            if (userEditableSettings?.notificationsEnabled != hasPermission) {
+                onNotificationsEnabled(hasPermission)
+            }
+        }
+    )
+
     val scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     /**
      * usePlatformDefaultWidth = false is use as a temporary fix to allow
@@ -147,7 +156,13 @@ fun SettingsUI(
                         settings = userEditableSettings,
                         onChangeDarkThemeConfig = onChangeDarkThemeConfig,
                         onChangeUseExperimentalFeatures = onChangeUseExperimentalFeatures,
-                        onChangeNotificationsEnabled = onNotificationsEnabled,
+                        onChangeNotificationsEnabled = { enabled ->
+                                if (enabled) {
+                                    notificationPermissionState.maybeRequest()
+                                } else {
+                                    onNotificationsEnabled(false)
+                                }
+                            },
                         supportsNotifications = supportsNotifications,
                     )
                 }
@@ -174,18 +189,6 @@ fun SettingsUI(
                             onClick = onSendNotifications,
                             enabled = supportsNotifications
                         )
-                    }
-
-                    if (supportsNotifications) {
-                        item {
-                            val notificationPermissionState =
-                                rememberNotificationPermissionState(userEditableSettings?.notificationsEnabled)
-                            ActionSettingsRow(
-                                title = "Request Notification Permission",
-                                subtitle = "Prompt OS dialog to allow reminders",
-                                onClick = { notificationPermissionState.maybeRequest() }
-                            )
-                        }
                     }
                 }
             }

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.jvm.kt
@@ -3,6 +3,9 @@ package dev.johnoreilly.confetti.permissions
 import androidx.compose.runtime.Composable
 
 @Composable
-actual fun rememberNotificationPermissionState(notificationsActive: Boolean?): NotificationPermissionState {
+actual fun rememberNotificationPermissionState(
+    notificationsActive: Boolean?,
+    onPermissionStatus: (hasPermission: Boolean) -> Unit
+): NotificationPermissionState {
     return NotificationPermissionState.NotApplicable
 }

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
@@ -3,6 +3,8 @@ package dev.johnoreilly.confetti.permissions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import dev.icerock.moko.permissions.Permission
 import dev.icerock.moko.permissions.PermissionState
 import dev.icerock.moko.permissions.PermissionsController
@@ -13,30 +15,36 @@ import dev.icerock.moko.permissions.notifications.REMOTE_NOTIFICATION
 import kotlinx.coroutines.launch
 
 @Composable
-actual fun rememberNotificationPermissionState(notificationsActive: Boolean?): NotificationPermissionState {
-    return when (notificationsActive) {
-        true -> {
-            val factory: PermissionsControllerFactory = rememberPermissionsControllerFactory()
-            val controller: PermissionsController = remember(factory) { factory.createPermissionsController() }
-            BindEffect(controller)
-            val coroutineScope = rememberCoroutineScope()
-            return remember(coroutineScope) {
-                NotificationPermissionState.Requestable {
-                    coroutineScope.launch {
-                        val permissionState = controller.getPermissionState(Permission.REMOTE_NOTIFICATION)
-                        when (permissionState) {
-                            PermissionState.NotDetermined, PermissionState.NotGranted -> {
-                                controller.providePermission(Permission.REMOTE_NOTIFICATION)
-                            }
+actual fun rememberNotificationPermissionState(
+    notificationsActive: Boolean?,
+    onPermissionStatus: (hasPermission: Boolean) -> Unit
+): NotificationPermissionState {
+    val factory: PermissionsControllerFactory = rememberPermissionsControllerFactory()
+    val controller: PermissionsController = remember(factory) { factory.createPermissionsController() }
+    BindEffect(controller)
+    val coroutineScope = rememberCoroutineScope()
 
-                            else -> {}
-                        }
-
-                    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (notificationsActive == true) {
+            coroutineScope.launch {
+                val permissionState = controller.getPermissionState(Permission.REMOTE_NOTIFICATION)
+                if (permissionState != PermissionState.Granted) {
+                    onPermissionStatus(false)
                 }
             }
         }
-        false -> NotificationPermissionState.NotApplicable
-        else -> NotificationPermissionState.NotDetermined
+    }
+
+    return remember(coroutineScope) {
+        NotificationPermissionState.Requestable {
+            coroutineScope.launch {
+                try {
+                    controller.providePermission(Permission.REMOTE_NOTIFICATION)
+                    onPermissionStatus(true)
+                } catch (e: Exception) {
+                    onPermissionStatus(false)
+                }
+            }
+        }
     }
 }

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.wasmJs.kt
@@ -3,6 +3,9 @@ package dev.johnoreilly.confetti.permissions
 import androidx.compose.runtime.Composable
 
 @Composable
-actual fun rememberNotificationPermissionState(notificationsActive: Boolean?): NotificationPermissionState {
+actual fun rememberNotificationPermissionState(
+    notificationsActive: Boolean?,
+    onPermissionStatus: (hasPermission: Boolean) -> Unit
+): NotificationPermissionState {
     return NotificationPermissionState.NotApplicable
 }


### PR DESCRIPTION
Require notification permission when user toggles settings switch on. If user denies permission, turn settings toggle back off automatically. Also check permission state when settings screen resumes; disable settings toggle if user revoked permission from system. Remove obsolete developer settings button for permission request.