### PR TITLE
  Apply Haze blur effect to the bottom navigation bar

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ multiplatform-settings = "1.3.0"
 nav-compose = "2.9.8"
 okio = "3.18.1"
 permissions = "0.20.1"
+haze = "1.1.1"
 protolayout = "1.4.1"
 robolectric = "4.16.1"
 room = "2.8.4"
@@ -94,6 +95,7 @@ apollo-execution-gradle-plugin = { module = "com.apollographql.execution:apollo-
 permissions-compose = { module = "dev.icerock.moko:permissions-compose", version.ref = "permissions" }
 permissions-notifications = { module = "dev.icerock.moko:permissions-notifications", version.ref = "permissions" }
 permissions = { module = "dev.icerock.moko:permissions", version.ref = "permissions" }
+haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
 spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "spring" }
 spring-boot-starter-logging = { module = "org.springframework.boot:spring-boot-starter-logging", version.ref = "spring" }
 spring-webflux = "org.springframework:spring-webflux:7.0.8"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -99,6 +99,7 @@ kotlin {
                 api(libs.materialkolor)
                 api(libs.compose.window.size)
                 implementation(libs.lifecyle.runtime)
+                implementation(libs.haze)
                 api("com.mikepenz:multiplatform-markdown-renderer-m3:0.43.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.9.1")
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -4,10 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocationOn
@@ -23,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
@@ -32,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -47,6 +48,10 @@ import confetti.shared.generated.resources.bookmarks
 import confetti.shared.generated.resources.schedule
 import confetti.shared.generated.resources.speakers
 import confetti.shared.generated.resources.venue
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeChild
 import dev.johnoreilly.confetti.decompose.AppComponent
 import dev.johnoreilly.confetti.decompose.ConferenceComponent
 import dev.johnoreilly.confetti.decompose.DefaultAppComponent
@@ -106,86 +111,107 @@ fun HomeView(component: HomeComponent) {
     val windowSizeClass = calculateWindowSizeClass()
     val shouldShowNavRail = windowSizeClass.isExpanded
     val snackbarHostState = remember { SnackbarHostState() }
+    val hazeState = remember { HazeState() }
 
-    Row {
-        if (shouldShowNavRail) {
-            NavigationRail(component)
-        }
-
-        val topBarNavigationIcon = @Composable {
-            AccountIcon(
-                onSwitchConference = component::onSwitchConferenceClicked,
-                onOpenAgent = component::onAgentClicked,
-                onSignIn = component::onSignInClicked,
-                onSignOut = component::onSignOutClicked,
-                onShowSettings = component::onShowSettingsClicked,
-                info = component.user?.let { user ->
-                    AccountInfo(photoUrl = user.photoUrl)
-                },
-                installOnWear = {}, // FIXME: handle
-                //wearSettingsUiState = wearUiState,
-                showAgentOption = component.isAgentEnabled()
-            )
-        }
-
-        val topBarActions: @Composable RowScope.() -> Unit = {
-            IconButton(onClick = { component.onSearchClicked() }) {
-                Icon(Icons.Outlined.Search, contentDescription = "search")
+    CompositionLocalProvider(LocalHazeState provides hazeState) {
+        Row {
+            if (shouldShowNavRail) {
+                NavigationRail(component)
             }
-        }
 
-        Scaffold(
-            bottomBar = { if (!shouldShowNavRail) BottomBar(component) },
-            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-            contentWindowInsets = WindowInsets(0.dp)
-        ) { innerPadding ->
-            Column(modifier = Modifier.padding(innerPadding)) {
+            val topBarNavigationIcon = @Composable {
+                AccountIcon(
+                    onSwitchConference = component::onSwitchConferenceClicked,
+                    onOpenAgent = component::onAgentClicked,
+                    onSignIn = component::onSignInClicked,
+                    onSignOut = component::onSignOutClicked,
+                    onShowSettings = component::onShowSettingsClicked,
+                    info = component.user?.let { user ->
+                        AccountInfo(photoUrl = user.photoUrl)
+                    },
+                    installOnWear = {}, // FIXME: handle
+                    //wearSettingsUiState = wearUiState,
+                    showAgentOption = component.isAgentEnabled()
+                )
+            }
 
-                Children(stack = component.stack) {
-                    when (val child = it.instance) {
-                        is HomeComponent.Child.Sessions ->
-                            SessionsUI(
-                                component = child.component,
-                                windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = topBarNavigationIcon,
-                                topBarActions = topBarActions,
-                                snackbarHostState = snackbarHostState
-                            )
-
-                        is HomeComponent.Child.Speakers ->
-                            SpeakersUI(
-                                component = child.component,
-                                windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = topBarNavigationIcon,
-                                topBarActions = topBarActions,
-                            )
-                        is HomeComponent.Child.Bookmarks ->
-                            BookmarksUI(
-                                component = child.component,
-                                windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = topBarNavigationIcon,
-                                topBarActions = topBarActions,
-                            )
-
-                        is HomeComponent.Child.Venue ->
-                            VenueUI(
-                                component = child.component,
-                                windowSizeClass = windowSizeClass,
-                                topBarNavigationIcon = topBarNavigationIcon,
-                                topBarActions = topBarActions,
-                            )
-
-                        is HomeComponent.Child.Search ->
-                            SearchUI(
-                                component = child.component,
-                                windowSizeClass = windowSizeClass,
-                                onBackClick = component::onBackClicked
-                            )
-
-                        is HomeComponent.Child.Agent -> ConferenceAgentView(child.component)
-                    }
+            val topBarActions: @Composable RowScope.() -> Unit = {
+                IconButton(onClick = { component.onSearchClicked() }) {
+                    Icon(Icons.Outlined.Search, contentDescription = "search")
                 }
+            }
 
+            Scaffold(
+                bottomBar = {
+                    if (!shouldShowNavRail) {
+                        BottomBar(
+                            component = component,
+                            modifier = Modifier.hazeChild(
+                                state = hazeState,
+                                style = HazeStyle(
+                                    backgroundColor = MaterialTheme.colorScheme.surface,
+                                    tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
+                                    blurRadius = 25.dp,
+                                )
+                            )
+                        )
+                    }
+                },
+                snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+                contentWindowInsets = WindowInsets(0.dp)
+            ) { innerPadding ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                ) {
+
+                    Children(stack = component.stack) {
+                        when (val child = it.instance) {
+                            is HomeComponent.Child.Sessions ->
+                                SessionsUI(
+                                    component = child.component,
+                                    windowSizeClass = windowSizeClass,
+                                    topBarNavigationIcon = topBarNavigationIcon,
+                                    topBarActions = topBarActions,
+                                    snackbarHostState = snackbarHostState
+                                )
+
+                            is HomeComponent.Child.Speakers ->
+                                SpeakersUI(
+                                    component = child.component,
+                                    windowSizeClass = windowSizeClass,
+                                    topBarNavigationIcon = topBarNavigationIcon,
+                                    topBarActions = topBarActions,
+                                )
+
+                            is HomeComponent.Child.Bookmarks ->
+                                BookmarksUI(
+                                    component = child.component,
+                                    windowSizeClass = windowSizeClass,
+                                    topBarNavigationIcon = topBarNavigationIcon,
+                                    topBarActions = topBarActions,
+                                )
+
+                            is HomeComponent.Child.Venue ->
+                                VenueUI(
+                                    component = child.component,
+                                    windowSizeClass = windowSizeClass,
+                                    topBarNavigationIcon = topBarNavigationIcon,
+                                    topBarActions = topBarActions,
+                                )
+
+                            is HomeComponent.Child.Search ->
+                                SearchUI(
+                                    component = child.component,
+                                    windowSizeClass = windowSizeClass,
+                                    onBackClick = component::onBackClicked
+                                )
+
+                            is HomeComponent.Child.Agent -> ConferenceAgentView(child.component)
+                        }
+                    }
+
+                }
             }
         }
     }
@@ -215,12 +241,14 @@ private fun NavigationRail(component: HomeComponent) {
 
 
 @Composable
-private fun BottomBar(component: HomeComponent) {
+private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
     Column {
         HorizontalDivider()
         NavigationBar(
+            modifier = modifier,
             contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
             tonalElevation = 0.dp,
+            containerColor = Color.Transparent,
         ) {
             NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, onClick ->
                 NavigationBarItem(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HomeScaffold.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HomeScaffold.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.johnoreilly.confetti.utils.isCompact
 import dev.johnoreilly.confetti.utils.isExpanded
+import dev.johnoreilly.confetti.utils.thenNotNull
+import dev.chrisbanes.haze.haze
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,8 +46,14 @@ fun HomeScaffold(
         TopAppBarDefaults.pinnedScrollBehavior()
     }
 
+    val hazeState = LocalHazeState.current
+
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .thenNotNull(hazeState) { state ->
+                haze(state)
+            },
         topBar = {
             CenterAlignedTopAppBar(
                 title = {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/LocalHazeState.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/LocalHazeState.kt
@@ -1,0 +1,6 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import dev.chrisbanes.haze.HazeState
+
+val LocalHazeState = staticCompositionLocalOf<HazeState?> { null }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ThenIf.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/ThenIf.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.Modifier
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-inline fun Modifier.thenIf(
+public inline fun Modifier.thenIf(
     condition: Boolean,
     block: Modifier.() -> Modifier,
 ): Modifier {
@@ -12,7 +12,7 @@ inline fun Modifier.thenIf(
 }
 
 @OptIn(ExperimentalContracts::class)
-inline fun <T> Modifier.thenNotNull(
+public inline fun <T> Modifier.thenNotNull(
     value: T?,
     block: Modifier.(T) -> Modifier,
 ): Modifier {


### PR DESCRIPTION
Apply the Haze blur effect to the bottom navigation bar.

- Set the navigation bar background to transparent.
- Use a `25.dp` blur and a 60% surface color opacity to make the text easy to read.
- Share the `HazeState` with a new `CompositionLocal`.

Schedule | Speakers
---|---
<img width="1080" height="2400" alt="Screenshot_20260810_160601" src="https://github.com/user-attachments/assets/f3fd25e2-1290-46b7-bd2f-5e5449ec01ad" /> | <img width="1080" height="2400" alt="Screenshot_20260810_160843" src="https://github.com/user-attachments/assets/cbaae5ad-0dae-4d40-8473-12c16d9499bc" />



