### PR TITLE
Remove schema CacheControl directives to prevent cache read OutOfMemoryError

### DIFF
--- a/shared/src/commonMain/graphql/extra.graphqls
+++ b/shared/src/commonMain/graphql/extra.graphqls
@@ -1,8 +1,7 @@
 extend schema
-@link(url: "https://specs.apollo.dev/kotlin_labs/v0.3")
 @link(
-    url: "https://specs.apollo.dev/cache/v0.3",
-    import: ["@typePolicy", "@fieldPolicy", "@cacheControl", "@cacheControlField"]
+    url: "https://specs.apollo.dev/kotlin_labs/v0.3",
+    import: ["@typePolicy", "@fieldPolicy"]
 )
 
 extend type Venue
@@ -10,25 +9,21 @@ extend type Venue
 
 extend type Session
 @typePolicy(keyFields: "id")
-@cacheControl(maxAge: 14400)
 
 extend type Bookmarks
 @typePolicy(keyFields: "id")
-@cacheControl(maxAge: 3600)
 
 extend type Speaker
 @typePolicy(keyFields: "id")
-@cacheControl(maxAge: 14400)
 
 extend type Room
 @typePolicy(keyFields: "id")
-@cacheControl(maxAge: 14400)
 
 extend type Conference
 @typePolicy(keyFields: "id")
-@cacheControl(maxAge: 14400)
 
 extend type Query
 @fieldPolicy(forField: "session", keyArgs: "id")
 @fieldPolicy(forField: "speaker", keyArgs: "id")
+
 


### PR DESCRIPTION
Remove @CacheControl annotations from extra.graphqls to stop Apollo from installing SchemaCoordinatesMaxAgeProvider.

When @CacheControl directives are defined on types in extra.graphqls, Apollo's normalized cache compiler plugin generates a maxAges map and attaches CacheControlCacheResolver to cache reads. During cache reads for large payloads such as GetConferenceDataQuery, SchemaCoordinatesMaxAgeProvider.getMaxAge() executes recursive type lookups on every single field. Each lookup calls allImplements(), creating repeated LinkedHashSet, ArrayList, and distinct() allocations for thousands of nodes. This excessive allocation pressure rapidly exhausts heap memory and triggers OutOfMemoryError on Android.

Confetti already configures maxStale(Duration.INFINITE) in ApolloClientCache and manages cache freshness explicitly via FetchPolicy (CacheFirst vs NetworkOnly). Removing @CacheControl clears the maxAges map, completely bypassing SchemaCoordinatesMaxAgeProvider with zero loss of caching functionality.

**Disclosure:** this PR contains code produced by generative Al.