### PR TITLE
Fix Settings crash on web/desktop: missing ApplicationInfo Koin binding

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -291,6 +291,11 @@ buildkonfig {
             "GEMINI_API_KEY",
             localProperties["gemini_api_key"]?.toString() ?: ""
         )
+        buildConfigField(
+            FieldSpec.Type.STRING,
+            "VERSION_NAME",
+            autoVersion
+        )
     }
 
 }

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -19,6 +19,7 @@ import com.russhwolf.settings.coroutines.toFlowSettings
 import dev.johnoreilly.confetti.BuildKonfig
 import dev.johnoreilly.confetti.agent.ApiEmbedder
 import dev.johnoreilly.confetti.agent.EmbeddingCache
+import dev.johnoreilly.confetti.appconfig.ApplicationInfo
 import dev.johnoreilly.confetti.auth.Authentication
 import dev.johnoreilly.confetti.dev.johnoreilly.confetti.work.SessionNotificationSender
 import dev.johnoreilly.confetti.utils.DateService
@@ -46,6 +47,7 @@ actual fun platformModule() = module {
         FetchPolicy.CacheAndNetwork
     }
     single<NotificationSender> { SessionNotificationSender() }
+    single<ApplicationInfo> { ApplicationInfo(BuildKonfig.VERSION_NAME) }
 
     System.getProperty("user.home")?.let { home ->
         single<EmbeddingCache> {

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
@@ -20,6 +20,7 @@ import ai.koog.prompt.llm.LLModel
 import com.russhwolf.settings.observable.makeObservable
 import dev.johnoreilly.confetti.BuildKonfig
 import dev.johnoreilly.confetti.agent.ApiEmbedder
+import dev.johnoreilly.confetti.appconfig.ApplicationInfo
 import dev.johnoreilly.confetti.auth.Authentication
 import dev.johnoreilly.confetti.dev.johnoreilly.confetti.work.SessionNotificationSender
 import dev.johnoreilly.confetti.utils.DateService
@@ -38,6 +39,7 @@ actual fun platformModule() = module {
         FetchPolicy.CacheAndNetwork
     }
     single<NotificationSender> { SessionNotificationSender() }
+    single<ApplicationInfo> { ApplicationInfo(BuildKonfig.VERSION_NAME) }
 
     single<Embedder> {
         ApiEmbedder(


### PR DESCRIPTION
## Summary
- On the live web client, clicking Settings did nothing visible, but the console showed two errors: `NoDefinitionFoundException: No definition found for type 'ApplicationInfo'` and, right after, `IllegalStateException: Configurations must be unique: [Home, Settings, Settings]`.
- Root cause: `SettingsComponent` injects `ApplicationInfo` eagerly, but `androidMain`/`iosMain` were the only platform Koin modules registering it — `wasmJsMain` and `jvmMain` (desktop) never did. The DI crash during composition triggered Compose's error-retry, which corrupted decompose's navigation stack and produced the second, unrelated-looking duplicate-config crash. Registering `ApplicationInfo` fixes both; the duplicate-config crash doesn't recur once the DI crash is gone.
- Added a `VERSION_NAME` BuildKonfig field (sourced from the existing `LIBRARY_VERSION` project version) and registered `single<ApplicationInfo> { ApplicationInfo(BuildKonfig.VERSION_NAME) }` in both `KoinWasmJs.kt` and `KoinJVM.kt`, matching the existing Android/iOS pattern.

## Test plan
- [x] Built `:compose-web:wasmJsBrowserDistribution` locally, served it, and manually verified: Settings opens and shows "Version: 0.9", console is clean, and repeated back-and-forth navigation into Settings doesn't crash.
- [x] `:shared:compileKotlinJvm`, `:shared:compileKotlinIosSimulatorArm64`, `:androidApp:compileReleaseKotlin` all compile clean.
- [ ] CI green on this PR (build-and-publish-web.yml now validates the web build on every PR)