### PR TITLE
Redo home navigation bar with new Account tab and top bar AI Assistant

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AccountComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AccountComponent.kt
@@ -1,0 +1,102 @@
+package dev.johnoreilly.confetti.decompose
+
+import com.apollographql.cache.normalized.FetchPolicy
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import dev.johnoreilly.confetti.AppSettings
+import dev.johnoreilly.confetti.BuildKonfig
+import dev.johnoreilly.confetti.ConfettiRepository
+import dev.johnoreilly.confetti.auth.User
+import dev.johnoreilly.confetti.decompose.coroutineScope
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+import kotlinx.datetime.LocalDate
+
+interface AccountComponent {
+    val conference: String
+    val user: User?
+    val uiState: Value<AccountUiState>
+
+    fun onVenueClicked()
+    fun onSwitchConferenceClicked()
+    fun onSettingsClicked()
+    fun onSignInClicked()
+    fun onSignOutClicked()
+}
+
+sealed interface AccountUiState {
+    data object Loading : AccountUiState
+    data class Success(
+        val conferenceName: String,
+        val conferenceDays: String,
+        val user: User?,
+        val hasVenue: Boolean = true,
+    ) : AccountUiState
+    data object Error : AccountUiState
+}
+
+class DefaultAccountComponent(
+    componentContext: ComponentContext,
+    override val conference: String,
+    override val user: User?,
+    private val onVenueSelected: () -> Unit,
+    private val onSwitchConference: () -> Unit,
+    private val onShowSettings: () -> Unit,
+    private val onSignIn: () -> Unit,
+    private val onSignOut: () -> Unit,
+) : AccountComponent, KoinComponent, ComponentContext by componentContext {
+
+    private val repository: ConfettiRepository by inject()
+    private val coroutineScope = coroutineScope()
+
+    private val _uiState = MutableValue<AccountUiState>(AccountUiState.Loading)
+    override val uiState: Value<AccountUiState> = _uiState
+
+    init {
+        coroutineScope.launch {
+            try {
+                val response = repository.conferenceData(conference, FetchPolicy.CacheFirst)
+                val config = response.data?.config
+                val venues = response.data?.venues
+                val daysStr = config?.days?.let { days ->
+                    formatConferenceDates(days)
+                }.orEmpty()
+
+                _uiState.value = AccountUiState.Success(
+                    conferenceName = config?.name ?: conference,
+                    conferenceDays = daysStr,
+                    user = user,
+                    hasVenue = !venues.isNullOrEmpty(),
+                )
+            } catch (e: Exception) {
+                _uiState.value = AccountUiState.Error
+            }
+        }
+    }
+
+    private fun formatConferenceDates(days: List<LocalDate>): String {
+        if (days.isEmpty()) return ""
+        val start = days.first()
+        val end = days.last()
+        val startMonth = start.month.name.take(3).lowercase().replaceFirstChar { it.uppercase() }
+        val endMonth = end.month.name.take(3).lowercase().replaceFirstChar { it.uppercase() }
+        return if (days.size == 1) {
+            "$startMonth ${start.dayOfMonth}, ${start.year}"
+        } else if (start.month == end.month && start.year == end.year) {
+            "$startMonth ${start.dayOfMonth} - ${end.dayOfMonth}, ${start.year}"
+        } else if (start.year == end.year) {
+            "$startMonth ${start.dayOfMonth} - $endMonth ${end.dayOfMonth}, ${start.year}"
+        } else {
+            "$startMonth ${start.dayOfMonth}, ${start.year} - $endMonth ${end.dayOfMonth}, ${end.year}"
+        }
+    }
+
+    override fun onVenueClicked() = onVenueSelected()
+    override fun onSwitchConferenceClicked() = onSwitchConference()
+    override fun onSettingsClicked() = onShowSettings()
+    override fun onSignInClicked() = onSignIn()
+    override fun onSignOutClicked() = onSignOut()
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
@@ -28,6 +28,7 @@ interface ConferenceComponent : BackHandlerOwner {
         class SpeakerDetails(val component: SpeakerDetailsComponent) : Child()
         class Settings(val component: SettingsComponent?) : Child()
         class Agent(val component: ConferenceAgentComponent) : Child()
+        class Venue(val component: VenueComponent) : Child()
     }
 }
 
@@ -76,6 +77,7 @@ class DefaultConferenceComponent(
                         onSignOut = onSignOut,
                         onShowSettings = { navigation.push(Config.Settings) },
                         onShowAgent = { navigation.push(Config.Agent) },
+                        onVenueSelected = { navigation.push(Config.Venue) },
                     )
                 )
 
@@ -115,6 +117,14 @@ class DefaultConferenceComponent(
                         userPhotoUrl = user?.photoUrl,
                     )
                 )
+
+            is Config.Venue ->
+                Child.Venue(
+                    DefaultVenueComponent(
+                        componentContext = componentContext,
+                        conference = conference,
+                    )
+                )
         }
 
     override fun onBackClicked() {
@@ -141,5 +151,8 @@ class DefaultConferenceComponent(
 
         @Serializable
         data object Agent : Config()
+
+        @Serializable
+        data object Venue : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -36,7 +36,7 @@ interface HomeComponent {
     fun onSessionsTabClicked()
     fun onSpeakersTabClicked()
     fun onBookmarksTabClicked()
-    fun onVenueTabClicked()
+    fun onAccountTabClicked()
     fun onSearchClicked()
     fun onSwitchConferenceClicked()
     fun onAgentClicked()
@@ -49,7 +49,7 @@ interface HomeComponent {
         class Sessions(val component: SessionsComponent) : Child()
         class Speakers(val component: SpeakersComponent) : Child()
         class Bookmarks(val component: BookmarksComponent) : Child()
-        class Venue(val component: VenueComponent) : Child()
+        class Account(val component: AccountComponent) : Child()
         class Search(val component: SearchComponent) : Child()
     }
 }
@@ -64,7 +64,8 @@ class DefaultHomeComponent(
     private val onSignIn: () -> Unit,
     private val onSignOut: () -> Unit,
     private val onShowSettings: () -> Unit,
-    private val onShowAgent: () -> Unit = {},
+    private val onShowAgent: () -> Unit,
+    private val onVenueSelected: () -> Unit,
 ) : HomeComponent, KoinComponent, ComponentContext by componentContext {
 
     private val dateService: DateService by inject()
@@ -147,11 +148,17 @@ class DefaultHomeComponent(
                     )
                 )
 
-            Config.Venue ->
-                Child.Venue(
-                    DefaultVenueComponent(
+            Config.Account ->
+                Child.Account(
+                    DefaultAccountComponent(
                         componentContext = componentContext,
-                        conference = conference
+                        conference = conference,
+                        user = user,
+                        onVenueSelected = onVenueSelected,
+                        onSwitchConference = onSwitchConference,
+                        onShowSettings = onShowSettings,
+                        onSignIn = onSignIn,
+                        onSignOut = onSignOut,
                     )
                 )
 
@@ -186,8 +193,8 @@ class DefaultHomeComponent(
         navigation.bringToFront(Config.Bookmarks)
     }
 
-    override fun onVenueTabClicked() {
-        navigation.bringToFront(Config.Venue)
+    override fun onAccountTabClicked() {
+        navigation.bringToFront(Config.Account)
     }
 
     override fun onSearchClicked() {
@@ -230,7 +237,7 @@ class DefaultHomeComponent(
         data object Bookmarks : Config()
 
         @Serializable
-        data object Venue : Config()
+        data object Account : Config()
 
         @Serializable
         data object Search : Config()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -11,13 +11,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Bookmarks
-import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.outlined.Bookmarks
-import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -338,7 +338,7 @@ private fun <T> T.NavigationButtons(
         activeChild is HomeComponent.Child.Sessions,
         {
             Icon(
-                imageVector = if (activeChild is HomeComponent.Child.Sessions) Icons.Filled.Home else Icons.Outlined.Home,
+                imageVector = if (activeChild is HomeComponent.Child.Sessions) Icons.Filled.CalendarToday else Icons.Outlined.CalendarToday,
                 contentDescription = stringResource(Res.string.schedule),
             )
         },
@@ -351,7 +351,7 @@ private fun <T> T.NavigationButtons(
         activeChild is HomeComponent.Child.Speakers,
         {
             Icon(
-                imageVector = if (activeChild is HomeComponent.Child.Speakers) Icons.Filled.Person else Icons.Outlined.Person,
+                imageVector = if (activeChild is HomeComponent.Child.Speakers) Icons.Filled.People else Icons.Outlined.People,
                 contentDescription = stringResource(Res.string.speakers),
             )
         },

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocationOn
@@ -31,11 +34,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetValue
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
@@ -45,19 +47,22 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.ChildStack
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import confetti.shared.generated.resources.Res
+import confetti.shared.generated.resources.agent_assistant
 import confetti.shared.generated.resources.bookmarks
 import confetti.shared.generated.resources.schedule
 import confetti.shared.generated.resources.speakers
 import confetti.shared.generated.resources.venue
+import org.jetbrains.compose.resources.stringResource
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
@@ -90,9 +95,10 @@ fun App(component: DefaultAppComponent) {
     }
 }
 
-@OptIn(ExperimentalDecomposeApi::class)
+@OptIn(ExperimentalDecomposeApi::class, ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ConferenceView(component: ConferenceComponent) {
+    val windowSizeClass = calculateWindowSizeClass()
     ConferenceMaterialThemeFromSettings(component.conferenceThemeColor) {
         ChildStack(
             stack = component.stack,
@@ -105,6 +111,16 @@ fun ConferenceView(component: ConferenceComponent) {
                 is ConferenceComponent.Child.Home -> HomeView(child.component)
                 is ConferenceComponent.Child.SessionDetails -> SessionDetailsUI(child.component)
                 is ConferenceComponent.Child.SpeakerDetails -> SpeakerDetailsUI(child.component)
+                is ConferenceComponent.Child.Venue ->
+                    VenueUI(
+                        component = child.component,
+                        windowSizeClass = windowSizeClass,
+                        topBarNavigationIcon = {
+                            IconButton(onClick = component::onBackClicked) {
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                            }
+                        }
+                    )
                 is ConferenceComponent.Child.Settings -> {
                     child.component?.let { childComponent ->
                         SettingsUI(childComponent, component::onBackClicked)
@@ -129,9 +145,6 @@ fun HomeView(component: HomeComponent) {
     val shouldShowNavRail = windowSizeClass.isExpanded
     val snackbarHostState = remember { SnackbarHostState() }
     val hazeState = remember { HazeState() }
-    val agentEnabled by produceState(initialValue = false) {
-        value = component.isAgentEnabled()
-    }
 
     CompositionLocalProvider(LocalHazeState provides hazeState) {
         Row {
@@ -139,19 +152,19 @@ fun HomeView(component: HomeComponent) {
                 NavigationRail(component)
             }
 
-            val topBarNavigationIcon = @Composable {
-                AccountIcon(
-                    onSwitchConference = component::onSwitchConferenceClicked,
-                    onOpenAgent = component::onAgentClicked,
-                    onSignIn = component::onSignInClicked,
-                    onSignOut = component::onSignOutClicked,
-                    onShowSettings = component::onShowSettingsClicked,
-                    info = component.user?.let { user ->
-                        AccountInfo(photoUrl = user.photoUrl)
-                    },
-                    installOnWear = {}, // FIXME: handle
-                    showAgentOption = agentEnabled
-                )
+            val agentEnabled by produceState(initialValue = false) {
+                value = component.isAgentEnabled()
+            }
+
+            val topBarNavigationIcon: @Composable () -> Unit = {
+                if (agentEnabled) {
+                    IconButton(onClick = component::onAgentClicked) {
+                        Icon(
+                            imageVector = Icons.Filled.Assistant,
+                            contentDescription = stringResource(Res.string.agent_assistant),
+                        )
+                    }
+                }
             }
 
             val topBarActions: @Composable RowScope.() -> Unit = {
@@ -214,8 +227,8 @@ fun HomeView(component: HomeComponent) {
                                         topBarActions = topBarActions,
                                     )
 
-                                is HomeComponent.Child.Venue ->
-                                    VenueUI(
+                                is HomeComponent.Child.Account ->
+                                    dev.johnoreilly.confetti.ui.account.AccountUI(
                                         component = child.component,
                                         windowSizeClass = windowSizeClass,
                                         topBarNavigationIcon = topBarNavigationIcon,
@@ -245,7 +258,7 @@ private fun NavigationRail(component: HomeComponent) {
         containerColor = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     ) {
-        NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, badgeCount, onClick ->
+        NavigationButtons(component = component) { isSelected, icon, text, badgeCount, onClick ->
             NavigationRailItem(
                 selected = isSelected,
                 onClick = onClick,
@@ -260,12 +273,10 @@ private fun NavigationRail(component: HomeComponent) {
                             }
                         }
                     ) {
-                        Icon(
-                            imageVector = if (isSelected) selectedIcon else unselectedIcon,
-                            contentDescription = text
-                        )
+                        icon()
                     }
                 },
+                label = { Text(text) },
             )
         }
     }
@@ -282,7 +293,7 @@ private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
             tonalElevation = 0.dp,
             containerColor = Color.Transparent,
         ) {
-            NavigationButtons(component = component) { isSelected, selectedIcon, unselectedIcon, text, badgeCount, onClick ->
+            NavigationButtons(component = component) { isSelected, icon, text, badgeCount, onClick ->
                 NavigationBarItem(
                     selected = isSelected,
                     onClick = onClick,
@@ -297,10 +308,7 @@ private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
                                 }
                             }
                         ) {
-                            Icon(
-                                imageVector = if (isSelected) selectedIcon else unselectedIcon,
-                                contentDescription = text,
-                            )
+                            icon()
                         }
                     },
                     label = { Text(text) },
@@ -316,8 +324,7 @@ private fun <T> T.NavigationButtons(
     component: HomeComponent,
     content: @Composable T.(
         isSelected: Boolean,
-        selectedIcon: ImageVector,
-        unselectedIcon: ImageVector,
+        icon: @Composable () -> Unit,
         text: String,
         badgeCount: Int,
         onClick: () -> Unit,
@@ -329,8 +336,12 @@ private fun <T> T.NavigationButtons(
 
     content(
         activeChild is HomeComponent.Child.Sessions,
-        Icons.Filled.Home,
-        Icons.Outlined.Home,
+        {
+            Icon(
+                imageVector = if (activeChild is HomeComponent.Child.Sessions) Icons.Filled.Home else Icons.Outlined.Home,
+                contentDescription = stringResource(Res.string.schedule),
+            )
+        },
         stringResource(Res.string.schedule),
         0,
         component::onSessionsTabClicked,
@@ -338,8 +349,12 @@ private fun <T> T.NavigationButtons(
 
     content(
         activeChild is HomeComponent.Child.Speakers,
-        Icons.Filled.Person,
-        Icons.Outlined.Person,
+        {
+            Icon(
+                imageVector = if (activeChild is HomeComponent.Child.Speakers) Icons.Filled.Person else Icons.Outlined.Person,
+                contentDescription = stringResource(Res.string.speakers),
+            )
+        },
         stringResource(Res.string.speakers),
         0,
         component::onSpeakersTabClicked,
@@ -347,20 +362,40 @@ private fun <T> T.NavigationButtons(
 
     content(
         activeChild is HomeComponent.Child.Bookmarks,
-        Icons.Filled.Bookmarks,
-        Icons.Outlined.Bookmarks,
+        {
+            Icon(
+                imageVector = if (activeChild is HomeComponent.Child.Bookmarks) Icons.Filled.Bookmarks else Icons.Outlined.Bookmarks,
+                contentDescription = stringResource(Res.string.bookmarks),
+            )
+        },
         stringResource(Res.string.bookmarks),
         upcomingBookmarksCount,
         component::onBookmarksTabClicked,
     )
 
+    val isAccountSelected = activeChild is HomeComponent.Child.Account
+    val userPhotoUrl = component.user?.photoUrl
     content(
-        activeChild is HomeComponent.Child.Venue,
-        Icons.Filled.LocationOn,
-        Icons.Outlined.LocationOn,
-        stringResource(Res.string.venue),
+        isAccountSelected,
+        {
+            if (userPhotoUrl != null) {
+                AsyncImage(
+                    model = userPhotoUrl,
+                    contentDescription = "Account",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                )
+            } else {
+                Icon(
+                    imageVector = if (isAccountSelected) Icons.Filled.AccountCircle else Icons.Outlined.AccountCircle,
+                    contentDescription = "Account",
+                )
+            }
+        },
+        "Account",
         0,
-        component::onVenueTabClicked,
+        component::onAccountTabClicked,
     )
-
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
@@ -41,6 +41,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -69,6 +72,7 @@ import dev.johnoreilly.confetti.ui.icons.Slack
 import org.jetbrains.compose.resources.stringResource
 
 import dev.johnoreilly.confetti.ui.component.ErrorView
+import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import dev.johnoreilly.confetti.ui.component.LoadingView
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -302,6 +306,8 @@ private fun UserAccountCard(
     onSignInClicked: () -> Unit,
     onSignOutClicked: () -> Unit,
 ) {
+    var showFullScreenPhoto by remember { mutableStateOf(false) }
+
     Card(
         shape = RoundedCornerShape(20.dp),
         colors = CardDefaults.cardColors(
@@ -323,7 +329,8 @@ private fun UserAccountCard(
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
                             .size(46.dp)
-                            .clip(CircleShape),
+                            .clip(CircleShape)
+                            .clickable { showFullScreenPhoto = true },
                     )
                 } else {
                     Surface(
@@ -413,6 +420,14 @@ private fun UserAccountCard(
                 }
             }
         }
+    }
+
+    if (showFullScreenPhoto && state.user?.photoUrl != null) {
+        FullScreenPhotoDialog(
+            photoUrl = state.user.photoUrl,
+            contentDescription = state.user.name,
+            onDismissRequest = { showFullScreenPhoto = false },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
@@ -1,0 +1,512 @@
+package dev.johnoreilly.confetti.ui.account
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.MeetingRoom
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import confetti.shared.generated.resources.Res
+import confetti.shared.generated.resources.report_issue
+import confetti.shared.generated.resources.report_issue_desc
+import confetti.shared.generated.resources.settings_title
+import confetti.shared.generated.resources.sign_in_lowercase
+import confetti.shared.generated.resources.sign_out
+import confetti.shared.generated.resources.switch_conference
+import confetti.shared.generated.resources.venue
+import dev.johnoreilly.confetti.decompose.AccountComponent
+import dev.johnoreilly.confetti.decompose.AccountUiState
+import dev.johnoreilly.confetti.ui.HomeScaffold
+import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
+import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
+import dev.johnoreilly.confetti.ui.icons.Github
+import dev.johnoreilly.confetti.ui.icons.Slack
+import org.jetbrains.compose.resources.stringResource
+
+import dev.johnoreilly.confetti.ui.component.ErrorView
+import dev.johnoreilly.confetti.ui.component.LoadingView
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountUI(
+    component: AccountComponent,
+    windowSizeClass: WindowSizeClass,
+    topBarNavigationIcon: @Composable () -> Unit = {},
+    topBarActions: @Composable RowScope.() -> Unit = {},
+) {
+    val uiState by component.uiState.subscribeAsState()
+
+    HomeScaffold(
+        title = "Account",
+        windowSizeClass = windowSizeClass,
+        topBarNavigationIcon = topBarNavigationIcon,
+        topBarActions = topBarActions,
+    ) {
+        when (val state = uiState) {
+            is AccountUiState.Success -> {
+                AccountView(
+                    state = state,
+                    onVenueClicked = component::onVenueClicked,
+                    onSwitchConferenceClicked = component::onSwitchConferenceClicked,
+                    onSettingsClicked = component::onSettingsClicked,
+                    onSignInClicked = component::onSignInClicked,
+                    onSignOutClicked = component::onSignOutClicked,
+                )
+            }
+            is AccountUiState.Loading -> LoadingView()
+            is AccountUiState.Error -> ErrorView {}
+        }
+    }
+}
+
+@Composable
+fun AccountView(
+    state: AccountUiState.Success,
+    onVenueClicked: () -> Unit,
+    onSwitchConferenceClicked: () -> Unit,
+    onSettingsClicked: () -> Unit,
+    onSignInClicked: () -> Unit,
+    onSignOutClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uriHandler = LocalUriHandler.current
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(
+                start = 16.dp,
+                top = 8.dp,
+                end = 16.dp,
+                bottom = 16.dp + LocalBottomNavigationPadding.current
+            ),
+    ) {
+        // 1. Permanent Conference Header
+        ConferenceHeader(state = state)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 2. User Profile Card
+        UserAccountCard(
+            state = state,
+            onSignInClicked = onSignInClicked,
+            onSignOutClicked = onSignOutClicked,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // 3. Grouped Conference Actions Card
+        Card(
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column {
+                if (state.hasVenue) {
+                    AccountGroupItem(
+                        title = stringResource(Res.string.venue),
+                        subtitle = "Location and venue details",
+                        icon = Icons.Outlined.LocationOn,
+                        onClick = onVenueClicked,
+                    )
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    )
+                }
+
+                AccountGroupItem(
+                    title = stringResource(Res.string.switch_conference),
+                    subtitle = "Change selected conference",
+                    icon = Icons.Outlined.MeetingRoom,
+                    onClick = onSwitchConferenceClicked,
+                )
+
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                )
+
+                AccountGroupItem(
+                    title = stringResource(Res.string.settings_title),
+                    subtitle = "Theme and notifications",
+                    icon = Icons.Outlined.Settings,
+                    onClick = onSettingsClicked,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 4. Support & Feedback Group Card
+        Card(
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            AccountGroupItem(
+                title = stringResource(Res.string.report_issue),
+                subtitle = stringResource(Res.string.report_issue_desc),
+                icon = Icons.Outlined.BugReport,
+                trailingIcon = Icons.AutoMirrored.Filled.OpenInNew,
+                onClick = { uriHandler.openUri("https://github.com/joreilly/Confetti/issues/new") },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // 5. Community Section (Chips)
+        Text(
+            text = "Community",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(start = 4.dp, bottom = 10.dp)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            AssistChip(
+                onClick = { uriHandler.openUri("https://kotlinlang.slack.com/archives/C051P2HUVKP") },
+                label = { Text("Kotlin Slack") },
+                leadingIcon = {
+                    Icon(
+                        imageVector = ConfettiIcons.Slack,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                },
+                shape = RoundedCornerShape(12.dp),
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                ),
+            )
+
+            AssistChip(
+                onClick = { uriHandler.openUri("https://github.com/joreilly/Confetti") },
+                label = { Text("GitHub") },
+                leadingIcon = {
+                    Icon(
+                        imageVector = ConfettiIcons.Github,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                },
+                shape = RoundedCornerShape(12.dp),
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConferenceHeader(state: AccountUiState.Success) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            modifier = Modifier.size(56.dp),
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.primaryContainer,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = state.conferenceName.take(1).ifEmpty { "C" },
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = state.conferenceName.ifEmpty { "Confetti" },
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = state.conferenceDays.ifEmpty { "Confetti Conference App" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun UserAccountCard(
+    state: AccountUiState.Success,
+    onSignInClicked: () -> Unit,
+    onSignOutClicked: () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (state.user != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (state.user.photoUrl != null) {
+                    AsyncImage(
+                        model = state.user.photoUrl,
+                        contentDescription = state.user.name,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(46.dp)
+                            .clip(CircleShape),
+                    )
+                } else {
+                    Surface(
+                        modifier = Modifier.size(46.dp),
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = Icons.Filled.AccountCircle,
+                                contentDescription = null,
+                                modifier = Modifier.size(30.dp),
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(14.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = state.user.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = state.user.email ?: "Signed in",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                OutlinedButton(
+                    onClick = onSignOutClicked,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.sign_out),
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+            }
+        } else {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.AccountCircle,
+                    contentDescription = null,
+                    modifier = Modifier.size(44.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.width(14.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(Res.string.sign_in_lowercase).replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "Sync bookmarks across devices",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Button(
+                    onClick = onSignInClicked,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.sign_in_lowercase).replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountGroupItem(
+    title: String,
+    subtitle: String? = null,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailingIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowForward,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp),
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (subtitle != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Icon(
+            imageVector = trailingIcon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@org.jetbrains.compose.ui.tooling.preview.Preview
+@Composable
+private fun AccountViewSignedOutPreview() {
+    AccountView(
+        state = AccountUiState.Success(
+            conferenceName = "KotlinConf 2026",
+            conferenceDays = "May 20 - 22, 2026",
+            user = null,
+            hasVenue = true,
+        ),
+        onVenueClicked = {},
+        onSwitchConferenceClicked = {},
+        onSettingsClicked = {},
+        onSignInClicked = {},
+        onSignOutClicked = {},
+    )
+}
+
+@org.jetbrains.compose.ui.tooling.preview.Preview
+@Composable
+private fun AccountViewSignedInPreview() {
+    AccountView(
+        state = AccountUiState.Success(
+            conferenceName = "KotlinConf 2026",
+            conferenceDays = "May 20 - 22, 2026",
+            user = object : dev.johnoreilly.confetti.auth.User {
+                override val name = "John Doe"
+                override val email = "john.doe@example.com"
+                override val photoUrl = null
+                override val uid = "123"
+                override suspend fun token(forceRefresh: Boolean) = null
+            },
+            hasVenue = true,
+        ),
+        onVenueClicked = {},
+        onSwitchConferenceClicked = {},
+        onSettingsClicked = {},
+        onSignInClicked = {},
+        onSignOutClicked = {},
+    )
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/account/AccountUI.kt
@@ -225,7 +225,7 @@ fun AccountView(
         ) {
             AssistChip(
                 onClick = { uriHandler.openUri("https://kotlinlang.slack.com/archives/C051P2HUVKP") },
-                label = { Text("Kotlin Slack") },
+                label = { Text("Slack") },
                 leadingIcon = {
                     Icon(
                         imageVector = ConfettiIcons.Slack,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/icons/Slack.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/icons/Slack.kt
@@ -1,0 +1,92 @@
+package dev.johnoreilly.confetti.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val ConfettiIcons.Slack: ImageVector
+    get() {
+        if (_Slack != null) {
+            return _Slack!!
+        }
+        _Slack = ImageVector.Builder(
+            name = "Slack",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF000000)),
+                strokeLineJoin = StrokeJoin.Round,
+            ) {
+                moveTo(5.042f, 15.165f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.52f, 2.523f)
+                arcTo(2.52f, 2.52f, 0.0f, false, true, 0.0f, 15.165f)
+                arcToRelative(2.527f, 2.527f, 0.0f, false, true, 2.522f, -2.52f)
+                horizontalLineToRelative(2.52f)
+                verticalLineToRelative(2.52f)
+                close()
+                moveTo(6.313f, 15.165f)
+                arcToRelative(2.527f, 2.527f, 0.0f, false, true, 2.521f, -2.52f)
+                arcToRelative(2.521f, 2.521f, 0.0f, false, true, 2.521f, 2.52f)
+                verticalLineToRelative(6.313f)
+                arcTo(2.528f, 2.528f, 0.0f, false, true, 8.834f, 24.0f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.521f, -2.522f)
+                verticalLineToRelative(-6.313f)
+                close()
+                moveTo(8.834f, 5.042f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.521f, -2.52f)
+                arcTo(2.52f, 2.52f, 0.0f, false, true, 8.834f, 0.0f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.521f, 2.522f)
+                verticalLineToRelative(2.52f)
+                horizontalLineTo(8.834f)
+                close()
+                moveTo(8.834f, 6.313f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.521f, 2.521f)
+                arcToRelative(2.52f, 2.52f, 0.0f, false, true, -2.521f, 2.52f)
+                horizontalLineTo(2.522f)
+                arcTo(2.528f, 2.528f, 0.0f, false, true, 0.0f, 8.834f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.522f, -2.521f)
+                horizontalLineToRelative(6.312f)
+                close()
+                moveTo(18.956f, 8.834f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.522f, -2.521f)
+                arcTo(2.52f, 2.52f, 0.0f, false, true, 24.0f, 8.834f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.522f, 2.521f)
+                horizontalLineToRelative(-2.522f)
+                verticalLineTo(8.834f)
+                close()
+                moveTo(17.688f, 8.834f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.523f, 2.521f)
+                arcToRelative(2.527f, 2.527f, 0.0f, false, true, -2.52f, -2.521f)
+                verticalLineTo(2.522f)
+                arcTo(2.527f, 2.527f, 0.0f, false, true, 15.165f, 0.0f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.523f, 2.522f)
+                verticalLineToRelative(6.312f)
+                close()
+                moveTo(15.165f, 18.956f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, 2.523f, 2.522f)
+                arcTo(2.52f, 2.52f, 0.0f, false, true, 15.165f, 24.0f)
+                arcToRelative(2.527f, 2.527f, 0.0f, false, true, -2.52f, -2.522f)
+                verticalLineToRelative(-2.522f)
+                horizontalLineToRelative(2.52f)
+                close()
+                moveTo(15.165f, 17.688f)
+                arcToRelative(2.527f, 2.527f, 0.0f, false, true, -2.52f, -2.523f)
+                arcToRelative(2.52f, 2.52f, 0.0f, false, true, 2.52f, -2.52f)
+                horizontalLineToRelative(6.313f)
+                arcTo(2.527f, 2.527f, 0.0f, false, true, 24.0f, 15.165f)
+                arcToRelative(2.528f, 2.528f, 0.0f, false, true, -2.522f, 2.523f)
+                horizontalLineToRelative(-6.313f)
+                close()
+            }
+        }.build()
+
+        return _Slack!!
+    }
+
+private var _Slack: ImageVector? = null

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -195,22 +195,6 @@ fun SettingsUI(
                     )
                 }
 
-                item {
-                    ActionSettingsRow(
-                        title = stringResource(Res.string.report_issue),
-                        subtitle = stringResource(Res.string.report_issue_desc),
-                        onClick = { uriHandler.openUri("https://github.com/joreilly/Confetti/issues/new") }
-                    )
-                }
-
-                item {
-                    ActionSettingsRow(
-                        title = stringResource(Res.string.slack_title),
-                        subtitle = stringResource(Res.string.slack_desc),
-                        onClick = { uriHandler.openUri("https://kotlinlang.slack.com/archives/C051P2HUVKP") }
-                    )
-                }
-
                 if (developerSettings != null) {
                     item {
                         Text(


### PR DESCRIPTION
- Add Account tab to bottom bar; remove Venue tab.
- Centralize conference info, profile sync, Venue navigation, conference switcher, Settings, and Slack/GitHub links in Account screen.
- Move AI Assistant button to top bar across all home screens for better visibility.
- Change Schedule icon to CalendarToday and Speakers icon to People.
- Show user avatar in bottom bar when signed in.

| Signed In | Signed Out |
| :---: | :---: |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0a22e64b-61b2-40ae-bb36-56f400de97c5" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8b475128-551b-4e8f-81e6-c8e1109b9ed3" /> |