### PR TITLE
Revamp the Gemini Assistant UI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,9 @@ ksp.allow.all.target.configuration=false
 LIBRARY_VERSION=0.9
 GROUP=dev.johnoreilly.confetti
 
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true
+
 # Uncomment to enable record mode
 #roborazzi.test.verify=true
 #roborazzi.test.record=true
-

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/AppSettings.kt
@@ -71,6 +71,13 @@ class AppSettings(val settings: FlowSettings) {
         settings.putBoolean(DEVELOPER_MODE, b)
     }
 
+    val forceEnableAssistantFlow = settings
+        .getBooleanFlow(FORCE_ENABLE_ASSISTANT, false)
+
+    suspend fun setForceEnableAssistant(value: Boolean) {
+        settings.putBoolean(FORCE_ENABLE_ASSISTANT, value)
+    }
+
     val onboardingCompletedFlow: Flow<Boolean> = settings
         .getBooleanFlow(ONBOARDING_COMPLETED, false)
 
@@ -90,5 +97,6 @@ class AppSettings(val settings: FlowSettings) {
         const val CONFERENCE_THEME_COLOR_SETTING = "conferenceThemeColor"
         const val CONFERENCE_NOT_SET = ""
         const val ONBOARDING_COMPLETED = "onboarding_completed"
+        const val FORCE_ENABLE_ASSISTANT = "force_enable_assistant"
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -69,27 +69,9 @@ class DefaultConferenceAgentComponent(
 
     private val state = MutableStateFlow(
         ConferenceAgentComponent.UiState(
-            userPhotoUrl = userPhotoUrl ?: "https://avatars.githubusercontent.com/u/4348197?s=400&u=c27e3f938a61471e2eebc00d6c8ab8826b0af816&v=4",
+            userPhotoUrl = userPhotoUrl,
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
-                ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchSessions(date=2026-08-12)"),
-                ConferenceAgentComponent.Message.ToolCall("filterSessions(topic=Kotlin)"),
-                ConferenceAgentComponent.Message.Agent("There are 2 Kotlin sessions tomorrow:\n1. *Kotlin Multiplatform in Action* at 10:00 AM\n2. *Advanced Coroutines* at 2:00 PM."),
-                ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
-                ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
-                ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
-                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you."),
-                ConferenceAgentComponent.Message.User("Who are the speakers for the Advanced Coroutines session?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchSessionDetails(id=session-coroutines-102)"),
-                ConferenceAgentComponent.Message.Agent("The speaker for *Advanced Coroutines* is **John Doe**, a Principal Engineer specialized in Kotlin asynchronous programming."),
-                ConferenceAgentComponent.Message.User("Great. Where is the venue of the conference?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchVenue()"),
-                ConferenceAgentComponent.Message.Agent("The conference is held at the **San Francisco Convention Center**, Hall A, located at 747 Howard St."),
-                ConferenceAgentComponent.Message.User("Is there any bookmark tab where I can view all my bookmarks?"),
-                ConferenceAgentComponent.Message.Agent("Yes, you can see all your bookmarked sessions in the 'Bookmarks' tab at the bottom navigation bar on the home screen."),
-                ConferenceAgentComponent.Message.User("Perfect, thanks for your help!"),
-                ConferenceAgentComponent.Message.Agent("You are welcome! Let me know if you need anything else.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -69,7 +69,7 @@ class DefaultConferenceAgentComponent(
 
     private val state = MutableStateFlow(
         ConferenceAgentComponent.UiState(
-            userPhotoUrl = userPhotoUrl ?: "https://avatars.githubusercontent.com/u/4348197?s=400&u=c27e3f938a61471e2eebc00d6c8ab8826b0af816&v=4",
+            userPhotoUrl = userPhotoUrl,
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
                 ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
@@ -79,17 +79,7 @@ class DefaultConferenceAgentComponent(
                 ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
                 ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
                 ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
-                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you."),
-                ConferenceAgentComponent.Message.User("Who are the speakers for the Advanced Coroutines session?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchSessionDetails(id=session-coroutines-102)"),
-                ConferenceAgentComponent.Message.Agent("The speaker for *Advanced Coroutines* is **John Doe**, a Principal Engineer specialized in Kotlin asynchronous programming."),
-                ConferenceAgentComponent.Message.User("Great. Where is the venue of the conference?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchVenue()"),
-                ConferenceAgentComponent.Message.Agent("The conference is held at the **San Francisco Convention Center**, Hall A, located at 747 Howard St."),
-                ConferenceAgentComponent.Message.User("Is there any bookmark tab where I can view all my bookmarks?"),
-                ConferenceAgentComponent.Message.Agent("Yes, you can see all your bookmarked sessions in the 'Bookmarks' tab at the bottom navigation bar on the home screen."),
-                ConferenceAgentComponent.Message.User("Perfect, thanks for your help!"),
-                ConferenceAgentComponent.Message.Agent("You are welcome! Let me know if you need anything else.")
+                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -69,7 +69,7 @@ class DefaultConferenceAgentComponent(
 
     private val state = MutableStateFlow(
         ConferenceAgentComponent.UiState(
-            userPhotoUrl = userPhotoUrl,
+            userPhotoUrl = userPhotoUrl ?: "https://avatars.githubusercontent.com/u/4348197?s=400&u=c27e3f938a61471e2eebc00d6c8ab8826b0af816&v=4",
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
                 ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
@@ -79,7 +79,17 @@ class DefaultConferenceAgentComponent(
                 ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
                 ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
                 ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
-                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you.")
+                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you."),
+                ConferenceAgentComponent.Message.User("Who are the speakers for the Advanced Coroutines session?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchSessionDetails(id=session-coroutines-102)"),
+                ConferenceAgentComponent.Message.Agent("The speaker for *Advanced Coroutines* is **John Doe**, a Principal Engineer specialized in Kotlin asynchronous programming."),
+                ConferenceAgentComponent.Message.User("Great. Where is the venue of the conference?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchVenue()"),
+                ConferenceAgentComponent.Message.Agent("The conference is held at the **San Francisco Convention Center**, Hall A, located at 747 Howard St."),
+                ConferenceAgentComponent.Message.User("Is there any bookmark tab where I can view all my bookmarks?"),
+                ConferenceAgentComponent.Message.Agent("Yes, you can see all your bookmarked sessions in the 'Bookmarks' tab at the bottom navigation bar on the home screen."),
+                ConferenceAgentComponent.Message.User("Perfect, thanks for your help!"),
+                ConferenceAgentComponent.Message.Agent("You are welcome! Let me know if you need anything else.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -37,6 +37,7 @@ interface ConferenceAgentComponent {
 
     data class UiState(
         val messages: List<Message>,
+        val userPhotoUrl: String? = null,
         val inputText: String = "",
         val isInputEnabled: Boolean = true,
         val isLoading: Boolean = false,
@@ -47,6 +48,7 @@ interface ConferenceAgentComponent {
 class DefaultConferenceAgentComponent(
     componentContext: ComponentContext,
     conference: String,
+    userPhotoUrl: String?,
 ) : ConferenceAgentComponent, KoinComponent, ComponentContext by componentContext {
 
     private val repository: ConfettiRepository by inject()
@@ -67,6 +69,7 @@ class DefaultConferenceAgentComponent(
 
     private val state = MutableStateFlow(
         ConferenceAgentComponent.UiState(
+            userPhotoUrl = userPhotoUrl,
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
                 ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -72,14 +72,6 @@ class DefaultConferenceAgentComponent(
             userPhotoUrl = userPhotoUrl,
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
-                ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
-                ConferenceAgentComponent.Message.ToolCall("fetchSessions(date=2026-08-12)"),
-                ConferenceAgentComponent.Message.ToolCall("filterSessions(topic=Kotlin)"),
-                ConferenceAgentComponent.Message.Agent("There are 2 Kotlin sessions tomorrow:\n1. *Kotlin Multiplatform in Action* at 10:00 AM\n2. *Advanced Coroutines* at 2:00 PM."),
-                ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
-                ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
-                ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
-                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -69,6 +69,14 @@ class DefaultConferenceAgentComponent(
         ConferenceAgentComponent.UiState(
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
+                ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchSessions(date=2026-08-12)"),
+                ConferenceAgentComponent.Message.ToolCall("filterSessions(topic=Kotlin)"),
+                ConferenceAgentComponent.Message.Agent("There are 2 Kotlin sessions tomorrow:\n1. *Kotlin Multiplatform in Action* at 10:00 AM\n2. *Advanced Coroutines* at 2:00 PM."),
+                ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
+                ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
+                ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
+                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceAgentComponent.kt
@@ -69,9 +69,27 @@ class DefaultConferenceAgentComponent(
 
     private val state = MutableStateFlow(
         ConferenceAgentComponent.UiState(
-            userPhotoUrl = userPhotoUrl,
+            userPhotoUrl = userPhotoUrl ?: "https://avatars.githubusercontent.com/u/4348197?s=400&u=c27e3f938a61471e2eebc00d6c8ab8826b0af816&v=4",
             messages = listOf(
                 ConferenceAgentComponent.Message.System(agentProvider.description),
+                ConferenceAgentComponent.Message.User("Hi, what Kotlin sessions are scheduled for tomorrow?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchSessions(date=2026-08-12)"),
+                ConferenceAgentComponent.Message.ToolCall("filterSessions(topic=Kotlin)"),
+                ConferenceAgentComponent.Message.Agent("There are 2 Kotlin sessions tomorrow:\n1. *Kotlin Multiplatform in Action* at 10:00 AM\n2. *Advanced Coroutines* at 2:00 PM."),
+                ConferenceAgentComponent.Message.User("Thanks! Can you bookmark the first one?"),
+                ConferenceAgentComponent.Message.ToolCall("bookmarkSession(id=session-kmp-101)"),
+                ConferenceAgentComponent.Message.System("Session bookmarked successfully."),
+                ConferenceAgentComponent.Message.Agent("I have bookmarked 'Kotlin Multiplatform in Action' for you."),
+                ConferenceAgentComponent.Message.User("Who are the speakers for the Advanced Coroutines session?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchSessionDetails(id=session-coroutines-102)"),
+                ConferenceAgentComponent.Message.Agent("The speaker for *Advanced Coroutines* is **John Doe**, a Principal Engineer specialized in Kotlin asynchronous programming."),
+                ConferenceAgentComponent.Message.User("Great. Where is the venue of the conference?"),
+                ConferenceAgentComponent.Message.ToolCall("fetchVenue()"),
+                ConferenceAgentComponent.Message.Agent("The conference is held at the **San Francisco Convention Center**, Hall A, located at 747 Howard St."),
+                ConferenceAgentComponent.Message.User("Is there any bookmark tab where I can view all my bookmarks?"),
+                ConferenceAgentComponent.Message.Agent("Yes, you can see all your bookmarked sessions in the 'Bookmarks' tab at the bottom navigation bar on the home screen."),
+                ConferenceAgentComponent.Message.User("Perfect, thanks for your help!"),
+                ConferenceAgentComponent.Message.Agent("You are welcome! Let me know if you need anything else.")
             ),
         ),
     )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
@@ -14,6 +14,9 @@ import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.decompose.ConferenceComponent.Child
 import kotlinx.serialization.Serializable
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import dev.johnoreilly.confetti.AppSettings
+import kotlinx.coroutines.runBlocking
 
 
 interface ConferenceComponent : BackHandlerOwner {
@@ -29,6 +32,7 @@ interface ConferenceComponent : BackHandlerOwner {
         class SessionDetails(val component: SessionDetailsComponent) : Child()
         class SpeakerDetails(val component: SpeakerDetailsComponent) : Child()
         class Settings(val component: SettingsComponent?) : Child()
+        class Agent(val component: ConferenceAgentComponent) : Child()
     }
 }
 
@@ -44,6 +48,16 @@ class DefaultConferenceComponent(
 ) : ConferenceComponent, KoinComponent, ComponentContext by componentContext {
 
     private val navigation = StackNavigation<Config>()
+
+    init {
+        val appSettings: AppSettings by inject()
+        val forceEnable = runBlocking {
+            appSettings.settings.getBoolean(AppSettings.FORCE_ENABLE_ASSISTANT, false)
+        }
+        if (forceEnable) {
+            navigation.push(Config.Agent)
+        }
+    }
 
     override val stack: Value<ChildStack<*, Child>> =
         childStack(
@@ -68,6 +82,7 @@ class DefaultConferenceComponent(
                         onSignIn = onSignIn,
                         onSignOut = onSignOut,
                         onShowSettings = { navigation.push(Config.Settings) },
+                        onShowAgent = { navigation.push(Config.Agent) },
                     )
                 )
 
@@ -96,6 +111,15 @@ class DefaultConferenceComponent(
                 )
 
             is Config.Settings -> Child.Settings(settingsComponent)
+
+            is Config.Agent ->
+                Child.Agent(
+                    DefaultConferenceAgentComponent(
+                        componentContext = componentContext,
+                        conference = conference,
+                        userPhotoUrl = user?.photoUrl,
+                    )
+                )
         }
 
     override fun onBackClicked() {
@@ -119,5 +143,8 @@ class DefaultConferenceComponent(
 
         @Serializable
         data object Settings : Config()
+
+        @Serializable
+        data object Agent : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -59,7 +59,7 @@ class DefaultHomeComponent(
         childStack(
             source = navigation,
             serializer = Config.serializer(),
-            initialConfiguration = Config.Sessions,
+            initialConfiguration = Config.Agent,
             handleBackButton = true,
             childFactory = ::child,
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -11,6 +11,10 @@ import dev.johnoreilly.confetti.BuildKonfig
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.decompose.HomeComponent.Child
 import kotlinx.serialization.Serializable
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import dev.johnoreilly.confetti.AppSettings
+import kotlinx.coroutines.runBlocking
 
 interface HomeComponent {
 
@@ -51,7 +55,7 @@ class DefaultHomeComponent(
     private val onSignIn: () -> Unit,
     private val onSignOut: () -> Unit,
     private val onShowSettings: () -> Unit,
-) : HomeComponent, ComponentContext by componentContext {
+) : HomeComponent, KoinComponent, ComponentContext by componentContext {
 
     private val navigation = StackNavigation<Config>()
 
@@ -127,7 +131,11 @@ class DefaultHomeComponent(
         }
 
     override fun isAgentEnabled(): Boolean {
-        return BuildKonfig.GEMINI_API_KEY.isNotEmpty()
+        val appSettings: AppSettings by inject()
+        val forceEnable = runBlocking {
+            appSettings.settings.getBoolean(AppSettings.FORCE_ENABLE_ASSISTANT, false)
+        }
+        return forceEnable || BuildKonfig.GEMINI_API_KEY.isNotEmpty()
     }
 
     override fun onSessionsTabClicked() {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -126,6 +126,7 @@ class DefaultHomeComponent(
                     DefaultConferenceAgentComponent(
                         componentContext = componentContext,
                         conference = conference,
+                        userPhotoUrl = user?.photoUrl,
                     )
                 )
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -7,6 +7,8 @@ import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.childContext
 import dev.johnoreilly.confetti.BuildKonfig
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.decompose.HomeComponent.Child
@@ -41,7 +43,6 @@ interface HomeComponent {
         class Bookmarks(val component: BookmarksComponent) : Child()
         class Venue(val component: VenueComponent) : Child()
         class Search(val component: SearchComponent) : Child()
-        class Agent(val component: ConferenceAgentComponent) : Child()
     }
 }
 
@@ -55,6 +56,7 @@ class DefaultHomeComponent(
     private val onSignIn: () -> Unit,
     private val onSignOut: () -> Unit,
     private val onShowSettings: () -> Unit,
+    private val onShowAgent: () -> Unit,
 ) : HomeComponent, KoinComponent, ComponentContext by componentContext {
 
     private val navigation = StackNavigation<Config>()
@@ -63,7 +65,7 @@ class DefaultHomeComponent(
         childStack(
             source = navigation,
             serializer = Config.serializer(),
-            initialConfiguration = Config.Agent,
+            initialConfiguration = Config.Sessions,
             handleBackButton = true,
             childFactory = ::child,
         )
@@ -120,15 +122,6 @@ class DefaultHomeComponent(
                         onSignIn = onSignIn,
                     )
                 )
-
-            Config.Agent ->
-                Child.Agent(
-                    DefaultConferenceAgentComponent(
-                        componentContext = componentContext,
-                        conference = conference,
-                        userPhotoUrl = user?.photoUrl,
-                    )
-                )
         }
 
     override fun isAgentEnabled(): Boolean {
@@ -164,7 +157,7 @@ class DefaultHomeComponent(
     }
 
     override fun onAgentClicked() {
-        navigation.bringToFront(Config.Agent)
+        onShowAgent()
     }
 
     override fun onSignInClicked() {
@@ -199,8 +192,5 @@ class DefaultHomeComponent(
 
         @Serializable
         data object Search : Config()
-
-        @Serializable
-        data object Agent : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SettingsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SettingsComponent.kt
@@ -21,7 +21,8 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 data class DeveloperSettings(
-    val token: String?
+    val token: String?,
+    val forceEnableAssistant: Boolean
 )
 
 /**
@@ -50,6 +51,7 @@ interface SettingsComponent {
     fun updateDarkThemeConfig(darkThemeConfig: DarkThemeConfig)
     fun updateUseExperimentalFeatures(value: Boolean)
     fun updateNotificationsEnabled(value: Boolean)
+    fun updateForceEnableAssistant(value: Boolean)
     fun enableDeveloperMode()
     fun sendNotifications()
     val supportsNotifications: Boolean
@@ -67,12 +69,15 @@ class DefaultSettingsComponent(
     private val settings = appSettings.settings
     override val applicationInfo: ApplicationInfo by inject()
 
-    override val developerSettings: StateFlow<DeveloperSettings?> = appSettings.developerModeFlow().flatMapLatest {
-        if (!it) {
+    override val developerSettings: StateFlow<DeveloperSettings?> = appSettings.developerModeFlow().flatMapLatest { devMode ->
+        if (!devMode) {
             flowOf(null)
         } else {
-            authentication.currentUser.map { user ->
-                DeveloperSettings(token = user?.token(false))
+            combine(
+                authentication.currentUser.map { user -> user?.token(false) },
+                appSettings.forceEnableAssistantFlow
+            ) { token, forceEnable ->
+                DeveloperSettings(token = token, forceEnableAssistant = forceEnable)
             }
         }
     }.stateIn(
@@ -114,6 +119,12 @@ class DefaultSettingsComponent(
         coroutineScope.launch {
             appSettings.setNotificationsEnabled(value)
             notificationSender?.updateSchedule(value)
+        }
+    }
+
+    override fun updateForceEnableAssistant(value: Boolean) {
+        coroutineScope.launch {
+            appSettings.setForceEnableAssistant(value)
         }
     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -29,6 +29,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
@@ -37,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.ExperimentalDecomposeApi
@@ -100,6 +106,12 @@ fun ConferenceView(component: ConferenceComponent) {
                         SettingsUI(childComponent, component::onBackClicked)
                     }
                 }
+                is ConferenceComponent.Child.Agent -> {
+                    ConferenceAgentView(
+                        component = child.component,
+                        onCloseClick = component::onBackClicked
+                    )
+                }
             }
         }
     }
@@ -131,7 +143,6 @@ fun HomeView(component: HomeComponent) {
                         AccountInfo(photoUrl = user.photoUrl)
                     },
                     installOnWear = {}, // FIXME: handle
-                    //wearSettingsUiState = wearUiState,
                     showAgentOption = component.isAgentEnabled()
                 )
             }
@@ -207,11 +218,6 @@ fun HomeView(component: HomeComponent) {
                                     windowSizeClass = windowSizeClass,
                                     onBackClick = component::onBackClicked
                                 )
-
-                            is HomeComponent.Child.Agent -> ConferenceAgentView(
-                                component = child.component,
-                                bottomContentPadding = innerPadding.calculateBottomPadding()
-                            )
                         }
                     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -76,28 +77,34 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
         }
     }
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .imePadding()
-            .padding(16.dp)
-            .padding(bottom = bottomContentPadding)
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Spacer(Modifier.weight(1f))
-            IconButton(onClick = { component.restartChat() }) {
-                Icon(
-                    imageVector = Icons.Filled.Refresh,
-                    contentDescription = stringResource(Res.string.agent_restart),
-                )
-            }
-        }
-
         LazyColumn(
-            modifier = Modifier.weight(1f).fillMaxWidth(),
+            modifier = Modifier.fillMaxSize(),
             state = listState,
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                top = 16.dp,
+                bottom = 88.dp + bottomContentPadding
+            ),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            item {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Spacer(Modifier.weight(1f))
+                    IconButton(onClick = { component.restartChat() }) {
+                        Icon(
+                            imageVector = Icons.Filled.Refresh,
+                            contentDescription = stringResource(Res.string.agent_restart),
+                        )
+                    }
+                }
+            }
+
             items(renderMessages) { renderMessage ->
                 when (renderMessage) {
                     is RenderMessage.Single -> MessageBubble(
@@ -116,10 +123,13 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
             }
         }
 
-        Spacer(Modifier.size(8.dp))
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(16.dp)
+                .padding(bottom = bottomContentPadding),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             OutlinedTextField(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -39,6 +39,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.animation.core.*
 import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
@@ -123,39 +127,61 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
             }
         }
 
-        Row(
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
                 .align(Alignment.BottomCenter)
                 .background(MaterialTheme.colorScheme.background)
-                .padding(16.dp)
-                .padding(bottom = bottomContentPadding),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            OutlinedTextField(
-                modifier = Modifier.weight(1f),
-                value = state.inputText,
-                onValueChange = component::updateInputText,
-                placeholder = { Text(stringResource(Res.string.agent_placeholder)) },
-                enabled = state.isInputEnabled && !state.isChatEnded,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                keyboardActions = KeyboardActions(onSend = { component.sendMessage() }),
-                shape = RoundedCornerShape(24.dp),
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                thickness = 1.dp
             )
-
-            Spacer(Modifier.width(8.dp))
-
-            IconButton(
-                onClick = { component.sendMessage() },
-                enabled = state.isInputEnabled &&
-                    !state.isChatEnded &&
-                    state.inputText.isNotBlank(),
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                    .padding(bottom = bottomContentPadding),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Send,
-                    contentDescription = stringResource(Res.string.agent_send),
+                TextField(
+                    modifier = Modifier.weight(1f),
+                    value = state.inputText,
+                    onValueChange = component::updateInputText,
+                    placeholder = { Text(stringResource(Res.string.agent_placeholder)) },
+                    enabled = state.isInputEnabled && !state.isChatEnded,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(onSend = {
+                        if (state.inputText.isNotBlank()) {
+                            component.sendMessage()
+                        }
+                    }),
+                    shape = CircleShape,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent
+                    )
                 )
+
+                Spacer(Modifier.width(8.dp))
+
+                FilledIconButton(
+                    onClick = { component.sendMessage() },
+                    enabled = state.isInputEnabled &&
+                        !state.isChatEnded &&
+                        state.inputText.isNotBlank(),
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Send,
+                        contentDescription = stringResource(Res.string.agent_send),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.animation.core.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -100,12 +101,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
 
             if (state.isLoading) {
                 item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(8.dp),
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                    }
+                    TypingBubble()
                 }
             }
         }
@@ -337,4 +333,66 @@ private fun groupMessages(messages: List<ConferenceAgentComponent.Message>): Lis
         result.add(RenderMessage.ToolCallGroup(currentToolCalls.toList()))
     }
     return result
+}
+
+@Composable
+private fun TypingBubble() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.Top
+    ) {
+        MessageAvatar(
+            imageVector = Icons.Filled.Assistant,
+            contentDescription = "Agent",
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            iconColor = MaterialTheme.colorScheme.onSecondaryContainer
+        )
+        Spacer(Modifier.width(8.dp))
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(12.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            TypingIndicator()
+        }
+    }
+}
+
+@Composable
+private fun TypingIndicator() {
+    val transition = rememberInfiniteTransition()
+    val alphas = (0..2).map { index ->
+        transition.animateFloat(
+            initialValue = 0.2f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = 600
+                    0.2f at 0 with LinearEasing
+                    1.0f at 200 with LinearEasing
+                    0.2f at 400 with LinearEasing
+                },
+                repeatMode = RepeatMode.Restart,
+                initialStartOffset = StartOffset(index * 150)
+            )
+        )
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 6.dp, vertical = 8.dp)
+    ) {
+        alphas.forEach { alphaState ->
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alphaState.value),
+                        shape = RoundedCornerShape(3.dp)
+                    )
+            )
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -24,8 +24,11 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material.icons.filled.Assistant
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -143,12 +146,34 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
 }
 
 @Composable
-private fun MessageBubble(message: ConferenceAgentComponent.Message) {
-    val alignment = when (message) {
-        is ConferenceAgentComponent.Message.User -> Alignment.End
-        is ConferenceAgentComponent.Message.System -> Alignment.CenterHorizontally
-        else -> Alignment.Start
+private fun MessageAvatar(
+    imageVector: ImageVector,
+    contentDescription: String,
+    containerColor: Color,
+    iconColor: Color
+) {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(containerColor, RoundedCornerShape(16.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            tint = iconColor,
+            modifier = Modifier.size(20.dp)
+        )
     }
+}
+
+@Composable
+private fun MessageBubble(message: ConferenceAgentComponent.Message) {
+    val isSystem = message is ConferenceAgentComponent.Message.System
+    val isUser = message is ConferenceAgentComponent.Message.User
+    val isAgent = message is ConferenceAgentComponent.Message.Agent
+    val isError = message is ConferenceAgentComponent.Message.Error
+
     val background = when (message) {
         is ConferenceAgentComponent.Message.User -> MaterialTheme.colorScheme.primaryContainer
         is ConferenceAgentComponent.Message.Agent -> MaterialTheme.colorScheme.surfaceVariant
@@ -157,32 +182,71 @@ private fun MessageBubble(message: ConferenceAgentComponent.Message) {
         is ConferenceAgentComponent.Message.Error -> MaterialTheme.colorScheme.errorContainer
     }
 
-    Column(modifier = Modifier.fillMaxWidth()) {
+    if (isSystem) {
         Box(
             modifier = Modifier
-                .align(alignment)
-                .widthIn(max = 720.dp)
-                .background(background, RoundedCornerShape(12.dp))
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+            contentAlignment = Alignment.Center
         ) {
-            when (message) {
-                is ConferenceAgentComponent.Message.Agent -> Markdown(message.text)
-                is ConferenceAgentComponent.Message.System ->
-                    Text(
-                        text = message.text,
-                        fontStyle = FontStyle.Italic,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline
-                    )
-                is ConferenceAgentComponent.Message.ToolCall ->
-                    Text(
-                        text = "🔧 ${message.text}",
-                        color = MaterialTheme.colorScheme.outline,
-                        fontStyle = FontStyle.Italic,
-                    )
-                is ConferenceAgentComponent.Message.Error ->
-                    Text(message.text, color = MaterialTheme.colorScheme.onErrorContainer)
-                is ConferenceAgentComponent.Message.User -> Text(message.text)
+            Box(
+                modifier = Modifier
+                    .background(background, RoundedCornerShape(12.dp))
+                    .padding(horizontal = 12.dp, vertical = 6.dp)
+            ) {
+                Text(
+                    text = message.text,
+                    fontStyle = FontStyle.Italic,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
+    } else {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+            verticalAlignment = Alignment.Top
+        ) {
+            if (!isUser && (isAgent || isError)) {
+                MessageAvatar(
+                    imageVector = Icons.Filled.Assistant,
+                    contentDescription = "Agent",
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    iconColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Spacer(Modifier.width(8.dp))
+            }
+
+            Box(
+                modifier = Modifier
+                    .widthIn(max = 660.dp)
+                    .background(background, RoundedCornerShape(12.dp))
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+            ) {
+                when (message) {
+                    is ConferenceAgentComponent.Message.Agent -> Markdown(message.text)
+                    is ConferenceAgentComponent.Message.Error ->
+                        Text(message.text, color = MaterialTheme.colorScheme.onErrorContainer)
+                    is ConferenceAgentComponent.Message.User -> Text(message.text)
+                    is ConferenceAgentComponent.Message.ToolCall ->
+                        Text(
+                            text = "🔧 ${message.text}",
+                            color = MaterialTheme.colorScheme.outline,
+                            fontStyle = FontStyle.Italic,
+                        )
+                    is ConferenceAgentComponent.Message.System -> {}
+                }
+            }
+
+            if (isUser) {
+                Spacer(Modifier.width(8.dp))
+                MessageAvatar(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "User",
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    iconColor = MaterialTheme.colorScheme.onPrimary
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -37,7 +37,7 @@ import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.CircularProgressIndicator
@@ -114,7 +114,7 @@ fun ConferenceAgentView(
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = onCloseClick) {
-                Icon(Icons.Filled.Close, contentDescription = "Close")
+                Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
             }
             Text(
                 text = "Assistant",

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -146,12 +146,13 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
 private fun MessageBubble(message: ConferenceAgentComponent.Message) {
     val alignment = when (message) {
         is ConferenceAgentComponent.Message.User -> Alignment.End
+        is ConferenceAgentComponent.Message.System -> Alignment.CenterHorizontally
         else -> Alignment.Start
     }
     val background = when (message) {
         is ConferenceAgentComponent.Message.User -> MaterialTheme.colorScheme.primaryContainer
         is ConferenceAgentComponent.Message.Agent -> MaterialTheme.colorScheme.surfaceVariant
-        is ConferenceAgentComponent.Message.System -> Color.Transparent
+        is ConferenceAgentComponent.Message.System -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
         is ConferenceAgentComponent.Message.ToolCall -> Color.Transparent
         is ConferenceAgentComponent.Message.Error -> MaterialTheme.colorScheme.errorContainer
     }
@@ -167,7 +168,12 @@ private fun MessageBubble(message: ConferenceAgentComponent.Message) {
             when (message) {
                 is ConferenceAgentComponent.Message.Agent -> Markdown(message.text)
                 is ConferenceAgentComponent.Message.System ->
-                    Text(message.text, fontStyle = FontStyle.Italic)
+                    Text(
+                        text = message.text,
+                        fontStyle = FontStyle.Italic,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline
+                    )
                 is ConferenceAgentComponent.Message.ToolCall ->
                     Text(
                         text = "🔧 ${message.text}",

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -32,6 +36,7 @@ import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.CircularProgressIndicator
@@ -61,6 +66,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -74,12 +80,18 @@ import dev.johnoreilly.confetti.decompose.ConferenceAgentComponent
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPadding: Dp = 0.dp) {
+fun ConferenceAgentView(
+    component: ConferenceAgentComponent,
+    onCloseClick: () -> Unit,
+    bottomContentPadding: Dp = 0.dp
+) {
     val state by component.uiState.subscribeAsState()
     val listState = rememberLazyListState()
     val renderMessages = remember(state.messages) { groupMessages(state.messages) }
     var showPhotoDialogUrl by remember { mutableStateOf<String?>(null) }
     val hazeState = remember { HazeState() }
+    val systemBottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val totalBottomPadding = systemBottomPadding + bottomContentPadding
 
     LaunchedEffect(renderMessages.size) {
         if (renderMessages.isNotEmpty()) {
@@ -87,113 +99,133 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
         }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .imePadding()
-    ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().haze(hazeState),
-            state = listState,
-            contentPadding = PaddingValues(
-                start = 16.dp,
-                end = 16.dp,
-                top = 16.dp,
-                bottom = 88.dp + bottomContentPadding
-            ),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            item {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Spacer(Modifier.weight(1f))
-                    IconButton(onClick = { component.restartChat() }) {
-                        Icon(
-                            imageVector = Icons.Filled.Refresh,
-                            contentDescription = stringResource(Res.string.agent_restart),
+            IconButton(onClick = onCloseClick) {
+                Icon(Icons.Filled.Close, contentDescription = "Close")
+            }
+            Text(
+                text = "Assistant",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center
+            )
+            IconButton(onClick = { component.restartChat() }) {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = stringResource(Res.string.agent_restart),
+                )
+            }
+        }
+
+        HorizontalDivider(
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+            thickness = 1.dp
+        )
+
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .imePadding()
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().haze(hazeState),
+                state = listState,
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 16.dp,
+                    bottom = 88.dp + totalBottomPadding
+                ),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(renderMessages) { renderMessage ->
+                    when (renderMessage) {
+                        is RenderMessage.Single -> MessageBubble(
+                            message = renderMessage.message,
+                            userPhotoUrl = state.userPhotoUrl,
+                            onPhotoClick = { url -> showPhotoDialogUrl = url }
                         )
+                        is RenderMessage.ToolCallGroup -> ToolCallGroupBubble(renderMessage)
+                    }
+                }
+
+                if (state.isLoading) {
+                    item {
+                        TypingBubble()
                     }
                 }
             }
 
-            items(renderMessages) { renderMessage ->
-                when (renderMessage) {
-                    is RenderMessage.Single -> MessageBubble(
-                        message = renderMessage.message,
-                        userPhotoUrl = state.userPhotoUrl,
-                        onPhotoClick = { url -> showPhotoDialogUrl = url }
-                    )
-                    is RenderMessage.ToolCallGroup -> ToolCallGroupBubble(renderMessage)
-                }
-            }
-
-            if (state.isLoading) {
-                item {
-                    TypingBubble()
-                }
-            }
-        }
-
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .hazeChild(
-                    state = hazeState,
-                    style = HazeStyle(
-                        backgroundColor = MaterialTheme.colorScheme.surface,
-                        tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
-                        blurRadius = 25.dp,
-                    )
-                )
-        ) {
-            HorizontalDivider(
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-                thickness = 1.dp
-            )
-            Row(
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-                    .padding(bottom = bottomContentPadding),
-                verticalAlignment = Alignment.CenterVertically,
+                    .align(Alignment.BottomCenter)
+                    .hazeChild(
+                        state = hazeState,
+                        style = HazeStyle(
+                            backgroundColor = MaterialTheme.colorScheme.surface,
+                            tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
+                            blurRadius = 25.dp,
+                        )
+                    )
             ) {
-                TextField(
-                    modifier = Modifier.weight(1f),
-                    value = state.inputText,
-                    onValueChange = component::updateInputText,
-                    placeholder = { Text(stringResource(Res.string.agent_placeholder)) },
-                    enabled = state.isInputEnabled && !state.isChatEnded,
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                    keyboardActions = KeyboardActions(onSend = {
-                        if (state.inputText.isNotBlank()) {
-                            component.sendMessage()
-                        }
-                    }),
-                    shape = CircleShape,
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent
-                    )
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    thickness = 1.dp
                 )
-
-                Spacer(Modifier.width(8.dp))
-
-                FilledIconButton(
-                    onClick = { component.sendMessage() },
-                    enabled = state.isInputEnabled &&
-                        !state.isChatEnded &&
-                        state.inputText.isNotBlank(),
-                    modifier = Modifier.size(48.dp)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .padding(bottom = totalBottomPadding),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        imageVector = Icons.Filled.Send,
-                        contentDescription = stringResource(Res.string.agent_send),
-                        modifier = Modifier.size(20.dp)
+                    TextField(
+                        modifier = Modifier.weight(1f),
+                        value = state.inputText,
+                        onValueChange = component::updateInputText,
+                        placeholder = { Text(stringResource(Res.string.agent_placeholder)) },
+                        enabled = state.isInputEnabled && !state.isChatEnded,
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                        keyboardActions = KeyboardActions(onSend = {
+                            if (state.inputText.isNotBlank()) {
+                                component.sendMessage()
+                            }
+                        }),
+                        shape = CircleShape,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        )
                     )
+
+                    Spacer(Modifier.width(8.dp))
+
+                    FilledIconButton(
+                        onClick = { component.sendMessage() },
+                        enabled = state.isInputEnabled &&
+                            !state.isChatEnded &&
+                            state.inputText.isNotBlank(),
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Send,
+                            contentDescription = stringResource(Res.string.agent_send),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -15,11 +15,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CircularProgressIndicator
@@ -31,6 +35,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,10 +58,11 @@ import org.jetbrains.compose.resources.stringResource
 fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPadding: Dp = 0.dp) {
     val state by component.uiState.subscribeAsState()
     val listState = rememberLazyListState()
+    val renderMessages = remember(state.messages) { groupMessages(state.messages) }
 
-    LaunchedEffect(state.messages.size) {
-        if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(state.messages.lastIndex)
+    LaunchedEffect(renderMessages.size) {
+        if (renderMessages.isNotEmpty()) {
+            listState.animateScrollToItem(renderMessages.lastIndex)
         }
     }
 
@@ -80,8 +88,11 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
             state = listState,
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(state.messages) { message ->
-                MessageBubble(message)
+            items(renderMessages) { renderMessage ->
+                when (renderMessage) {
+                    is RenderMessage.Single -> MessageBubble(renderMessage.message)
+                    is RenderMessage.ToolCallGroup -> ToolCallGroupBubble(renderMessage)
+                }
             }
 
             if (state.isLoading) {
@@ -169,4 +180,91 @@ private fun MessageBubble(message: ConferenceAgentComponent.Message) {
             }
         }
     }
+}
+
+@Composable
+private fun ToolCallGroupBubble(group: RenderMessage.ToolCallGroup) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = !expanded }
+            .padding(vertical = 4.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = "🔧 Called ${group.toolCalls.size} tools",
+                color = MaterialTheme.colorScheme.outline,
+                style = MaterialTheme.typography.bodyMedium,
+                fontStyle = FontStyle.Italic,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Filled.ArrowDropUp else Icons.Filled.ArrowDropDown,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.outline
+            )
+        }
+
+        if (expanded) {
+            Spacer(Modifier.height(4.dp))
+            Column(
+                modifier = Modifier
+                    .padding(start = 16.dp)
+                    .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                group.toolCalls.forEach { toolCall ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                                RoundedCornerShape(8.dp)
+                            )
+                            .padding(horizontal = 12.dp, vertical = 6.dp)
+                    ) {
+                        Text(
+                            text = toolCall.text,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontStyle = FontStyle.Italic
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private sealed interface RenderMessage {
+    data class Single(val message: ConferenceAgentComponent.Message) : RenderMessage
+    data class ToolCallGroup(val toolCalls: List<ConferenceAgentComponent.Message.ToolCall>) : RenderMessage
+}
+
+private fun groupMessages(messages: List<ConferenceAgentComponent.Message>): List<RenderMessage> {
+    val result = mutableListOf<RenderMessage>()
+    val currentToolCalls = mutableListOf<ConferenceAgentComponent.Message.ToolCall>()
+
+    for (message in messages) {
+        if (message is ConferenceAgentComponent.Message.ToolCall) {
+            currentToolCalls.add(message)
+        } else {
+            if (currentToolCalls.isNotEmpty()) {
+                result.add(RenderMessage.ToolCallGroup(currentToolCalls.toList()))
+                currentToolCalls.clear()
+            }
+            result.add(RenderMessage.Single(message))
+        }
+    }
+    if (currentToolCalls.isNotEmpty()) {
+        result.add(RenderMessage.ToolCallGroup(currentToolCalls.toList()))
+    }
+    return result
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.animation.core.*
 import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import dev.chrisbanes.haze.HazeState
@@ -99,8 +100,12 @@ fun ConferenceAgentView(
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Row(
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .statusBarsPadding()
@@ -231,12 +236,13 @@ fun ConferenceAgentView(
         }
     }
 
-    if (showPhotoDialogUrl != null) {
-        FullScreenPhotoDialog(
-            photoUrl = showPhotoDialogUrl,
-            contentDescription = "User Profile Photo",
-            onDismissRequest = { showPhotoDialogUrl = null }
-        )
+        if (showPhotoDialogUrl != null) {
+            FullScreenPhotoDialog(
+                photoUrl = showPhotoDialogUrl,
+                contentDescription = "User Profile Photo",
+                onDismissRequest = { showPhotoDialogUrl = null }
+            )
+        }
     }
 }
 
@@ -319,6 +325,7 @@ private fun MessageBubble(
 
             Box(
                 modifier = Modifier
+                    .weight(1f, fill = false)
                     .widthIn(max = 660.dp)
                     .background(background, RoundedCornerShape(12.dp))
                     .padding(horizontal = 12.dp, vertical = 8.dp),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -383,7 +384,15 @@ private fun ToolCallGroupBubble(group: RenderMessage.ToolCallGroup) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    shape = RoundedCornerShape(8.dp)
+                )
                 .padding(horizontal = 12.dp, vertical = 8.dp)
         ) {
             Text(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -60,6 +61,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .imePadding()
             .padding(16.dp)
             .padding(bottom = bottomContentPadding)
     ) {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -378,21 +378,22 @@ private fun ToolCallGroupBubble(group: RenderMessage.ToolCallGroup) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(8.dp)
+            )
             .clickable { expanded = !expanded }
             .padding(vertical = 4.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .background(
-                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                    shape = RoundedCornerShape(8.dp)
-                )
+                .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 8.dp)
         ) {
             Text(
@@ -410,30 +411,26 @@ private fun ToolCallGroupBubble(group: RenderMessage.ToolCallGroup) {
         }
 
         if (expanded) {
-            Spacer(Modifier.height(4.dp))
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 12.dp)
+            )
+            Spacer(Modifier.height(8.dp))
             Column(
                 modifier = Modifier
-                    .padding(start = 16.dp)
+                    .padding(horizontal = 12.dp)
                     .fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
                 group.toolCalls.forEach { toolCall ->
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(
-                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                                RoundedCornerShape(8.dp)
-                            )
-                            .padding(horizontal = 12.dp, vertical = 6.dp)
-                    ) {
-                        Text(
-                            text = toolCall.text,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.bodySmall,
-                            fontStyle = FontStyle.Italic
-                        )
-                    }
+                    Text(
+                        text = toolCall.text,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontStyle = FontStyle.Italic,
+                        modifier = Modifier.padding(bottom = 6.dp)
+                    )
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.animation.core.*
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -67,6 +68,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
     val state by component.uiState.subscribeAsState()
     val listState = rememberLazyListState()
     val renderMessages = remember(state.messages) { groupMessages(state.messages) }
+    var showPhotoDialogUrl by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(renderMessages.size) {
         if (renderMessages.isNotEmpty()) {
@@ -98,7 +100,11 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
         ) {
             items(renderMessages) { renderMessage ->
                 when (renderMessage) {
-                    is RenderMessage.Single -> MessageBubble(renderMessage.message, state.userPhotoUrl)
+                    is RenderMessage.Single -> MessageBubble(
+                        message = renderMessage.message,
+                        userPhotoUrl = state.userPhotoUrl,
+                        onPhotoClick = { url -> showPhotoDialogUrl = url }
+                    )
                     is RenderMessage.ToolCallGroup -> ToolCallGroupBubble(renderMessage)
                 }
             }
@@ -143,6 +149,14 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
             }
         }
     }
+
+    if (showPhotoDialogUrl != null) {
+        FullScreenPhotoDialog(
+            photoUrl = showPhotoDialogUrl,
+            contentDescription = "User Profile Photo",
+            onDismissRequest = { showPhotoDialogUrl = null }
+        )
+    }
 }
 
 @Composable
@@ -168,7 +182,11 @@ private fun MessageAvatar(
 }
 
 @Composable
-private fun MessageBubble(message: ConferenceAgentComponent.Message, userPhotoUrl: String?) {
+private fun MessageBubble(
+    message: ConferenceAgentComponent.Message,
+    userPhotoUrl: String?,
+    onPhotoClick: (String) -> Unit
+) {
     val isSystem = message is ConferenceAgentComponent.Message.System
     val isUser = message is ConferenceAgentComponent.Message.User
     val isAgent = message is ConferenceAgentComponent.Message.Agent
@@ -249,6 +267,7 @@ private fun MessageBubble(message: ConferenceAgentComponent.Message, userPhotoUr
                         modifier = Modifier
                             .size(32.dp)
                             .clip(CircleShape)
+                            .clickable { onPhotoClick(userPhotoUrl) }
                     )
                 } else {
                     MessageAvatar(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -19,6 +19,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -94,7 +98,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
         ) {
             items(renderMessages) { renderMessage ->
                 when (renderMessage) {
-                    is RenderMessage.Single -> MessageBubble(renderMessage.message)
+                    is RenderMessage.Single -> MessageBubble(renderMessage.message, state.userPhotoUrl)
                     is RenderMessage.ToolCallGroup -> ToolCallGroupBubble(renderMessage)
                 }
             }
@@ -164,7 +168,7 @@ private fun MessageAvatar(
 }
 
 @Composable
-private fun MessageBubble(message: ConferenceAgentComponent.Message) {
+private fun MessageBubble(message: ConferenceAgentComponent.Message, userPhotoUrl: String?) {
     val isSystem = message is ConferenceAgentComponent.Message.System
     val isUser = message is ConferenceAgentComponent.Message.User
     val isAgent = message is ConferenceAgentComponent.Message.Agent
@@ -237,12 +241,23 @@ private fun MessageBubble(message: ConferenceAgentComponent.Message) {
 
             if (isUser) {
                 Spacer(Modifier.width(8.dp))
-                MessageAvatar(
-                    imageVector = Icons.Filled.Person,
-                    contentDescription = "User",
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    iconColor = MaterialTheme.colorScheme.onPrimary
-                )
+                if (userPhotoUrl != null) {
+                    AsyncImage(
+                        model = userPhotoUrl,
+                        contentDescription = "User Profile",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                    )
+                } else {
+                    MessageAvatar(
+                        imageVector = Icons.Filled.Person,
+                        contentDescription = "User",
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        iconColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -35,7 +35,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -123,8 +123,8 @@ fun ConferenceAgentView(
             )
             IconButton(onClick = { component.restartChat() }) {
                 Icon(
-                    imageVector = Icons.Filled.Refresh,
-                    contentDescription = stringResource(Res.string.agent_restart),
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = "Clear Chat",
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -46,6 +46,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.animation.core.*
 import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeChild
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -74,6 +79,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
     val listState = rememberLazyListState()
     val renderMessages = remember(state.messages) { groupMessages(state.messages) }
     var showPhotoDialogUrl by remember { mutableStateOf<String?>(null) }
+    val hazeState = remember { HazeState() }
 
     LaunchedEffect(renderMessages.size) {
         if (renderMessages.isNotEmpty()) {
@@ -87,7 +93,7 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
             .imePadding()
     ) {
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().haze(hazeState),
             state = listState,
             contentPadding = PaddingValues(
                 start = 16.dp,
@@ -130,7 +136,14 @@ fun ConferenceAgentView(component: ConferenceAgentComponent, bottomContentPaddin
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .background(MaterialTheme.colorScheme.background)
+                .hazeChild(
+                    state = hazeState,
+                    style = HazeStyle(
+                        backgroundColor = MaterialTheme.colorScheme.surface,
+                        tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
+                        blurRadius = 25.dp,
+                    )
+                )
         ) {
             HorizontalDivider(
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -88,6 +88,7 @@ fun SettingsUI(
         onSendNotifications = component::sendNotifications,
         supportsNotifications = component.supportsNotifications,
         onNotificationsEnabled = component::updateNotificationsEnabled,
+        onChangeForceEnableAssistant = component::updateForceEnableAssistant,
         popBack = popBack
     )
 }
@@ -103,6 +104,7 @@ fun SettingsUI(
     onSendNotifications: () -> Unit,
     supportsNotifications: Boolean,
     onNotificationsEnabled: (value: Boolean) -> Unit,
+    onChangeForceEnableAssistant: (value: Boolean) -> Unit,
     popBack: () -> Unit
 ) {
     var showPermissionDeniedDialog by remember { mutableStateOf(false) }
@@ -208,6 +210,15 @@ fun SettingsUI(
                             subtitle = "Trigger a mock session reminder alert",
                             onClick = onSendNotifications,
                             enabled = supportsNotifications
+                        )
+                    }
+
+                    item {
+                        SwitchSettingsRow(
+                            title = "Force Open Assistant",
+                            description = "Enable Gemini Assistant without API key config",
+                            value = developerSettings.forceEnableAssistant,
+                            onValueChange = onChangeForceEnableAssistant
                         )
                     }
                 }


### PR DESCRIPTION
Overhaul the Assistant layout, chat timeline, and navigation to create a polished, full-screen chat experience:

- Chat UI Improvements:
  - Message Bubbles: Introduce styled, padded message bubbles with rounded corners, aligned left (Agent) or right (User).
  - User & Agent Avatars: Add distinct user and agent avatars in the timeline, including support for loading user profile photos with a person icon fallback.
  - Animated Typing Indicator: Render a bouncing-dots loading bubble utilizing infinite keyframe animations when the agent is executing queries.
  - Centered System Status: Center italicized system messages on the screen to visually separate them from the conversation flow.
  - Unified Tool Call Cards: Group sequential API/tool calls inside a collapsible, outlined card to clean up the timeline.
- Navigation & Spacing:
  - Migrate the Assistant from a tab inside HomeComponent to a full-screen child destination in the ConferenceComponent navigation stack (hiding the bottom bar when open).
  - Wrap the screen in a Surface container to ensure the correct theme background color is applied.
- Toolbar Actions:
  - Add a Back Arrow button on the left of the toolbar to go back.
  - Change the restart button icon from Refresh to Delete to better represent the clear history action.
- Developer Controls:
  - Add a toggle in the developer settings to force open the assistant on application startup.

Screenshot:

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/73cd39b3-6269-4844-b194-4c69734f18d8" />
