### PR TITLE
Fix conference date range display for 3+ day conferences

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -243,8 +243,8 @@ private fun getConferenceDatesString(days: List<LocalDate>): String {
     if (days.isNotEmpty()) {
         conferenceDatesString = days[0].conferenceDayMonthFormat()
     }
-    if (days.size == 2) {
-        conferenceDatesString += " - ${days[1].conferenceDayMonthFormat()}"
+    if (days.size >= 2) {
+        conferenceDatesString += " - ${days.last().conferenceDayMonthFormat()}"
     }
     return conferenceDatesString
 }


### PR DESCRIPTION
## Summary
- `getConferenceDatesString` in `ConferenceListView.kt` only appended an end date when `days.size == 2`, so any conference spanning 3+ days (e.g. droidcon Berlin 2026, Oct 7-9) showed just the first day ("07 Oct") on the conference list instead of a range
- Changed to `days.size >= 2` using `days.last()`, so it correctly shows a range for any number of days
- Shared `commonMain` code, so this fixes Android, iOS, desktop, and web at once

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata` passes
- [ ] Verify droidcon Berlin 2026 shows "07 Oct - 09 Oct" in the app after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)