### PR TITLE
Improve schedule and speaker list rendering performance

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -305,6 +305,9 @@ class SessionsSimpleComponent(
 
             val sessionsByStartTime = sessions
                 .groupBy { getSessionTime(it) }
+                .mapValues { (_, sessionsList) ->
+                    sessionsList.sortedBy { session -> rooms.indexOfFirst { it.name == session.room?.name } }
+                }
 
             sessionsByStartTimeList.add(sessionsByStartTime)
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -147,7 +149,11 @@ class SessionsSimpleComponent(
         combineUiState()
             .combine(searchQuery) { uiState, search ->
                 filterSessions(uiState, search)
-            }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5000), SessionsUiState.Loading)
+            }
+            // Run heavy mapping and filtering operations on Default dispatcher to avoid blocking UI.
+            // Default dispatcher is preferred over IO dispatcher because these are CPU-bound memory tasks.
+            .flowOn(Dispatchers.Default)
+            .stateIn(coroutineScope, SharingStarted.WhileSubscribed(5000), SessionsUiState.Loading)
 
     private var job: Job? = null
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -145,6 +145,9 @@ class SessionsSimpleComponent(
     private val selectedSessionId = MutableStateFlow<String?>(null)
     private val appSettings: AppSettings by inject()
 
+    private var lastSessionsData: GetConferenceDataQuery.Data? = null
+    private var cachedParsedData: ParsedConferenceData? = null
+
     val uiState: StateFlow<SessionsUiState> =
         combineUiState()
             .combine(searchQuery) { uiState, search ->
@@ -269,24 +272,11 @@ class SessionsSimpleComponent(
         return session.startsAt.sessionTimeFormat()
     }
 
-    private fun uiStates(
-        refreshData: ResponseData,
-        isRefreshing: Boolean,
-        searchString: String,
-        selectedSessionId: String?,
-        notificationsActive: Boolean,
-    ): SessionsUiState {
-        val bookmarksResponse = refreshData.bookmarksResponse
-        val sessionsResponse = refreshData.sessionsResponse
-        val bookmarksData = bookmarksResponse.data
-        val sessionsData = sessionsResponse.data
-
-        if (sessionsData == null || bookmarksData == null) {
-            bookmarksResponse.exception?.printStackTrace()
-            sessionsResponse.exception?.printStackTrace()
-            bookmarksResponse.errors?.let { println(it) }
-            sessionsResponse.errors?.let { println(it) }
-            return SessionsUiState.Error
+    private fun getOrParseConferenceData(sessionsData: GetConferenceDataQuery.Data): ParsedConferenceData {
+        val lastData = lastSessionsData
+        val cached = cachedParsedData
+        if (lastData === sessionsData && cached != null) {
+            return cached
         }
 
         val conferenceName = sessionsData.config.name
@@ -315,9 +305,8 @@ class SessionsSimpleComponent(
         val formattedConfDates = confDates.map { date ->
             date.atTime(0, 0).conferenceDateFormat()
         }
-        return SessionsUiState.Success(
-            now = dateService.now(),
-            conference = conference,
+
+        val parsed = ParsedConferenceData(
             conferenceName = conferenceName,
             venueLat = venueLat,
             venueLon = venueLon,
@@ -325,7 +314,47 @@ class SessionsSimpleComponent(
             formattedConfDates = formattedConfDates,
             sessionsByStartTimeList = sessionsByStartTimeList,
             speakers = speakers,
-            rooms = rooms,
+            rooms = rooms
+        )
+
+        lastSessionsData = sessionsData
+        cachedParsedData = parsed
+        return parsed
+    }
+
+    private fun uiStates(
+        refreshData: ResponseData,
+        isRefreshing: Boolean,
+        searchString: String,
+        selectedSessionId: String?,
+        notificationsActive: Boolean,
+    ): SessionsUiState {
+        val bookmarksResponse = refreshData.bookmarksResponse
+        val sessionsResponse = refreshData.sessionsResponse
+        val bookmarksData = bookmarksResponse.data
+        val sessionsData = sessionsResponse.data
+
+        if (sessionsData == null || bookmarksData == null) {
+            bookmarksResponse.exception?.printStackTrace()
+            sessionsResponse.exception?.printStackTrace()
+            bookmarksResponse.errors?.let { println(it) }
+            sessionsResponse.errors?.let { println(it) }
+            return SessionsUiState.Error
+        }
+
+        val parsed = getOrParseConferenceData(sessionsData)
+
+        return SessionsUiState.Success(
+            now = dateService.now(),
+            conference = conference,
+            conferenceName = parsed.conferenceName,
+            venueLat = parsed.venueLat,
+            venueLon = parsed.venueLon,
+            confDates = parsed.confDates,
+            formattedConfDates = parsed.formattedConfDates,
+            sessionsByStartTimeList = parsed.sessionsByStartTimeList,
+            speakers = parsed.speakers,
+            rooms = parsed.rooms,
             bookmarks = bookmarksData.bookmarks?.sessionIds.orEmpty().toSet(),
             isRefreshing = isRefreshing,
             searchString = searchString,
@@ -357,3 +386,14 @@ sealed interface SessionsUiState {
         val notificationsActive: Boolean
     ) : SessionsUiState
 }
+
+private data class ParsedConferenceData(
+    val conferenceName: String,
+    val venueLat: Double?,
+    val venueLon: Double?,
+    val confDates: List<LocalDate>,
+    val formattedConfDates: List<String>,
+    val sessionsByStartTimeList: List<Map<String, List<SessionDetails>>>,
+    val speakers: List<SpeakerDetails>,
+    val rooms: List<RoomDetails>
+)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakersComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakersComponent.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.Dispatchers
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
@@ -56,7 +58,10 @@ class SpeakersSimpleComponent(
                     emit(SpeakersUiState.Success(conference, it))
                 }
             }
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5000), SpeakersUiState.Loading)
+    }
+        // Offload speaker mapping to Default dispatcher to keep UI responsive.
+        .flowOn(Dispatchers.Default)
+        .stateIn(coroutineScope, SharingStarted.WhileSubscribed(5000), SpeakersUiState.Loading)
 }
 
 sealed interface SpeakersUiState {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
@@ -117,9 +117,7 @@ fun SessionListView(
                                     ConfettiHeader(icon = ConfettiIcons.AccessTime, text = startTime)
                                 }
 
-                                val sortedSessions =
-                                    sessions.sortedBy { session -> uiState.rooms.indexOfFirst { it.name == session.room?.name } }
-                                itemsIndexed(sortedSessions) { index, session ->
+                                itemsIndexed(sessions) { index, session ->
                                     SessionItemView(
                                         session = session,
                                         sessionSelected = sessionSelected,
@@ -129,7 +127,7 @@ fun SessionListView(
                                         onNavigateToSignIn = onNavigateToSignIn,
                                         isLoggedIn = isLoggedIn,
                                     )
-                                    if (index < sortedSessions.lastIndex) {
+                                    if (index < sessions.lastIndex) {
                                         HorizontalDivider()
                                     }
                                 }


### PR DESCRIPTION
This PR improves the performance and responsiveness of the schedule and speaker list screens by offloading data mapping operations to a background thread and optimizing the rendering pipeline.

- Background Flow Dispatcher: Offloaded heavy session/speaker list mapping, grouping, sorting, and filtering operations from the Main UI thread to `Dispatchers.Default` using `.flowOn(Dispatchers.Default)`.
- Pre-Sort Sessions by Room: Moved the sorting by room index logic from the UI scroll path (`SessionListView` composition/scrolling) to the background component flow. Instead of executing up to 500+ CPU operations (example: 100 sessions * 5 rooms) on the Main thread during scroll, the list is pre-sorted in the background.
- Cache Parsed Schedule Data: Added in-memory caching for parsed session and speaker data in `SessionsComponent`. Mapping and sorting computations are only executed when the raw query data changes, preventing CPU jank during searches.