### PR TITLE
Correct ASC API key role requirement comment

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,8 +156,8 @@ platform :ios do
     # Resolves an App Store Connect API key from environment variables so no Apple ID
     # password or 2FA is ever needed (works identically locally and in CI). Create the
     # key once at App Store Connect > Users and Access > Integrations > App Store Connect
-    # API (needs App Manager or Admin role on the team to also create the app record),
-    # then set:
+    # API (needs Admin role — App Manager can't drive Xcode's Cloud Managed Signing during
+    # `beta`'s archive/export step, and can't create the app record either), then set:
     #   ASC_KEY_ID      - the key's Key ID
     #   ASC_ISSUER_ID   - the Issuer ID shown above the keys table
     #   ASC_KEY_CONTENT - base64 of the downloaded AuthKey_XXXX.p8


### PR DESCRIPTION
## Summary
Doc-only fix: the comment said App Manager or Admin role was sufficient for the ASC API key. In practice App Manager fails the `beta` lane's archive/export step with "Cloud signing permission error" / "No signing certificate found" — confirmed while getting `publish-ios.yml` working (see #1784's history). Admin is required.

## Test plan
- [x] `ruby -c fastlane/Fastfile` — syntax OK (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)