### PR TITLE
chore(deps): update compose-ai-tools to 0.19.45

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.40
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.45
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.40
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.45
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.45
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.46
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.45
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.46
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.45
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.46
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.40
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.19.45
         with:
           version: catalog
           catalog-key: composeai-preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.19.45"
+composeai-preview = "0.19.46"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.70.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "0.19.40"
+composeai-preview = "0.19.45"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 


### PR DESCRIPTION
## Summary

Bumps the compose-ai-tools pin from `0.19.40` to `0.19.45`.

- `gradle/libs.versions.toml`: `composeai-preview = "0.19.45"` (drives `ee.schimke.composeai:preview-annotations` and the `ee.schimke.composeai.preview` plugin, used by `androidApp` and `wearApp`)
- `.github/workflows/compose-preview.yml`: both `actions/apply@v0.19.45`
- `.github/workflows/design-artifacts.yml`: `actions/install@v0.19.45`

The catalog key and the action refs move together so the workflow CLI and the in-build plugin come from the same release.

## Visual evidence

Renderer-version bump only — no composable, theme, or preview in this repo changed, so there is no source-level before/after to picture. Any pixel drift originates in the renderer itself and is captured by the `compose-preview` visual-diff bot on this PR (base render vs head render).

## Test plan

- `compose-preview` renders `androidApp` and `wearApp` previews against 0.19.45.
- `design-artifacts` regenerates the delivery branches after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFqEqb1QaTbL542XYjJYvf)_