### PR TITLE
Rework session grid view as a time-proportional calendar layout

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -1,25 +1,27 @@
 package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +38,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -45,7 +48,6 @@ import dev.johnoreilly.confetti.decompose.SessionsUiState
 import dev.johnoreilly.confetti.fragment.RoomDetails
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.isLightning
-import dev.johnoreilly.confetti.isService
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.sessionsSuccessState
 import dev.johnoreilly.confetti.ui.SignInDialog
@@ -54,6 +56,25 @@ import dev.johnoreilly.confetti.ui.component.LoadingView
 import dev.johnoreilly.confetti.ui.icons.Bolt
 import dev.johnoreilly.confetti.ui.icons.Bookmark
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+
+// Width of the leading time-axis column, and each room column
+private val TimeAxisWidth = 64.dp
+private val RoomColumnWidth = 280.dp
+
+// Height of the room-name header row, shared by the pinned time axis (as a matching spacer)
+// and the scrollable room columns, so the two stay aligned.
+private val RoomHeaderHeight = 56.dp
+
+// Vertical scale of the grid: how tall one minute of conference time renders as.
+private val MinuteHeight = 3.dp
+
+// Interval, in minutes, between horizontal gridlines/time labels.
+private const val GridSlotMinutes = 30
+
+// Below this rendered height, a session card switches to a compact, title-only layout.
+private val CompactCardThreshold = 64.dp
 
 @Composable
 fun SessionListGridView(
@@ -70,8 +91,6 @@ fun SessionListGridView(
         SessionsUiState.Loading -> LoadingView()
 
         is SessionsUiState.Success -> {
-
-            println("SessionsUiState.Success, conference = ${uiState.conferenceName}")
             Column {
                 val pagerState = rememberPagerState {
                     uiState.formattedConfDates.size
@@ -80,57 +99,195 @@ fun SessionListGridView(
                 SessionListTabRow(pagerState, uiState)
 
                 HorizontalPager(state = pagerState) { page ->
+                    SessionScheduleGrid(
+                        conference = uiState.conference,
+                        confDate = uiState.confDates[page],
+                        sessionsByStartTime = uiState.sessionsByStartTimeList[page],
+                        allRooms = uiState.rooms,
+                        bookmarks = uiState.bookmarks,
+                        sessionSelected = sessionSelected,
+                        addBookmark = addBookmark,
+                        removeBookmark = removeBookmark,
+                        onNavigateToSignIn = onNavigateToSignIn,
+                        isLoggedIn = isLoggedIn,
+                    )
+                }
+            }
+        }
+    }
+}
 
-                    Row(Modifier.horizontalScroll(rememberScrollState())) {                        val sessionsByStartTime = uiState.sessionsByStartTimeList[page]
+/**
+ * Renders one conference day as a time-proportional grid: rooms as columns, a shared time axis
+ * down the left, and sessions positioned/sized by their actual start/end time (like a calendar
+ * day view) rather than bucketed into fixed-height rows. Sessions that genuinely overlap within
+ * the same room are placed side-by-side as sub-columns instead of one silently hiding the other.
+ */
+@Composable
+private fun SessionScheduleGrid(
+    conference: String,
+    confDate: LocalDate,
+    sessionsByStartTime: Map<String, List<SessionDetails>>,
+    allRooms: List<RoomDetails>,
+    bookmarks: Set<String>,
+    sessionSelected: (id: String) -> Unit,
+    addBookmark: (sessionId: String) -> Unit,
+    removeBookmark: (sessionId: String) -> Unit,
+    onNavigateToSignIn: () -> Unit,
+    isLoggedIn: Boolean,
+) {
+    val daySessions = remember(sessionsByStartTime) {
+        sessionsByStartTime.values.flatten().filter { it.room != null }
+    }
+    val rooms = remember(daySessions, allRooms) {
+        allRooms.filter { room -> daySessions.any { it.room?.name == room.name } }
+    }
 
-                        val rooms = uiState.rooms.filter { room ->
-                            sessionsByStartTime.values.any { session -> session.any { it.room?.name == room.name } }
-                        }
+    if (rooms.isEmpty() || daySessions.isEmpty()) {
+        return
+    }
 
-                        val timeInfoWidth = 90.dp
-                        val sessionInfoWidth = 280.dp
+    val gridStart = remember(daySessions) {
+        floorToSlot(daySessions.minOf { it.startsAt.offsetMinutes(confDate) }, GridSlotMinutes)
+    }
+    val gridEnd = remember(daySessions) {
+        ceilToSlot(daySessions.maxOf { it.endsAt.offsetMinutes(confDate) }, GridSlotMinutes)
+    }
 
-                        Column {
-                            Row(
-                                modifier = Modifier.padding(
-                                    start = timeInfoWidth,
-                                    top = 16.dp,
-                                    bottom = 16.dp
-                                )
-                            ) {
-                                rooms.forEach { room ->
-                                    Text(
-                                        modifier = Modifier.width(sessionInfoWidth),
-                                        textAlign = TextAlign.Center,
-                                        fontSize = 20.sp,
-                                        fontWeight = FontWeight.Bold,
-                                        text = room.name
+    val placedSessionsByRoom = remember(daySessions, rooms) {
+        rooms.associateWith { room ->
+            assignOverlapColumns(daySessions.filter { it.room?.name == room.name }, confDate)
+        }
+    }
+
+    // The time intervals each room actually has a session running, so gridlines aren't drawn
+    // across dead time in that room's column - whether that's before its first session, after
+    // its last one, or a gap between two sessions (e.g. a room packed with short lightning talks
+    // that don't quite line up with the other rooms' longer sessions).
+    val roomSessionIntervals = remember(daySessions, rooms, confDate) {
+        rooms.associateWith { room ->
+            daySessions
+                .filter { it.room?.name == room.name }
+                .map { it.startsAt.offsetMinutes(confDate)..it.endsAt.offsetMinutes(confDate) }
+        }
+    }
+
+    val verticalScrollState = rememberScrollState()
+    val totalHeight = MinuteHeight * (gridEnd - gridStart)
+
+    Row {
+        // Pinned time axis: scrolls vertically in lockstep with the room columns (shared scroll
+        // state) but stays put when the room columns scroll horizontally, so you don't lose track
+        // of what time you're looking at once you've scrolled past the first couple of rooms.
+        Column {
+            Spacer(Modifier.height(RoomHeaderHeight))
+            Box(Modifier.verticalScroll(verticalScrollState)) {
+                Box(
+                    Modifier
+                        .width(TimeAxisWidth)
+                        .height(totalHeight)
+                        .padding(bottom = 16.dp)
+                ) {
+                    var slotStart = gridStart
+                    while (slotStart <= gridEnd) {
+                        val y = MinuteHeight * (slotStart - gridStart)
+                        Text(
+                            text = formatMinuteOfDay(slotStart),
+                            modifier = Modifier
+                                .offset(x = 0.dp, y = y - 8.dp)
+                                .width(TimeAxisWidth - 8.dp),
+                            textAlign = TextAlign.End,
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        slotStart += GridSlotMinutes
+                    }
+                }
+            }
+        }
+
+        Box(
+            Modifier
+                .width(1.dp)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.outlineVariant)
+        )
+
+        Row(Modifier.horizontalScroll(rememberScrollState())) {
+            Column {
+                Row(
+                    modifier = Modifier.height(RoomHeaderHeight),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    rooms.forEach { room ->
+                        Text(
+                            modifier = Modifier.width(RoomColumnWidth),
+                            textAlign = TextAlign.Center,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold,
+                            text = room.name
+                        )
+                    }
+                }
+
+                Box(Modifier.verticalScroll(verticalScrollState)) {
+                    Box(
+                        Modifier
+                            .width(RoomColumnWidth * rooms.size)
+                            .height(totalHeight)
+                            .padding(bottom = 16.dp)
+                    ) {
+                        var slotStart = gridStart
+                        while (slotStart <= gridEnd) {
+                            val y = MinuteHeight * (slotStart - gridStart)
+                            rooms.forEachIndexed { roomIndex, room ->
+                                if (roomSessionIntervals.getValue(room).any { slotStart in it }) {
+                                    Box(
+                                        Modifier
+                                            .offset(x = RoomColumnWidth * roomIndex, y = y)
+                                            .width(RoomColumnWidth)
+                                            .height(1.dp)
+                                            .background(MaterialTheme.colorScheme.outlineVariant)
                                     )
                                 }
                             }
+                            slotStart += GridSlotMinutes
+                        }
 
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                contentPadding = PaddingValues(end = 16.dp)
-                            ) {
-                                sessionsByStartTime.forEach {
-                                    item {
-                                        SessionGridRow(
-                                            conference = uiState.conference,
-                                            sessionByTimeList = it,
-                                            rooms = rooms,
-                                            bookmarks = uiState.bookmarks,
-                                            sessionInfoWidth = sessionInfoWidth,
-                                            timeInfoWidth = timeInfoWidth,
-                                            sessionSelected = sessionSelected,
-                                            addBookmark = addBookmark,
-                                            removeBookmark = removeBookmark,
-                                            onNavigateToSignIn = onNavigateToSignIn,
-                                            isLoggedIn = isLoggedIn,
-                                        )
-                                    }
-                                }
+                        rooms.forEachIndexed { roomIndex, _ ->
+                            Box(
+                                Modifier
+                                    .offset(x = RoomColumnWidth * roomIndex)
+                                    .width(1.dp)
+                                    .height(totalHeight)
+                                    .background(MaterialTheme.colorScheme.outlineVariant)
+                            )
+                        }
+
+                        rooms.forEachIndexed { roomIndex, room ->
+                            placedSessionsByRoom.getValue(room).forEach { placed ->
+                                val columnWidth = RoomColumnWidth / placed.columnCount
+                                val x = RoomColumnWidth * roomIndex +
+                                    columnWidth * placed.columnIndex
+                                val y = MinuteHeight * (placed.startOffset - gridStart)
+                                val height = MinuteHeight * (placed.endOffset - placed.startOffset)
+
+                                SessionGridCard(
+                                    conference = conference,
+                                    session = placed.session,
+                                    bookmarks = bookmarks,
+                                    height = height,
+                                    sessionSelected = sessionSelected,
+                                    addBookmark = addBookmark,
+                                    removeBookmark = removeBookmark,
+                                    onNavigateToSignIn = onNavigateToSignIn,
+                                    isLoggedIn = isLoggedIn,
+                                    modifier = Modifier
+                                        .offset(x = x, y = y)
+                                        .width(columnWidth)
+                                        .height(height)
+                                        .padding(2.dp),
+                                )
                             }
                         }
                     }
@@ -140,104 +297,159 @@ fun SessionListGridView(
     }
 }
 
+/** A session as placed within a single room column: its time offsets and overlap sub-column. */
+private data class PlacedSession(
+    val session: SessionDetails,
+    val startOffset: Int,
+    val endOffset: Int,
+    val columnIndex: Int,
+    val columnCount: Int,
+)
+
+/**
+ * Lays sessions for a single room out on a timeline, splitting genuinely overlapping sessions
+ * into side-by-side sub-columns (the same greedy-interval-coloring approach a calendar day view
+ * uses) instead of letting one silently hide the other.
+ */
+private fun assignOverlapColumns(
+    sessions: List<SessionDetails>,
+    confDate: LocalDate,
+): List<PlacedSession> {
+    data class Interval(val session: SessionDetails, val start: Int, val end: Int)
+
+    val sorted = sessions
+        .map { Interval(it, it.startsAt.offsetMinutes(confDate), it.endsAt.offsetMinutes(confDate)) }
+        .sortedWith(compareBy({ it.start }, { it.end }))
+
+    // Group into clusters of transitively-overlapping sessions.
+    val clusters = mutableListOf<MutableList<Interval>>()
+    var clusterEnd = Int.MIN_VALUE
+    for (interval in sorted) {
+        if (clusters.isEmpty() || interval.start >= clusterEnd) {
+            clusters += mutableListOf(interval)
+            clusterEnd = interval.end
+        } else {
+            clusters.last() += interval
+            clusterEnd = maxOf(clusterEnd, interval.end)
+        }
+    }
+
+    val result = mutableListOf<PlacedSession>()
+    for (cluster in clusters) {
+        val columnEnds = mutableListOf<Int>()
+        val columnIndexOf = mutableMapOf<Interval, Int>()
+        for (interval in cluster) {
+            val freeColumn = columnEnds.indexOfFirst { it <= interval.start }
+            if (freeColumn >= 0) {
+                columnEnds[freeColumn] = interval.end
+                columnIndexOf[interval] = freeColumn
+            } else {
+                columnEnds += interval.end
+                columnIndexOf[interval] = columnEnds.size - 1
+            }
+        }
+        val columnCount = columnEnds.size
+        cluster.forEach { interval ->
+            result += PlacedSession(
+                session = interval.session,
+                startOffset = interval.start,
+                endOffset = interval.end,
+                columnIndex = columnIndexOf.getValue(interval),
+                columnCount = columnCount,
+            )
+        }
+    }
+    return result
+}
+
+private fun LocalDateTime.offsetMinutes(referenceDate: LocalDate): Int {
+    val dayDiff = (date.toEpochDays() - referenceDate.toEpochDays()).toInt()
+    return dayDiff * 24 * 60 + hour * 60 + minute
+}
+
+private fun floorToSlot(minutes: Int, slot: Int) = (minutes / slot) * slot
+private fun ceilToSlot(minutes: Int, slot: Int) = ((minutes + slot - 1) / slot) * slot
+
+private fun formatMinuteOfDay(minutes: Int): String {
+    val normalized = ((minutes % (24 * 60)) + 24 * 60) % (24 * 60)
+    val hour = normalized / 60
+    val minute = normalized % 60
+    return "${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}"
+}
 
 @Composable
-fun SessionGridRow(
+private fun SessionGridCard(
     conference: String,
-    sessionByTimeList: Map.Entry<String, List<SessionDetails>>,
+    session: SessionDetails,
     bookmarks: Set<String>,
-    rooms: List<RoomDetails>,
-    sessionInfoWidth: Dp,
-    timeInfoWidth: Dp,
+    height: Dp,
     sessionSelected: (id: String) -> Unit,
     addBookmark: (sessionId: String) -> Unit,
     removeBookmark: (sessionId: String) -> Unit,
     onNavigateToSignIn: () -> Unit,
     isLoggedIn: Boolean,
+    modifier: Modifier = Modifier,
 ) {
-    Row {
-        Text(
-            sessionByTimeList.key,
-            modifier = Modifier
-                .width(timeInfoWidth)
-                .padding(16.dp),
-            fontWeight = FontWeight.Bold,
-            fontSize = 18.sp,
-            color = MaterialTheme.colorScheme.primary
-        )
+    val compact = height < CompactCardThreshold
 
-        val sessionList = rooms.mapNotNull { room ->
-            sessionByTimeList.value.find { it.room?.name == room.name }
-        }
-
-        val height = if (sessionList.size == 1 && sessionList[0].isService())
-            100.dp
-        else
-            220.dp
-
-        rooms.forEach { room ->
-            val session = sessionList.firstOrNull { it.room?.name == room.name }
-
-            if (session != null) {
-                Surface(
-                    modifier = Modifier
-                        .width(sessionInfoWidth)
-                        .height(height)
-                        .padding(bottom = 16.dp)
-                        .clickable(onClick = {
-                            sessionSelected(session.id)
-                        })
-                        .border(BorderStroke(1.dp, MaterialTheme.colorScheme.primary)),
-                    color = MaterialTheme.colorScheme.surfaceContainerLow
-                ) {
-                    Box(Modifier.fillMaxSize()) {
-                        Column(
-                            modifier = Modifier
-                                .padding(16.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Text(
-                                modifier = Modifier.align(Alignment.Start),
-                                text = session.title,
-                                fontSize = 16.sp,
-                                textAlign = TextAlign.Start,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer
+    Surface(
+        modifier = modifier
+            .clickable(onClick = { sessionSelected(session.id) })
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.primary)),
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = 8.dp,
+                    vertical = if (compact) 4.dp else 12.dp
+                ),
+            ) {
+                Text(
+                    text = session.title,
+                    fontSize = if (compact) 12.sp else 16.sp,
+                    maxLines = if (compact) 2 else 4,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Start,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                if (!compact) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Speakers(conference, session)
+                }
+                if (session.isLightning()) {
+                    Surface(
+                        modifier = Modifier.padding(top = if (compact) 2.dp else 8.dp),
+                        shape = MaterialTheme.shapes.extraSmall,
+                        color = MaterialTheme.colorScheme.primaryContainer
+                    ) {
+                        Row(Modifier.padding(vertical = 2.dp, horizontal = 6.dp)) {
+                            Icon(
+                                imageVector = ConfettiIcons.Bolt,
+                                contentDescription = "lightning",
+                                modifier = Modifier.size(12.dp),
                             )
-                            //Spacer(modifier = Modifier.weight(1f))
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Speakers(conference, session)
-                            if (session.isLightning()) {
-                                Surface(
-                                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                                    shape = MaterialTheme.shapes.small,
-                                    color = MaterialTheme.colorScheme.primaryContainer
-                                ) {
-                                    Row(Modifier.padding(vertical = 4.dp, horizontal = 8.dp)) {
-                                        // TODO find alternative
-                                        Icon(imageVector = ConfettiIcons.Bolt, contentDescription = "lightning")
-                                        Spacer(Modifier.width(4.dp))
-                                        Text("Lightning / ${session.startsAt.time}-${session.endsAt.time}")
-                                    }
-                                }
+                            if (!compact) {
+                                Spacer(Modifier.width(4.dp))
+                                Text(
+                                    "Lightning / ${session.startsAt.time}-${session.endsAt.time}",
+                                    fontSize = 10.sp,
+                                )
                             }
                         }
-                        Bookmark(
-                            modifier = Modifier.align(Alignment.CenterEnd),
-                            bookmarks = bookmarks,
-                            session = session,
-                            isLoggedIn = isLoggedIn,
-                            removeBookmark = removeBookmark,
-                            addBookmark = addBookmark,
-                            onNavigateToSignIn = onNavigateToSignIn
-                        )
                     }
                 }
-            } else {
-                Box(Modifier
-                    .width(sessionInfoWidth)
-                    .height(height)
-                )
             }
+            Bookmark(
+                modifier = Modifier.align(Alignment.TopEnd),
+                compact = compact,
+                bookmarks = bookmarks,
+                session = session,
+                isLoggedIn = isLoggedIn,
+                removeBookmark = removeBookmark,
+                addBookmark = addBookmark,
+                onNavigateToSignIn = onNavigateToSignIn
+            )
         }
     }
 }
@@ -277,6 +489,7 @@ private fun Speakers(conference: String, session: SessionDetails) {
 @Composable
 private fun Bookmark(
     modifier: Modifier = Modifier,
+    compact: Boolean = false,
     bookmarks: Set<String>,
     session: SessionDetails,
     isLoggedIn: Boolean,
@@ -288,22 +501,37 @@ private fun Bookmark(
 
     val isBookmarked = bookmarks.contains(session.id)
     if (isBookmarked) {
-        IconButton(
-            modifier = modifier,
-            onClick = {
-                if (isLoggedIn) {
-                    removeBookmark(session.id)
-                } else {
-                    showDialog = true
-                }
+        val onClick = {
+            if (isLoggedIn) {
+                removeBookmark(session.id)
+            } else {
+                showDialog = true
             }
-        ) {
+        }
+        if (compact) {
+            // A full IconButton enforces a 48dp minimum touch target, which doesn't fit a
+            // lightning-talk-sized card - so trade that down for a small, directly-clickable icon.
             Icon(
                 imageVector = ConfettiIcons.Bookmark,
                 contentDescription = "remove bookmark",
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(8.dp)
+                modifier = modifier
+                    .padding(4.dp)
+                    .size(14.dp)
+                    .clickable(onClick = onClick)
             )
+        } else {
+            IconButton(
+                modifier = modifier,
+                onClick = onClick,
+            ) {
+                Icon(
+                    imageVector = ConfettiIcons.Bookmark,
+                    contentDescription = "remove bookmark",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
         }
     } else {
         // disable from this view for now


### PR DESCRIPTION
## Summary
- Replace the fixed-height, start-time-bucketed grid rows with a time-proportional layout: each session's position/height is derived from its actual start/end time, like a calendar day view.
- Fix overlap handling: sessions that genuinely overlap within the same room now render side-by-side as sub-columns instead of one silently hiding the other (previously `firstOrNull` matching would drop all but one session sharing a room+start-time).
- Only draw gridlines where a room actually has a session running (not across dead time before/after/between sessions).
- Pin the time axis so it stays visible while the room columns scroll horizontally.
- Keep a (smaller) bookmark affordance on compact/lightning-talk cards instead of dropping it entirely.

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata` passes
- [x] Manually verified in `./gradlew :compose-desktop:run`: time-proportional sizing (Break/Lunch cells scaled to real duration), gridlines only under active rooms, pinned time axis while scrolling to later rooms, overlap sub-columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)