### PR TITLE
Fix conference assistant input bar overlapping bottom nav bar

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -207,7 +207,10 @@ fun HomeView(component: HomeComponent) {
                                     onBackClick = component::onBackClicked
                                 )
 
-                            is HomeComponent.Child.Agent -> ConferenceAgentView(child.component)
+                            is HomeComponent.Child.Agent -> ConferenceAgentView(
+                                component = child.component,
+                                bottomContentPadding = innerPadding.calculateBottomPadding()
+                            )
                         }
                     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.mikepenz.markdown.m3.Markdown
@@ -46,7 +47,7 @@ import dev.johnoreilly.confetti.decompose.ConferenceAgentComponent
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun ConferenceAgentView(component: ConferenceAgentComponent) {
+fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPadding: Dp = 0.dp) {
     val state by component.uiState.subscribeAsState()
     val listState = rememberLazyListState()
 
@@ -56,7 +57,12 @@ fun ConferenceAgentView(component: ConferenceAgentComponent) {
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .padding(bottom = bottomContentPadding)
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Spacer(Modifier.weight(1f))
             IconButton(onClick = { component.restartChat() }) {


### PR DESCRIPTION
## Summary
- The Haze blur bottom-bar change (#1790) made the outer content `Column` in `App.kt` ignore Scaffold's `innerPadding`, so content renders full-bleed behind the now-transparent/blurred nav bar. That's intentional for scrollable screens (Sessions/Speakers/Bookmarks/Venue), giving the blur effect pixels to sample.
- The conference assistant chat screen (`ConferenceAgentView`) has a fixed, non-scrolling input row (text field + send button) pinned to the bottom of the screen — with no inset applied, it renders at the exact same position as the bottom nav bar, so the placeholder text and send icon visibly overlap the "Schedule"/"Speakers"/"Venue" labels and icons through the blur.
- Fix: pass the Scaffold's bottom inset (`innerPadding.calculateBottomPadding()`) down into `ConferenceAgentView` and apply it to the input row's container, so it renders above the nav bar instead of behind it.

## Test plan
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata` passes
- [ ] Open the conference assistant screen and confirm the input field and send button sit fully above the bottom nav bar, with no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)