### PR TITLE
Fix speaker photos not loading on web

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,6 +115,7 @@ coil-test = { module = "io.coil-kt:coil-test", version.ref = "io-coil-kt" }
 coil3-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "io-coil3-kt" }
 coil3-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "io-coil3-kt" }
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version = "3.5.2" }
+ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version = "3.5.2" }
 materialkolor = { module = "com.materialkolor:material-kolor", version.ref = "materialkolor" }
 
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -188,6 +188,9 @@ kotlin {
 
         val wasmJsMain by getting {
             dependencies {
+                // coil3-network-ktor needs an explicit HttpClientEngine per platform; without
+                // this, Coil's remote image fetches (e.g. speaker photos) silently fail on web.
+                implementation(libs.ktor.client.js)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,0 +1,15 @@
+package dev.johnoreilly.confetti
+
+import dev.johnoreilly.confetti.fragment.SpeakerDetails
+
+/**
+ * The avatar URL to render for this speaker on the current platform.
+ *
+ * Native platforms use [SpeakerDetails.photoUrl] (the original Sessionize-hosted image) directly.
+ * The web target instead routes through the backend's proxied [SpeakerDetails.photoUrlThumbnail],
+ * since Sessionize's CDN rejects the same URL when fetched via browser fetch()/XHR from a foreign
+ * origin (likely anti-hotlink/bot protection) even though it works fine via direct navigation or a
+ * native HTTP client - the proxy sidesteps that, at the cost of an extra hop native platforms don't
+ * need to pay for.
+ */
+expect fun SpeakerDetails.avatarUrl(): String?

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -201,8 +201,8 @@ internal fun SessionSpeakerInfo(
             null
         },
         leadingContent = {
-            speaker.photoUrl?.let {
-                val url = speaker.photoUrl
+            speaker.photoUrlThumbnail?.let {
+                val url = speaker.photoUrlThumbnail
                 SubcomposeAsyncImage(
                     model = url,
                     contentDescription = speaker.name,
@@ -224,7 +224,7 @@ internal fun SessionSpeakerInfo(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrl,
+            photoUrl = speaker.photoUrlThumbnail,
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.speakers
+import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.fullNameAndCompany
@@ -201,8 +202,7 @@ internal fun SessionSpeakerInfo(
             null
         },
         leadingContent = {
-            speaker.photoUrlThumbnail?.let {
-                val url = speaker.photoUrlThumbnail
+            speaker.avatarUrl()?.let { url ->
                 SubcomposeAsyncImage(
                     model = url,
                     contentDescription = speaker.name,
@@ -224,7 +224,7 @@ internal fun SessionSpeakerInfo(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrlThumbnail,
+            photoUrl = speaker.avatarUrl(),
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -463,8 +463,8 @@ private fun Speakers(conference: String, session: SessionDetails) {
                 .padding(2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (speaker.speakerDetails.photoUrl?.isNotEmpty() == true) {
-                val url = speaker.speakerDetails.photoUrl //"https://confetti-app.dev/images/avatar/${conference}/${speaker.id}"
+            if (speaker.speakerDetails.photoUrlThumbnail?.isNotEmpty() == true) {
+                val url = speaker.speakerDetails.photoUrlThumbnail
                 AsyncImage(
                     model = url,
                     contentDescription = speaker.speakerDetails.name,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -47,6 +47,7 @@ import coil3.compose.AsyncImage
 import dev.johnoreilly.confetti.decompose.SessionsUiState
 import dev.johnoreilly.confetti.fragment.RoomDetails
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.isLightning
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.sessionsSuccessState
@@ -463,8 +464,8 @@ private fun Speakers(conference: String, session: SessionDetails) {
                 .padding(2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (speaker.speakerDetails.photoUrlThumbnail?.isNotEmpty() == true) {
-                val url = speaker.speakerDetails.photoUrlThumbnail
+            val url = speaker.speakerDetails.avatarUrl()
+            if (url?.isNotEmpty() == true) {
                 AsyncImage(
                     model = url,
                     contentDescription = speaker.speakerDetails.name,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -60,7 +60,7 @@ fun SpeakerItemView(
         },
         leadingContent = {
             SubcomposeAsyncImage(
-                model = speaker.photoUrl,
+                model = speaker.photoUrlThumbnail,
                 contentDescription = speaker.name,
                 loading = {
                     CircularProgressIndicator(
@@ -89,7 +89,7 @@ fun SpeakerItemView(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrl,
+            photoUrl = speaker.photoUrlThumbnail,
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakerItemView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
+import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.johnOreillySpeaker
@@ -60,7 +61,7 @@ fun SpeakerItemView(
         },
         leadingContent = {
             SubcomposeAsyncImage(
-                model = speaker.photoUrlThumbnail,
+                model = speaker.avatarUrl(),
                 contentDescription = speaker.name,
                 loading = {
                     CircularProgressIndicator(
@@ -89,7 +90,7 @@ fun SpeakerItemView(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrlThumbnail,
+            photoUrl = speaker.avatarUrl(),
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -55,6 +55,7 @@ import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import dev.johnoreilly.confetti.ui.icons.Person
 import dev.johnoreilly.confetti.preview.MobilePreviews
+import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.preview.johnOreillySpeaker
 import dev.johnoreilly.confetti.preview.martinBonninSpeaker
 import dev.johnoreilly.confetti.ui.component.ConfettiHeader
@@ -102,7 +103,7 @@ fun SpeakerDetailsView(
                         .padding(contentPaddings),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    val url = speaker.photoUrlThumbnail
+                    val url = speaker.avatarUrl()
                     SubcomposeAsyncImage(
                         model = url,
                         contentDescription = speaker.name,
@@ -186,7 +187,7 @@ fun SpeakerDetailsView(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrlThumbnail,
+            photoUrl = speaker.avatarUrl(),
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -102,7 +102,7 @@ fun SpeakerDetailsView(
                         .padding(contentPaddings),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    val url = speaker.photoUrl
+                    val url = speaker.photoUrlThumbnail
                     SubcomposeAsyncImage(
                         model = url,
                         contentDescription = speaker.name,
@@ -186,7 +186,7 @@ fun SpeakerDetailsView(
 
     if (showFullScreenPhoto) {
         FullScreenPhotoDialog(
-            photoUrl = speaker.photoUrl,
+            photoUrl = speaker.photoUrlThumbnail,
             contentDescription = speaker.name,
             onDismissRequest = { showFullScreenPhoto = false }
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
@@ -61,7 +61,7 @@ fun SpeakerGridView(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         SubcomposeAsyncImage(
-                            model = speaker.photoUrl,
+                            model = speaker.photoUrlThumbnail,
                             contentDescription = speaker.name,
                             loading = {
                                 CircularProgressIndicator(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersGridView.kt
@@ -29,6 +29,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
+import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.sampleSpeakers
@@ -61,7 +62,7 @@ fun SpeakerGridView(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         SubcomposeAsyncImage(
-                            model = speaker.photoUrlThumbnail,
+                            model = speaker.avatarUrl(),
                             contentDescription = speaker.name,
                             loading = {
                                 CircularProgressIndicator(

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,0 +1,5 @@
+package dev.johnoreilly.confetti
+
+import dev.johnoreilly.confetti.fragment.SpeakerDetails
+
+actual fun SpeakerDetails.avatarUrl(): String? = photoUrl

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,0 +1,5 @@
+package dev.johnoreilly.confetti
+
+import dev.johnoreilly.confetti.fragment.SpeakerDetails
+
+actual fun SpeakerDetails.avatarUrl(): String? = photoUrl

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,0 +1,5 @@
+package dev.johnoreilly.confetti
+
+import dev.johnoreilly.confetti.fragment.SpeakerDetails
+
+actual fun SpeakerDetails.avatarUrl(): String? = photoUrlThumbnail


### PR DESCRIPTION
## Summary
- Add the missing `ktor-client-js` HttpClientEngine to `wasmJsMain`, so Coil3's `coil-network-ktor3` fetcher can actually make requests on the web target (previously there was no engine on the classpath at all, so every image fetch failed with zero network requests attempted).
- Even with that fixed, raw `photoUrl` (sessionize.com) requests come back `503` when fetched via browser `fetch()`/XHR from a foreign origin, while the exact same URL works fine via direct navigation or native platforms' HTTP clients - consistent with Sessionize's anti-hotlink/bot protection rejecting non-navigation requests.
- The backend already has a working avatar proxy (`/images/avatar/{conference}/{avatar}`, server-side fetch + resize) exposed via the `photoUrlThumbnail` GraphQL field, but no UI code was using it.
- Rather than routing every platform through that proxy (which made avatar loading noticeably slower on mobile/desktop, where the raw `photoUrl` already loaded fine directly), added an `expect`/`actual` `SpeakerDetails.avatarUrl()`: mobile and desktop resolve to the original `photoUrl` (unchanged, fast), wasmJs resolves to the proxied `photoUrlThumbnail` (works around the web-only fetch rejection). Updated all speaker avatar rendering (speaker list, speaker grid, speaker detail + full-screen photo, session detail speaker rows, session grid speaker rows) to go through it.

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata :shared:compileMobileMainKotlinMetadata :shared:compileKotlinJvm :shared:compileKotlinWasmJs` passes
- [x] Manually verified in `./gradlew :compose-web:wasmJsBrowserDevelopmentRun`: speaker avatars render correctly in the browser
- [x] Manually verified in `./gradlew :compose-desktop:run`: speaker avatars still load directly from `photoUrl` (no proxy hop, unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)