### PR TITLE
Support bookmarking from speaker details and add upcoming bookmarks badge

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
@@ -91,7 +91,9 @@ class DefaultConferenceComponent(
                         componentContext = componentContext,
                         conference = conference,
                         speakerId = config.speakerId,
+                        user = user,
                         onSessionSelected = { navigation.bringToFront(Config.SessionDetails(sessionId = it)) },
+                        onSignIn = onSignIn,
                         onFinished = navigation::pop,
                     )
                 )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -16,12 +16,21 @@ import kotlinx.serialization.Serializable
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import dev.johnoreilly.confetti.AppSettings
+import dev.johnoreilly.confetti.utils.DateService
+import dev.johnoreilly.confetti.utils.createCurrentLocalDateTimeFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 
 interface HomeComponent {
 
     val conference: String
     val user: User?
     val stack: Value<ChildStack<*, Child>>
+    val upcomingBookmarksCount: Flow<Int>
 
     suspend fun isAgentEnabled(): Boolean
     fun onSessionsTabClicked()
@@ -55,8 +64,44 @@ class DefaultHomeComponent(
     private val onSignIn: () -> Unit,
     private val onSignOut: () -> Unit,
     private val onShowSettings: () -> Unit,
-    private val onShowAgent: () -> Unit,
+    private val onShowAgent: () -> Unit = {},
 ) : HomeComponent, KoinComponent, ComponentContext by componentContext {
+
+    private val dateService: DateService by inject()
+
+    private val sessionsComponent =
+        SessionsSimpleComponent(
+            componentContext = childContext("HomeSessions"),
+            conference = conference,
+            user = user,
+        )
+
+    private val loadedSessions = sessionsComponent
+        .uiState
+        .filterIsInstance<SessionsUiState.Success>()
+
+    private val bookmarks = loadedSessions
+        .map { state -> state.bookmarks }
+
+    private val sessions = loadedSessions
+        .map { state ->
+            state
+                .sessionsByStartTimeList
+                .flatMap { sessions -> sessions.values }
+                .flatten()
+        }
+        .combine(bookmarks) { sessions, bookmarks ->
+            sessions.filter { session -> session.id in bookmarks }
+        }
+
+    private val currentDateTimeFlow = dateService
+        .createCurrentLocalDateTimeFlow()
+
+    override val upcomingBookmarksCount: Flow<Int> = sessions
+        .combine(currentDateTimeFlow) { sessions, now ->
+            sessions.count { session -> session.endsAt >= now }
+        }
+        .flowOn(Dispatchers.Default)
 
     private val navigation = StackNavigation<Config>()
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
@@ -4,50 +4,89 @@ import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository
+import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState.Error
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState.Loading
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState.Success
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 interface SpeakerDetailsComponent {
 
     val uiState: Value<SpeakerDetailsUiState>
+    val isLoggedIn: Boolean
 
+    fun addBookmark(sessionId: String)
+    fun removeBookmark(sessionId: String)
     fun onSessionClicked(id: String)
     fun onCloseClicked()
+    fun onSignInClicked()
 }
 
 sealed class SpeakerDetailsUiState {
-    object Loading : SpeakerDetailsUiState()
-    object Error : SpeakerDetailsUiState()
-    class Success(val conference: String, val details: SpeakerDetails) : SpeakerDetailsUiState()
+    data object Loading : SpeakerDetailsUiState()
+    data object Error : SpeakerDetailsUiState()
+    data class Success(
+        val conference: String,
+        val details: SpeakerDetails,
+        val bookmarks: Set<String> = emptySet(),
+    ) : SpeakerDetailsUiState()
 }
 
 class DefaultSpeakerDetailsComponent(
     componentContext: ComponentContext,
-    conference: String,
-    speakerId: String,
+    private val conference: String,
+    private val speakerId: String,
+    private val user: User? = null,
     private val onSessionSelected: (id: String) -> Unit,
+    private val onSignIn: () -> Unit = {},
     private val onFinished: () -> Unit = {},
 ) : SpeakerDetailsComponent, KoinComponent, ComponentContext by componentContext {
     private val repository: ConfettiRepository by inject()
     private val coroutineScope = coroutineScope()
 
+    override val isLoggedIn: Boolean = user != null
+
     override val uiState: Value<SpeakerDetailsUiState> = flow {
+        val initialBookmarks = repository.bookmarks(conference, user?.uid, user, FetchPolicy.CacheFirst).first()
         // FixMe: add .speaker(id)
         val response = repository.conferenceData(conference = conference, FetchPolicy.CacheFirst)
         val details = response.data?.speakers?.nodes?.map { it.speakerDetails }
             ?.firstOrNull { it.id == speakerId }
 
         if (details != null) {
-            emit(Success(conference, details))
+            val initialBookmarksSet = initialBookmarks.data?.bookmarks?.sessionIds.orEmpty().toSet()
+            emitAll(
+                repository.watchBookmarks(conference, user?.uid, user, initialBookmarks.data)
+                    .map { it.data?.bookmarks?.sessionIds.orEmpty().toSet() }
+                    .onStart { emit(initialBookmarksSet) }
+                    .map { bookmarks ->
+                        Success(conference, details, bookmarks)
+                    }
+            )
         } else {
             emit(Error)
         }
     }.asValue(initialValue = Loading, lifecycle = lifecycle)
+
+    override fun addBookmark(sessionId: String) {
+        coroutineScope.launch {
+            repository.addBookmark(conference, user?.uid, user, sessionId)
+        }
+    }
+
+    override fun removeBookmark(sessionId: String) {
+        coroutineScope.launch {
+            repository.removeBookmark(conference, user?.uid, user, sessionId)
+        }
+    }
 
     override fun onSessionClicked(id: String) {
         onSessionSelected(id)
@@ -56,5 +95,10 @@ class DefaultSpeakerDetailsComponent(
     override fun onCloseClicked() {
         onFinished()
     }
+
+    override fun onSignInClicked() {
+        onSignIn()
+    }
 }
+
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -254,7 +254,8 @@ private fun NavigationRail(component: HomeComponent) {
                         badge = {
                             if (badgeCount > 0) {
                                 Badge {
-                                    Text(badgeCount.toString())
+                                    val badgeText = if (badgeCount > 99) "99+" else badgeCount.toString()
+                                    Text(badgeText)
                                 }
                             }
                         }
@@ -290,7 +291,8 @@ private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
                             badge = {
                                 if (badgeCount > 0) {
                                     Badge {
-                                        Text(badgeCount.toString())
+                                        val badgeText = if (badgeCount > 99) "99+" else badgeCount.toString()
+                                        Text(badgeText)
                                     }
                                 }
                             }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -16,6 +16,8 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -41,6 +43,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -242,15 +245,25 @@ private fun NavigationRail(component: HomeComponent) {
         containerColor = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     ) {
-        NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, onClick ->
+        NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, badgeCount, onClick ->
             NavigationRailItem(
                 selected = isSelected,
                 onClick = onClick,
                 icon = {
-                    Icon(
-                        imageVector = if (isSelected) selectedIcon else unselectedIcon,
-                        contentDescription = text
-                    )
+                    BadgedBox(
+                        badge = {
+                            if (badgeCount > 0) {
+                                Badge {
+                                    Text(badgeCount.toString())
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = if (isSelected) selectedIcon else unselectedIcon,
+                            contentDescription = text
+                        )
+                    }
                 },
             )
         }
@@ -268,15 +281,25 @@ private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
             tonalElevation = 0.dp,
             containerColor = Color.Transparent,
         ) {
-            NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, onClick ->
+            NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, badgeCount, onClick ->
                 NavigationBarItem(
                     selected = isSelected,
                     onClick = onClick,
                     icon = {
-                        Icon(
-                            imageVector = if (isSelected) selectedIcon else unselectedIcon,
-                            contentDescription = text,
-                        )
+                        BadgedBox(
+                            badge = {
+                                if (badgeCount > 0) {
+                                    Badge {
+                                        Text(badgeCount.toString())
+                                    }
+                                }
+                            }
+                        ) {
+                            Icon(
+                                imageVector = if (isSelected) selectedIcon else unselectedIcon,
+                                contentDescription = text,
+                            )
+                        }
                     },
                     label = { Text(text) },
                 )
@@ -294,17 +317,20 @@ private fun <T> T.NavigationButtons(
         selectedIcon: ImageVector,
         unselectedIcon: ImageVector,
         text: String,
+        badgeCount: Int,
         onClick: () -> Unit,
     ) -> Unit,
 ) {
     val stack by component.stack.subscribeAsState()
     val activeChild = stack.active.instance
+    val upcomingBookmarksCount by component.upcomingBookmarksCount.collectAsStateWithLifecycle(initialValue = 0)
 
     content(
         activeChild is HomeComponent.Child.Sessions,
         Icons.Filled.Home,
         Icons.Outlined.Home,
         stringResource(Res.string.schedule),
+        0,
         component::onSessionsTabClicked,
     )
 
@@ -313,6 +339,7 @@ private fun <T> T.NavigationButtons(
         Icons.Filled.Person,
         Icons.Outlined.Person,
         stringResource(Res.string.speakers),
+        0,
         component::onSpeakersTabClicked,
     )
 
@@ -321,6 +348,7 @@ private fun <T> T.NavigationButtons(
         Icons.Filled.Bookmarks,
         Icons.Outlined.Bookmarks,
         stringResource(Res.string.bookmarks),
+        upcomingBookmarksCount,
         component::onBookmarksTabClicked,
     )
 
@@ -329,6 +357,7 @@ private fun <T> T.NavigationButtons(
         Icons.Filled.LocationOn,
         Icons.Outlined.LocationOn,
         stringResource(Res.string.venue),
+        0,
         component::onVenueTabClicked,
     )
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -47,6 +47,8 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
+import dev.johnoreilly.confetti.ui.SignInDialog
+import dev.johnoreilly.confetti.ui.bookmarks.Bookmark
 import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import coil3.compose.SubcomposeAsyncImage
 import confetti.shared.generated.resources.Res
@@ -67,6 +69,11 @@ import org.jetbrains.compose.resources.stringResource
 fun SpeakerDetailsView(
     conference: String,
     speaker: SpeakerDetails,
+    isBookmarked: (sessionId: String) -> Boolean = { false },
+    addBookmark: (sessionId: String) -> Unit = {},
+    removeBookmark: (sessionId: String) -> Unit = {},
+    onNavigateToSignIn: () -> Unit = {},
+    isLoggedIn: Boolean = false,
     navigateToSession: (id: String) -> Unit,
     popBack: () -> Unit,
     onSocialLinkClicked: (String) -> Unit
@@ -180,6 +187,11 @@ fun SpeakerDetailsView(
             SpeakerTalks(
                 modifier = Modifier.padding(vertical = 8.dp),
                 sessions = speaker.sessions,
+                isBookmarked = isBookmarked,
+                addBookmark = addBookmark,
+                removeBookmark = removeBookmark,
+                onNavigateToSignIn = onNavigateToSignIn,
+                isLoggedIn = isLoggedIn,
                 navigateToSession = navigateToSession,
             )
         }
@@ -197,9 +209,16 @@ fun SpeakerDetailsView(
 @Composable
 fun SpeakerTalks(
     sessions: List<SpeakerDetails.Session>,
+    isBookmarked: (sessionId: String) -> Boolean,
+    addBookmark: (sessionId: String) -> Unit,
+    removeBookmark: (sessionId: String) -> Unit,
+    onNavigateToSignIn: () -> Unit,
+    isLoggedIn: Boolean,
     navigateToSession: (id: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showDialog by remember { mutableStateOf(false) }
+
     Column(Modifier.fillMaxWidth()) {
 
         ConfettiHeader(icon = Icons.Filled.Event, text = stringResource(Res.string.sessions))
@@ -208,6 +227,7 @@ fun SpeakerTalks(
 
         Column(modifier) {
             sessions.forEachIndexed { index, session ->
+                val bookmarked = isBookmarked(session.id)
                 ListItem(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -217,6 +237,22 @@ fun SpeakerTalks(
                             text = session.title,
                             style = MaterialTheme.typography.titleMedium
                         )
+                    },
+                    trailingContent = {
+                        Bookmark(
+                            isBookmarked = bookmarked,
+                            onBookmarkChange = { shouldAdd ->
+                                if (!isLoggedIn) {
+                                    showDialog = true
+                                    return@Bookmark
+                                }
+                                if (shouldAdd) {
+                                    addBookmark(session.id)
+                                } else {
+                                    removeBookmark(session.id)
+                                }
+                            }
+                        )
                     }
                 )
                 if (index < sessions.lastIndex) {
@@ -224,6 +260,13 @@ fun SpeakerTalks(
                 }
             }
         }
+    }
+
+    if (showDialog) {
+        SignInDialog(
+            onDismissRequest = { showDialog = false },
+            onSignInClicked = onNavigateToSignIn
+        )
     }
 }
 
@@ -234,6 +277,10 @@ internal fun SpeakerDetailsViewLoadedPreview() {
         SpeakerDetailsView(
             conference = "kotlinconf2023",
             speaker = johnOreillySpeaker,
+            isBookmarked = { false },
+            addBookmark = {},
+            removeBookmark = {},
+            isLoggedIn = true,
             navigateToSession = {},
             popBack = {},
             onSocialLinkClicked = {},
@@ -248,6 +295,10 @@ internal fun SpeakerDetailsViewAlternateSpeakerPreview() {
         SpeakerDetailsView(
             conference = "kotlinconf2023",
             speaker = martinBonninSpeaker,
+            isBookmarked = { false },
+            addBookmark = {},
+            removeBookmark = {},
+            isLoggedIn = true,
             navigateToSession = {},
             popBack = {},
             onSocialLinkClicked = {},

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersUI.kt
@@ -59,11 +59,16 @@ fun SpeakerDetailsUI(component: SpeakerDetailsComponent) {
         is SpeakerDetailsUiState.Loading -> LoadingView()
         is SpeakerDetailsUiState.Error -> ErrorView()
         is SpeakerDetailsUiState.Success -> SpeakerDetailsView(
-            state.conference,
-            state.details,
-            component::onSessionClicked,
-            component::onCloseClicked,
-            uriHandler::openUri)
+            conference = state.conference,
+            speaker = state.details,
+            isBookmarked = { state.bookmarks.contains(it) },
+            addBookmark = component::addBookmark,
+            removeBookmark = component::removeBookmark,
+            onNavigateToSignIn = component::onSignInClicked,
+            isLoggedIn = component.isLoggedIn,
+            navigateToSession = component::onSessionClicked,
+            popBack = component::onCloseClicked,
+            onSocialLinkClicked = uriHandler::openUri
+        )
     }
-
 }


### PR DESCRIPTION
- Allow users to bookmark and unbookmark sessions directly from the speaker details talk list.
- Show sign-in dialog when unauthenticated users try to bookmark from speaker details.
- Add badge to bookmarks icon on bottom navigation bar and navigation rail.
- Badge shows total count of upcoming bookmarked talks and updates as talks finish or bookmarks change.

| 0 | 3 | 99+ |
| :---: | :---: | :---: |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8a2a6ecb-fb61-4a55-a5f0-2b5fbc07ebd4" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/941a5ce5-fe11-4087-8b48-a915749c7dfa" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/34761682-8b15-43bd-96a3-191b6879dbd4" /> |




