### PR TITLE
Add Onboarding

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
@@ -71,6 +71,16 @@ class AppSettings(val settings: FlowSettings) {
         settings.putBoolean(DEVELOPER_MODE, b)
     }
 
+    val onboardingCompletedFlow: Flow<Boolean> = settings
+        .getBooleanFlow(ONBOARDING_COMPLETED, false)
+
+    suspend fun isOnboardingCompleted(): Boolean =
+        settings.getBoolean(ONBOARDING_COMPLETED, false)
+
+    suspend fun setOnboardingCompleted(value: Boolean) {
+        settings.putBoolean(ONBOARDING_COMPLETED, value)
+    }
+
     companion object {
         const val DEVELOPER_MODE = "developer_mode"
         const val EXPERIMENTAL_FEATURES_ENABLED = "experimental_features_enabled"
@@ -79,5 +89,6 @@ class AppSettings(val settings: FlowSettings) {
         const val CONFERENCE_SETTING = "conference"
         const val CONFERENCE_THEME_COLOR_SETTING = "conferenceThemeColor"
         const val CONFERENCE_NOT_SET = ""
+        const val ONBOARDING_COMPLETED = "onboarding_completed"
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -27,6 +27,7 @@ interface AppComponent {
 
     sealed class Child {
         object Loading : Child()
+        class Onboarding(val component: OnboardingComponent) : Child()
         class Conferences(val component: ConferencesComponent) : Child()
         class Conference(val component: ConferenceComponent) : Child()
     }
@@ -78,15 +79,19 @@ class DefaultAppComponent(
             if (initialConferenceId != null) {
                 selectAndNavigateToDeepLinkedConference(initialConferenceId)
             } else {
-                val conference: String = repository.getConference()
-                if (conference == AppSettings.CONFERENCE_NOT_SET) {
-                    showConferences()
+                if (!appSettings.isOnboardingCompleted()) {
+                    showOnboarding()
                 } else {
-                    val conferenceThemeColor = repository.getConferenceThemeColor()
-                    showConference(conference = conference, conferenceThemeColor = conferenceThemeColor)
+                    val conference: String = repository.getConference()
+                    if (conference == AppSettings.CONFERENCE_NOT_SET) {
+                        showConferences()
+                    } else {
+                        val conferenceThemeColor = repository.getConferenceThemeColor()
+                        showConference(conference = conference, conferenceThemeColor = conferenceThemeColor)
 
-                    // Take the opportunity to update any listeners of the conference
-                    repository.updateConfenceListeners(conference, conferenceThemeColor)
+                        // Take the opportunity to update any listeners of the conference
+                        repository.updateConfenceListeners(conference, conferenceThemeColor)
+                    }
                 }
             }
         }
@@ -119,6 +124,24 @@ class DefaultAppComponent(
     private fun child(config: Config, componentContext: ComponentContext): Child =
         when (config) {
             is Config.Loading -> Child.Loading
+
+            is Config.Onboarding ->
+                Child.Onboarding(
+                    DefaultOnboardingComponent(
+                        componentContext = componentContext,
+                        onFinished = {
+                            coroutineScope.launch {
+                                val conference: String = repository.getConference()
+                                if (conference == AppSettings.CONFERENCE_NOT_SET) {
+                                    showConferences()
+                                } else {
+                                    val conferenceThemeColor = repository.getConferenceThemeColor()
+                                    showConference(conference = conference, conferenceThemeColor = conferenceThemeColor)
+                                }
+                            }
+                        }
+                    )
+                )
 
             is Config.Conferences ->
                 Child.Conferences(
@@ -156,6 +179,10 @@ class DefaultAppComponent(
                 )
         }
 
+    private fun showOnboarding() {
+        navigation.replaceAll(Config.Onboarding)
+    }
+
     private fun showConferences() {
         navigation.replaceAll(Config.Conferences())
     }
@@ -172,6 +199,9 @@ class DefaultAppComponent(
     private sealed class Config {
         @Serializable
         data object Loading : Config()
+
+        @Serializable
+        data object Onboarding : Config()
 
         @Serializable
         data class Conferences(val isSwitching: Boolean = false) : Config()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/OnboardingComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/OnboardingComponent.kt
@@ -1,0 +1,47 @@
+package dev.johnoreilly.confetti.decompose
+
+import com.arkivanov.decompose.ComponentContext
+import dev.johnoreilly.confetti.AppSettings
+import dev.johnoreilly.confetti.work.NotificationSender
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface OnboardingComponent {
+    val supportsNotifications: Boolean
+    val notificationsEnabled: Flow<Boolean>
+
+    fun updateNotificationsEnabled(enabled: Boolean)
+    fun completeOnboarding()
+}
+
+class DefaultOnboardingComponent(
+    componentContext: ComponentContext,
+    private val onFinished: () -> Unit,
+) : OnboardingComponent, KoinComponent, ComponentContext by componentContext {
+
+    private val appSettings: AppSettings by inject()
+    private val notificationSender: NotificationSender? by inject()
+    private val coroutineScope = coroutineScope()
+
+    override val supportsNotifications: Boolean
+        get() = notificationSender != null
+
+    override val notificationsEnabled: Flow<Boolean>
+        get() = appSettings.notificationsEnabledFlow
+
+    override fun updateNotificationsEnabled(enabled: Boolean) {
+        coroutineScope.launch {
+            appSettings.setNotificationsEnabled(enabled)
+            notificationSender?.updateSchedule(enabled)
+        }
+    }
+
+    override fun completeOnboarding() {
+        coroutineScope.launch {
+            appSettings.setOnboardingCompleted(true)
+            onFinished()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/PermissionState.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/PermissionState.kt
@@ -2,14 +2,22 @@ package dev.johnoreilly.confetti.permissions
 
 sealed interface NotificationPermissionState {
     fun maybeRequest() {}
+    fun openSettings() {}
 
     data object NotApplicable: NotificationPermissionState
 
     object NotDetermined: NotificationPermissionState
 
-    class Requestable(private val onRequest: () -> Unit): NotificationPermissionState {
+    class Requestable(
+        private val onRequest: () -> Unit,
+        private val onOpenSettings: () -> Unit = {}
+    ): NotificationPermissionState {
         override fun maybeRequest() {
             onRequest()
+        }
+
+        override fun openSettings() {
+            onOpenSettings()
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
@@ -5,5 +5,6 @@ import androidx.compose.runtime.Composable
 @Composable
 expect fun rememberNotificationPermissionState(
     notificationsActive: Boolean?,
+    onPermissionDeniedAlways: () -> Unit = {},
     onPermissionStatus: (hasPermission: Boolean) -> Unit = {}
 ): NotificationPermissionState

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -73,6 +73,7 @@ fun App(component: DefaultAppComponent) {
     Children(stack = component.stack) {
         when (val child = it.instance) {
             is AppComponent.Child.Loading -> LoadingView()
+            is AppComponent.Child.Onboarding -> OnboardingUI(child.component)
             is AppComponent.Child.Conferences -> ConferenceListView(child.component)
             is AppComponent.Child.Conference -> ConferenceView(child.component)
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -1,0 +1,320 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.johnoreilly.confetti.decompose.OnboardingComponent
+import dev.johnoreilly.confetti.permissions.rememberNotificationPermissionState
+import dev.johnoreilly.confetti.ui.component.ConfettiAlertDialog
+import kotlinx.coroutines.launch
+
+@Composable
+fun OnboardingUI(component: OnboardingComponent) {
+    val coroutineScope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(initialPage = 0) { 3 }
+    val notificationsEnabled by component.notificationsEnabled.collectAsState(initial = false)
+
+    var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+
+    val notificationPermissionState = rememberNotificationPermissionState(
+        notificationsActive = notificationsEnabled,
+        onPermissionDeniedAlways = {
+            showPermissionDeniedDialog = true
+        },
+        onPermissionStatus = { hasPermission ->
+            if (notificationsEnabled != hasPermission) {
+                component.updateNotificationsEnabled(hasPermission)
+            }
+        }
+    )
+
+    if (showPermissionDeniedDialog) {
+        ConfettiAlertDialog(
+            title = "Permission Required",
+            text = "Notification permission was permanently denied. Please enable it in Settings to receive updates.",
+            confirmText = "Open Settings",
+            onConfirm = {
+                showPermissionDeniedDialog = false
+                notificationPermissionState.openSettings()
+            },
+            dismissText = "Cancel",
+            onDismiss = { showPermissionDeniedDialog = false }
+        )
+    }
+
+    Scaffold { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Main Onboarding Card containing HorizontalPager
+            Card(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                ),
+                shape = MaterialTheme.shapes.large
+            ) {
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        when (page) {
+                            0 -> OnboardingStep1()
+                            1 -> OnboardingStep2()
+                            2 -> OnboardingStep3(
+                                notificationsEnabled = notificationsEnabled,
+                                supportsNotifications = component.supportsNotifications,
+                                onNotificationsToggle = { enabled ->
+                                    if (enabled) {
+                                        notificationPermissionState.maybeRequest()
+                                    } else {
+                                        component.updateNotificationsEnabled(false)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Bottom Navigation & Progress Indicator
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Back Button
+                if (pagerState.currentPage > 0) {
+                    TextButton(onClick = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                        }
+                    }) {
+                        Text("Back")
+                    }
+                } else {
+                    Spacer(modifier = Modifier.width(64.dp))
+                }
+
+                // Smooth Dot Indicators (Clickable)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    for (step in 0..2) {
+                        val isActive = pagerState.currentPage == step
+                        val width by animateDpAsState(targetValue = if (isActive) 24.dp else 8.dp)
+                        val color = if (isActive) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                        }
+                        Box(
+                            modifier = Modifier
+                                .size(width = width, height = 8.dp)
+                                .clip(CircleShape)
+                                .background(color)
+                                .clickable {
+                                    coroutineScope.launch {
+                                        pagerState.animateScrollToPage(step)
+                                    }
+                                }
+                        )
+                    }
+                }
+
+                // Next or Done Button
+                Button(
+                    onClick = {
+                        if (pagerState.currentPage < 2) {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                            }
+                        } else {
+                            component.completeOnboarding()
+                        }
+                    }
+                ) {
+                    Text(if (pagerState.currentPage == 2) "Done" else "Next")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun OnboardingStep1() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Event,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .size(96.dp)
+                .padding(bottom = 24.dp)
+        )
+        Text(
+            text = "Welcome to Confetti",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        Text(
+            text = "Your conference companion. Browse schedules, speakers, and venues offline.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+    }
+}
+
+@Composable
+fun OnboardingStep2() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Bookmarks,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .size(96.dp)
+                .padding(bottom = 24.dp)
+        )
+        Text(
+            text = "Features",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        Column(
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            FeatureRow("Bookmark sessions to build schedule")
+            FeatureRow("Get answers from the AI assistant")
+            FeatureRow("View speakers and venue maps")
+        }
+    }
+}
+
+@Composable
+private fun FeatureRow(text: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Star,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.size(16.dp)
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun OnboardingStep3(
+    notificationsEnabled: Boolean,
+    supportsNotifications: Boolean,
+    onNotificationsToggle: (Boolean) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Notifications,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .size(96.dp)
+                .padding(bottom = 24.dp)
+        )
+        Text(
+            text = "Stay Updated",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        Text(
+            text = "Enable notifications to receive session reminders. You can disable this anytime in settings.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
+        )
+        if (supportsNotifications) {
+            Row(
+                modifier = Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(if (notificationsEnabled) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable { onNotificationsToggle(!notificationsEnabled) }
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Switch(
+                    checked = notificationsEnabled,
+                    onCheckedChange = null
+                )
+                Text(
+                    text = "Enable notifications",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (notificationsEnabled) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -1,7 +1,7 @@
 package dev.johnoreilly.confetti.ui
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.*
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -21,8 +21,16 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeChild
 import dev.johnoreilly.confetti.decompose.OnboardingComponent
 import dev.johnoreilly.confetti.permissions.rememberNotificationPermissionState
 import dev.johnoreilly.confetti.ui.component.ConfettiAlertDialog
@@ -62,127 +70,184 @@ fun OnboardingUI(component: OnboardingComponent) {
         )
     }
 
-    Scaffold { padding ->
-        Column(
+    // Infinite transition to create a slowly moving gradient background
+    val infiniteTransition = rememberInfiniteTransition(label = "GradientAnimation")
+    val xOffset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 12000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "xOffset"
+    )
+    val yOffset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 18000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "yOffset"
+    )
+
+    val backgroundBrush = Brush.linearGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f),
+            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
+            MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f),
+        ),
+        start = Offset(x = xOffset, y = 0f),
+        end = Offset(x = 1000f - xOffset, y = yOffset)
+    )
+
+    val hazeState = remember { HazeState() }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Animated moving gradient background container with haze modifier
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            // Skip Button Row
-            Row(
-                modifier = Modifier.fillMaxWidth().height(48.dp),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (pagerState.currentPage < 2) {
-                    TextButton(onClick = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(2)
-                        }
-                    }) {
-                        Text("Skip")
-                    }
-                }
-            }
+                .background(backgroundBrush)
+                .haze(hazeState)
+        )
 
-            // Main Onboarding Card containing HorizontalPager
-            Card(
+        // Scaffold as a sibling layout to prevent nested descendant error
+        Scaffold(
+            containerColor = Color.Transparent,
+            modifier = Modifier.fillMaxSize()
+        ) { padding ->
+            Column(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                ),
-                shape = MaterialTheme.shapes.large
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                HorizontalPager(
-                    state = pagerState,
-                    modifier = Modifier.fillMaxSize()
-                ) { page ->
-                    when (page) {
-                        0 -> OnboardingStep1(visible = pagerState.currentPage == 0)
-                        1 -> OnboardingStep2(visible = pagerState.currentPage == 1)
-                        2 -> OnboardingStep3(
-                            visible = pagerState.currentPage == 2,
-                            notificationsEnabled = notificationsEnabled,
-                            supportsNotifications = component.supportsNotifications,
-                            onNotificationsToggle = { enabled ->
-                                if (enabled) {
-                                    notificationPermissionState.maybeRequest()
-                                } else {
-                                    component.updateNotificationsEnabled(false)
-                                }
-                            }
-                        )
-                    }
-                }
-            }
-
-            // Bottom Navigation & Progress Indicator
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Back Button
-                if (pagerState.currentPage > 0) {
-                    TextButton(onClick = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                        }
-                    }) {
-                        Text("Back")
-                    }
-                } else {
-                    Spacer(modifier = Modifier.width(64.dp))
-                }
-
-                // Smooth Dot Indicators (Clickable)
+                // Skip Button Row
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth().height(48.dp),
+                    horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    for (step in 0..2) {
-                        val isActive = pagerState.currentPage == step
-                        val width by animateDpAsState(targetValue = if (isActive) 24.dp else 8.dp)
-                        val color = if (isActive) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                    if (pagerState.currentPage < 2) {
+                        TextButton(onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(2)
+                            }
+                        }) {
+                            Text("Skip")
                         }
-                        Box(
-                            modifier = Modifier
-                                .size(width = width, height = 8.dp)
-                                .clip(CircleShape)
-                                .background(color)
-                                .clickable {
-                                    coroutineScope.launch {
-                                        pagerState.animateScrollToPage(step)
-                                    }
-                                }
-                        )
                     }
                 }
 
-                // Next or Done Button
-                Button(
-                    onClick = {
-                        if (pagerState.currentPage < 2) {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                            }
-                        } else {
-                            component.completeOnboarding()
+                // Glassmorphic Card (sibling of background haze modifier)
+                val cardShape = MaterialTheme.shapes.large
+                Card(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp)
+                        .clip(cardShape)
+                        .hazeChild(
+                            state = hazeState,
+                            style = HazeStyle(
+                                backgroundColor = Color.Transparent,
+                                tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.70f)),
+                                blurRadius = 30.dp,
+                            )
+                        ),
+                    colors = CardDefaults.cardColors(
+                        containerColor = Color.Transparent
+                    ),
+                    shape = cardShape
+                ) {
+                    HorizontalPager(
+                        state = pagerState,
+                        modifier = Modifier.fillMaxSize()
+                    ) { page ->
+                        when (page) {
+                            0 -> OnboardingStep1(visible = pagerState.currentPage == 0)
+                            1 -> OnboardingStep2(visible = pagerState.currentPage == 1)
+                            2 -> OnboardingStep3(
+                                visible = pagerState.currentPage == 2,
+                                notificationsEnabled = notificationsEnabled,
+                                supportsNotifications = component.supportsNotifications,
+                                onNotificationsToggle = { enabled ->
+                                    if (enabled) {
+                                        notificationPermissionState.maybeRequest()
+                                    } else {
+                                        component.updateNotificationsEnabled(false)
+                                    }
+                                }
+                            )
                         }
                     }
+                }
+
+                // Bottom Navigation & Progress Indicator
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(if (pagerState.currentPage == 2) "Done" else "Next")
+                    // Back Button
+                    if (pagerState.currentPage > 0) {
+                        TextButton(onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                            }
+                        }) {
+                            Text("Back")
+                        }
+                    } else {
+                        Spacer(modifier = Modifier.width(64.dp))
+                    }
+
+                    // Smooth Dot Indicators (Clickable)
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        for (step in 0..2) {
+                            val isActive = pagerState.currentPage == step
+                            val width by animateDpAsState(targetValue = if (isActive) 24.dp else 8.dp)
+                            val color = if (isActive) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .size(width = width, height = 8.dp)
+                                    .clip(CircleShape)
+                                    .background(color)
+                                    .clickable {
+                                        coroutineScope.launch {
+                                            pagerState.animateScrollToPage(step)
+                                        }
+                                    }
+                            )
+                        }
+                    }
+
+                    // Next or Done Button
+                    Button(
+                        onClick = {
+                            if (pagerState.currentPage < 2) {
+                                coroutineScope.launch {
+                                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                                }
+                            } else {
+                                component.completeOnboarding()
+                            }
+                        }
+                    ) {
+                        Text(if (pagerState.currentPage == 2) "Done" else "Next")
+                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -67,6 +67,23 @@ fun OnboardingUI(component: OnboardingComponent) {
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            // Skip Button Row
+            Row(
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (pagerState.currentPage < 2) {
+                    TextButton(onClick = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(2)
+                        }
+                    }) {
+                        Text("Skip")
+                    }
+                }
+            }
+
             // Main Onboarding Card containing HorizontalPager
             Card(
                 modifier = Modifier

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -1,6 +1,10 @@
 package dev.johnoreilly.confetti.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -99,26 +103,21 @@ fun OnboardingUI(component: OnboardingComponent) {
                     state = pagerState,
                     modifier = Modifier.fillMaxSize()
                 ) { page ->
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        when (page) {
-                            0 -> OnboardingStep1()
-                            1 -> OnboardingStep2()
-                            2 -> OnboardingStep3(
-                                notificationsEnabled = notificationsEnabled,
-                                supportsNotifications = component.supportsNotifications,
-                                onNotificationsToggle = { enabled ->
-                                    if (enabled) {
-                                        notificationPermissionState.maybeRequest()
-                                    } else {
-                                        component.updateNotificationsEnabled(false)
-                                    }
+                    when (page) {
+                        0 -> OnboardingStep1(visible = pagerState.currentPage == 0)
+                        1 -> OnboardingStep2(visible = pagerState.currentPage == 1)
+                        2 -> OnboardingStep3(
+                            visible = pagerState.currentPage == 2,
+                            notificationsEnabled = notificationsEnabled,
+                            supportsNotifications = component.supportsNotifications,
+                            onNotificationsToggle = { enabled ->
+                                if (enabled) {
+                                    notificationPermissionState.maybeRequest()
+                                } else {
+                                    component.updateNotificationsEnabled(false)
                                 }
-                            )
-                        }
+                            }
+                        )
                     }
                 }
             }
@@ -191,69 +190,81 @@ fun OnboardingUI(component: OnboardingComponent) {
 }
 
 @Composable
-fun OnboardingStep1() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun OnboardingStep1(visible: Boolean) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 3 }),
+        exit = fadeOut()
     ) {
-        Icon(
-            imageVector = Icons.Default.Event,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
+        Column(
             modifier = Modifier
-                .size(96.dp)
-                .padding(bottom = 24.dp)
-        )
-        Text(
-            text = "Welcome to Confetti",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
-        Text(
-            text = "Your conference companion. Browse schedules, speakers, and venues offline.",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 16.dp)
-        )
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Event,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(96.dp)
+                    .padding(bottom = 24.dp)
+            )
+            Text(
+                text = "Welcome to Confetti",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            Text(
+                text = "Your conference companion. Browse schedules, speakers, and venues offline.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+        }
     }
 }
 
 @Composable
-fun OnboardingStep2() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun OnboardingStep2(visible: Boolean) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 3 }),
+        exit = fadeOut()
     ) {
-        Icon(
-            imageVector = Icons.Default.Bookmarks,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier
-                .size(96.dp)
-                .padding(bottom = 24.dp)
-        )
-        Text(
-            text = "Features",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
         Column(
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(horizontal = 16.dp)
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            FeatureRow("Bookmark sessions to build schedule")
-            FeatureRow("Get answers from the AI assistant")
-            FeatureRow("View speakers and venue maps")
+            Icon(
+                imageVector = Icons.Default.Bookmarks,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(96.dp)
+                    .padding(bottom = 24.dp)
+            )
+            Text(
+                text = "Features",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
+                FeatureRow("Bookmark sessions to build schedule")
+                FeatureRow("Get answers from the AI assistant")
+                FeatureRow("View speakers and venue maps")
+            }
         }
     }
 }
@@ -280,57 +291,64 @@ private fun FeatureRow(text: String) {
 
 @Composable
 fun OnboardingStep3(
+    visible: Boolean,
     notificationsEnabled: Boolean,
     supportsNotifications: Boolean,
     onNotificationsToggle: (Boolean) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 3 }),
+        exit = fadeOut()
     ) {
-        Icon(
-            imageVector = Icons.Default.Notifications,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
+        Column(
             modifier = Modifier
-                .size(96.dp)
-                .padding(bottom = 24.dp)
-        )
-        Text(
-            text = "Stay Updated",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
-        Text(
-            text = "Enable notifications to receive session reminders. You can disable this anytime in settings.",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
-        )
-        if (supportsNotifications) {
-            Row(
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Notifications,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(if (notificationsEnabled) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant)
-                    .clickable { onNotificationsToggle(!notificationsEnabled) }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Switch(
-                    checked = notificationsEnabled,
-                    onCheckedChange = null
-                )
-                Text(
-                    text = "Enable notifications",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = if (notificationsEnabled) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                    .size(96.dp)
+                    .padding(bottom = 24.dp)
+            )
+            Text(
+                text = "Stay Updated",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            Text(
+                text = "Enable notifications to receive session reminders. You can disable this anytime in settings.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
+            )
+            if (supportsNotifications) {
+                Row(
+                    modifier = Modifier
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(if (notificationsEnabled) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant)
+                        .clickable { onNotificationsToggle(!notificationsEnabled) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Switch(
+                        checked = notificationsEnabled,
+                        onCheckedChange = null
+                    )
+                    Text(
+                        text = "Enable notifications",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = if (notificationsEnabled) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiAlertDialog.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiAlertDialog.kt
@@ -1,0 +1,35 @@
+package dev.johnoreilly.confetti.ui.component
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ConfettiAlertDialog(
+    title: String,
+    text: String,
+    confirmText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    dismissText: String? = null,
+    onDismissRequest: () -> Unit = onDismiss
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = title) },
+        text = { Text(text = text) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = confirmText)
+            }
+        },
+        dismissButton = dismissText?.let {
+            {
+                TextButton(onClick = onDismiss) {
+                    Text(text = it)
+                }
+            }
+        }
+    )
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import dev.johnoreilly.confetti.ui.component.ConfettiAlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -104,14 +105,33 @@ fun SettingsUI(
     onNotificationsEnabled: (value: Boolean) -> Unit,
     popBack: () -> Unit
 ) {
+    var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+
     val notificationPermissionState = rememberNotificationPermissionState(
         notificationsActive = userEditableSettings?.notificationsEnabled,
+        onPermissionDeniedAlways = {
+            showPermissionDeniedDialog = true
+        },
         onPermissionStatus = { hasPermission ->
             if (userEditableSettings?.notificationsEnabled != hasPermission) {
                 onNotificationsEnabled(hasPermission)
             }
         }
     )
+
+    if (showPermissionDeniedDialog) {
+        ConfettiAlertDialog(
+            title = "Permission Required",
+            text = "Notification permission was permanently denied. Please enable it in Settings to receive updates.",
+            confirmText = "Open Settings",
+            onConfirm = {
+                showPermissionDeniedDialog = false
+                notificationPermissionState.openSettings()
+            },
+            dismissText = "Cancel",
+            onDismiss = { showPermissionDeniedDialog = false }
+        )
+    }
 
     val scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     /**

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.jvm.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.jvm.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 @Composable
 actual fun rememberNotificationPermissionState(
     notificationsActive: Boolean?,
+    onPermissionDeniedAlways: () -> Unit,
     onPermissionStatus: (hasPermission: Boolean) -> Unit
 ): NotificationPermissionState {
     return NotificationPermissionState.NotApplicable

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import dev.icerock.moko.permissions.DeniedAlwaysException
 import dev.icerock.moko.permissions.Permission
 import dev.icerock.moko.permissions.PermissionState
 import dev.icerock.moko.permissions.PermissionsController
@@ -17,6 +18,7 @@ import kotlinx.coroutines.launch
 @Composable
 actual fun rememberNotificationPermissionState(
     notificationsActive: Boolean?,
+    onPermissionDeniedAlways: () -> Unit,
     onPermissionStatus: (hasPermission: Boolean) -> Unit
 ): NotificationPermissionState {
     val factory: PermissionsControllerFactory = rememberPermissionsControllerFactory()
@@ -36,15 +38,23 @@ actual fun rememberNotificationPermissionState(
     }
 
     return remember(coroutineScope) {
-        NotificationPermissionState.Requestable {
-            coroutineScope.launch {
-                try {
-                    controller.providePermission(Permission.REMOTE_NOTIFICATION)
-                    onPermissionStatus(true)
-                } catch (e: Exception) {
-                    onPermissionStatus(false)
+        NotificationPermissionState.Requestable(
+            onRequest = {
+                coroutineScope.launch {
+                    try {
+                        controller.providePermission(Permission.REMOTE_NOTIFICATION)
+                        onPermissionStatus(true)
+                    } catch (e: DeniedAlwaysException) {
+                        onPermissionDeniedAlways()
+                        onPermissionStatus(false)
+                    } catch (e: Exception) {
+                        onPermissionStatus(false)
+                    }
                 }
+            },
+            onOpenSettings = {
+                controller.openAppSettings()
             }
-        }
+        )
     }
 }

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/permissions/rememberNotificationPermissionState.wasmJs.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 @Composable
 actual fun rememberNotificationPermissionState(
     notificationsActive: Boolean?,
+    onPermissionDeniedAlways: () -> Unit,
     onPermissionStatus: (hasPermission: Boolean) -> Unit
 ): NotificationPermissionState {
     return NotificationPermissionState.NotApplicable


### PR DESCRIPTION
This change adds a three-step onboarding pager that introduces the welcome message, app features, and notifications configuration to new users. Users can skip the welcome steps directly to the final notifications screen. We handle permanently denied notification permissions by showing a custom alert dialog that helps the user open settings directly. The onboarding UI features a moving gradient background, a glassmorphic card container using the Haze library, and animated entry transitions for step contents.

| Screen | Photo |
| --- | --- |
| Step 1: Welcome | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/87c9a8fe-c132-41a8-a6ad-ef115b7202ad" /> |
| Step 2: Features | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d3542ab2-603d-42bf-8857-229c12f6d0b3" /> |
| Step 3: Notifications | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b0107871-1d28-4dc1-a61a-69faa10d4638" /> |
| Permission Dialog | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/2baa4745-9aa5-402f-9ac7-c3e044cfdaa0" /> |

