### PR TITLE
Add iOS TestFlight publishing via fastlane

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -1,0 +1,57 @@
+name: Publish iOS (TestFlight)
+
+# Manual only: publishing shouldn't fire on every push. Requires three repo secrets
+# holding an App Store Connect API key (Settings > Secrets and variables > Actions):
+#   ASC_KEY_ID       - the key's Key ID
+#   ASC_ISSUER_ID    - the Issuer ID from App Store Connect > Users and Access > Integrations
+#   ASC_KEY_CONTENT  - base64 of the AuthKey_XXXX.p8  (base64 -i AuthKey_XXXX.p8)
+# Run `fastlane ios createApp` once locally first to register the bundle id + app record
+# (Confetti's app record already exists on App Store Connect, so this is a no-op here).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-ios-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  testflight:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+      # Unique, monotonic build number per run (CFBundleVersion) so TestFlight accepts each upload.
+      BUILD_NUMBER: ${{ github.run_number }}
+      # Read-only BuildFetch remote cache (see settings.gradle.kts): RO token and no ON_CI, so the
+      # Kotlin/Native compile Gradle runs (invoked by xcodebuild) only read from the cache.
+      BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN: ${{ secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      # Kotlin/Native framework (:shared:embedAndSignAppleFrameworkForXcode) is compiled by the
+      # Xcode build phase via Gradle; cache its dependencies and the Konan toolchain across runs.
+      - uses: gradle/actions/setup-gradle@v6
+
+      - name: Cache KMP libraries
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-v1-${{ hashFiles('**/libs.versions.toml') }}
+
+      - name: Set Xcode Version 26.6
+        shell: bash
+        run: |
+          xcodes select 26.6
+
+      - name: Build and upload to TestFlight
+        run: fastlane ios beta

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,8 @@ terraform.tfstate.backup
 swiftpm
 /.kotlin/
 
+# fastlane iOS build output (gym default output_directory is repo root)
+*.ipa
+*.app.dSYM.zip
+
 */.compose-preview-history

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,9 @@
+# Android (supply / Play Store)
 json_key_file "api-7766993617350370117-734745-0ad3ebc14f84.json" # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
 package_name "dev.johnoreilly.confetti"
+
+# iOS (produce / pilot / deliver — App Store Connect). Auth is via the App Store
+# Connect API key resolved in the Fastfile, so no apple_id/team_id is needed here.
+for_platform :ios do
+  app_identifier "dev.johnoreilly.confetti"
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,3 +143,169 @@ platform :android do
     # )
   end
 end
+
+
+platform :ios do
+
+    ios_app_identifier = "dev.johnoreilly.confetti"
+    ios_app_name = "Confetti"
+    marketingVersion = "1.0.16"
+
+    # Resolves an App Store Connect API key from environment variables so no Apple ID
+    # password or 2FA is ever needed (works identically locally and in CI). Create the
+    # key once at App Store Connect > Users and Access > Integrations > App Store Connect
+    # API (needs App Manager or Admin role on the team to also create the app record),
+    # then set:
+    #   ASC_KEY_ID      - the key's Key ID
+    #   ASC_ISSUER_ID   - the Issuer ID shown above the keys table
+    #   ASC_KEY_CONTENT - base64 of the downloaded AuthKey_XXXX.p8
+    #                     (generate with: base64 -i AuthKey_XXXX.p8 | pbcopy)
+    def app_store_api_key
+        app_store_connect_api_key(
+            key_id: ENV.fetch("ASC_KEY_ID"),
+            issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+            key_content: ENV.fetch("ASC_KEY_CONTENT"),
+            is_key_content_base64: true
+        )
+    end
+
+
+    desc "One-time: register the bundle id and create the App Store Connect app record"
+    lane :createApp do |options|
+        # NOTE: we deliberately don't use `produce` here. produce authenticates every step via
+        # Spaceship::ConnectAPI.login, which forces an Apple ID web session (2FA) and ignores the
+        # App Store Connect API key. Instead we call the App Store Connect API directly with the
+        # token that app_store_connect_api_key installs on Spaceship::ConnectAPI, so this stays
+        # fully key-authenticated (no Apple ID / 2FA). Needs a key with Admin or App Manager role.
+        app_store_api_key
+        require "spaceship"
+
+        # 1. Register the App ID (bundle id) in the developer account, if not already there.
+        if Spaceship::ConnectAPI::BundleId.find(ios_app_identifier).nil?
+            UI.message("Registering bundle id #{ios_app_identifier}")
+            Spaceship::ConnectAPI::BundleId.create(
+                name: ios_app_name, # Apple Developer portal name: letters, numbers and spaces only
+                identifier: ios_app_identifier,
+                platform: Spaceship::ConnectAPI::BundleIdPlatform::IOS
+            )
+            UI.success("Registered bundle id #{ios_app_identifier}")
+        else
+            UI.success("Bundle id #{ios_app_identifier} already registered")
+        end
+
+        # 2. The App Store Connect app record. The App Store Connect API cannot create apps
+        #    (POST /apps is rejected: "resource 'apps' does not allow CREATE"), so this single
+        #    step can't use the API key — create the record once in the web UI. The bundle id
+        #    registered above is selectable in the New App dialog. Everything after this
+        #    (fastlane ios beta / release) is fully API-key driven.
+        if Spaceship::ConnectAPI::App.find(ios_app_identifier).nil?
+            UI.important("Bundle id is registered, but no App Store Connect app record exists yet.")
+            UI.important("Apple's API can't create apps — do it once at https://appstoreconnect.apple.com/apps")
+            UI.important("  \"+\" > New App  |  Platform: iOS  |  Name: #{ios_app_name}")
+            UI.important("  Primary language: English  |  Bundle ID: #{ios_app_identifier}  |  SKU: confetti-ios")
+            UI.important("Then run: fastlane ios beta")
+        else
+            UI.success("App '#{ios_app_name}' already exists on App Store Connect")
+        end
+    end
+
+
+    desc "Build a Release archive and upload it to TestFlight"
+    lane :beta do |options|
+        api_key = app_store_api_key
+
+        # TestFlight rejects duplicate build numbers, so default to a UTC timestamp
+        # (override with BUILD_NUMBER, e.g. the CI run number). Passed as an xcarg so
+        # no agvtool/apple-generic versioning setup is required on the target.
+        build_number = ENV["BUILD_NUMBER"] || Time.now.utc.strftime("%Y%m%d%H%M")
+
+        build_app(
+            project: "iosApp/iosApp.xcodeproj",
+            scheme: "iosApp",
+            configuration: "Release",
+            export_method: "app-store",
+            # Let Xcode create/refresh the App Store distribution profile via the API key.
+            xcargs: "MARKETING_VERSION=#{marketingVersion} CURRENT_PROJECT_VERSION=#{build_number} -allowProvisioningUpdates"
+        )
+
+        upload_to_testflight(
+            api_key: api_key,
+            skip_waiting_for_build_processing: true
+        )
+    end
+
+
+    desc "Show the processing state of the most recent TestFlight builds"
+    lane :buildStatus do |options|
+        app_store_api_key
+        app = Spaceship::ConnectAPI::App.find(ios_app_identifier)
+        UI.user_error!("No App Store Connect record for #{ios_app_identifier}") if app.nil?
+        builds = Spaceship::ConnectAPI::Build.all(app_id: app.id, limit: 5)
+        if builds.empty?
+            UI.important("No TestFlight builds found for #{ios_app_identifier}")
+        else
+            builds.each do |b|
+                UI.message("#{b.pre_release_version&.version} (#{b.version}) - #{b.processing_state} - uploaded #{b.uploaded_date}")
+            end
+        end
+    end
+
+
+    desc "Upload the App Store listing text (fastlane/metadata/ios) to App Store Connect — no binary, no screenshots"
+    lane :uploadMetadata do |options|
+        deliver(
+            api_key: app_store_api_key,
+            app_identifier: ios_app_identifier,
+            metadata_path: "fastlane/metadata/ios",
+            skip_binary_upload: true,
+            skip_screenshots: true,
+            skip_metadata: false,
+            run_precheck_before_submit: false,
+            force: true,
+            submit_for_review: false
+        )
+    end
+
+
+    desc "Upload the App Store screenshots (fastlane/metadata/ios/screenshots/<locale>) to App Store Connect"
+    lane :uploadScreenshots do |options|
+        # Uploads screenshots only — no binary, and skip_metadata leaves the listing text alone.
+        # deliver auto-detects the device size (e.g. 6.9" iPhone) from each image's dimensions.
+        deliver(
+            api_key: app_store_api_key,
+            app_identifier: ios_app_identifier,
+            # iOS metadata + screenshots share fastlane/metadata/ios (locale dirs hold both the
+            # .txt and the .png). Point deliver here so it doesn't scan the shared ./fastlane/metadata
+            # (which has the non-locale android/ios subdirs and fails locale validation).
+            metadata_path: "fastlane/metadata/ios",
+            screenshots_path: "fastlane/metadata/ios",
+            skip_binary_upload: true,
+            skip_metadata: true,
+            skip_screenshots: false,
+            overwrite_screenshots: true,
+            run_precheck_before_submit: false,
+            force: true,
+            submit_for_review: false
+        )
+    end
+
+
+    desc "Submit the latest TestFlight build + metadata to the App Store for review"
+    lane :release do |options|
+        deliver(
+            api_key: app_store_api_key,
+            app_identifier: ios_app_identifier,
+            # Locale dirs under fastlane/metadata/ios hold both the .txt metadata and the .png
+            # screenshots; point deliver here so it skips the shared ./fastlane/metadata (whose
+            # non-locale android/ios subdirs fail deliver's locale validation).
+            metadata_path: "fastlane/metadata/ios",
+            screenshots_path: "fastlane/metadata/ios",
+            submit_for_review: false,
+            automatic_release: false,
+            force: true,               # skip the HTML metadata preview / confirmation prompt
+            skip_binary_upload: true,  # reuse the build already sent to TestFlight by :beta
+            overwrite_screenshots: true,
+            precheck_include_in_app_purchases: false
+        )
+    end
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -81,6 +81,59 @@ Promote app from alpha to production in Play Store
 
 ----
 
+
+## iOS
+
+### ios createApp
+
+```sh
+[bundle exec] fastlane ios createApp
+```
+
+One-time: register the bundle id and create the App Store Connect app record
+
+### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
+```
+
+Build a Release archive and upload it to TestFlight
+
+### ios buildStatus
+
+```sh
+[bundle exec] fastlane ios buildStatus
+```
+
+Show the processing state of the most recent TestFlight builds
+
+### ios uploadMetadata
+
+```sh
+[bundle exec] fastlane ios uploadMetadata
+```
+
+Upload the App Store listing text (fastlane/metadata/ios) to App Store Connect — no binary, no screenshots
+
+### ios uploadScreenshots
+
+```sh
+[bundle exec] fastlane ios uploadScreenshots
+```
+
+Upload the App Store screenshots (fastlane/metadata/ios/screenshots/<locale>) to App Store Connect
+
+### ios release
+
+```sh
+[bundle exec] fastlane ios release
+```
+
+Submit the latest TestFlight build + metadata to the App Store for review
+
+----
+
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 
 More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -23,7 +23,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.15</string>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -35,8 +37,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleVersion</key>
-	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## Summary
- Add a `platform :ios` block to `fastlane/Fastfile` (lanes: `createApp`, `beta`, `buildStatus`, `uploadMetadata`, `uploadScreenshots`, `release`), matching the App Store Connect API-key-based approach used in FormAI and GalwayBus — no Apple ID / 2FA needed.
- Add the `for_platform :ios` block to `fastlane/Appfile`.
- Add `.github/workflows/publish-ios.yml`, a manual (`workflow_dispatch`) CI workflow that runs `fastlane ios beta`, mirroring GalwayBus's `publish-ios.yml` but keeping Confetti's existing Gradle/BuildFetch caching and pinned Xcode 26.6.
- Fix `iosApp/iosApp/Info.plist`: `CFBundleShortVersionString`/`CFBundleVersion` were hardcoded literals (`1.0.15`/`1`) instead of `$(MARKETING_VERSION)`/`$(CURRENT_PROJECT_VERSION)` placeholders, so the Fastfile's version overrides were silently ignored during TestFlight uploads (discovered while validating this — the first two upload attempts failed with Apple's "closed pre-release train" / "must contain CFBundleShortVersionString" errors until this was fixed).
- `.gitignore`: ignore `*.ipa` / `*.app.dSYM.zip`, which `gym` (fastlane's build_app) writes to repo root by default.

Verified locally end-to-end: `fastlane ios beta` built, signed, and successfully uploaded build 1.0.16 to TestFlight (App Store Connect app id 1660211390).

Two things still need manual setup before the new CI workflow can run:
- Repo secrets `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_CONTENT` (App Store Connect API key) aren't configured yet.
- `fastlane/metadata/ios` doesn't exist yet (only `metadata/android` does), so `uploadMetadata`/`uploadScreenshots`/`release` will fail until populated — `beta` doesn't need it.

## Test plan
- [x] `ruby -c` on `Fastfile`/`Appfile` — syntax OK
- [x] `plutil -lint` on `Info.plist` — OK
- [x] Ran `fastlane ios beta` locally end-to-end — archive, sign, export, and TestFlight upload all succeeded
- [ ] Add `ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_KEY_CONTENT` repo secrets, then trigger `publish-ios.yml` from Actions to verify CI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)