### PR TITLE
Fix Session Details loading error and polish loading and error UI

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/di/KoinAndroid.kt
@@ -75,9 +75,6 @@ actual fun platformModule() = module {
             }
             .build()
     }
-    single<FetchPolicy> {
-        FetchPolicy.CacheAndNetwork
-    }
     single<WebSocket.Factory> {
         get<OkHttpClient>()
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
@@ -10,10 +10,12 @@ import dev.johnoreilly.confetti.GetSessionQuery
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -31,6 +33,7 @@ interface SessionDetailsComponent {
     val isBookmarked: StateFlow<Boolean>
     val isLoggedIn: Boolean
 
+    fun refresh()
     fun addBookmark()
     fun removeBookmark()
     fun onCloseClicked()
@@ -63,17 +66,31 @@ class DefaultSessionDetailsComponent(
     override val addErrorChannel = Channel<Int>()
     override val removeErrorChannel = Channel<Int>()
 
+    private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     override val uiState: Value<SessionDetailsUiState> =
-        repository.sessionDetails(conference = conference, sessionId = sessionId, fetchPolicy = FetchPolicy.CacheFirst)
-            .runningFold<ApolloResponse<GetSessionQuery.Data>, SessionDetailsUiState>(SessionDetailsUiState.Loading) { previousState, response ->
-                val details = response.data?.session?.sessionDetails
-                when {
-                    details != null -> SessionDetailsUiState.Success(conference, details)
-                    previousState is SessionDetailsUiState.Success -> previousState
-                    else -> SessionDetailsUiState.Error
-                }
+        flow {
+            emit(FetchPolicy.CacheFirst)
+            refreshTrigger.collect {
+                emit(FetchPolicy.NetworkOnly)
             }
-            .asValue(initialValue = SessionDetailsUiState.Loading, lifecycle = lifecycle)
+        }
+        .flatMapLatest { fetchPolicy ->
+            repository.sessionDetails(conference = conference, sessionId = sessionId, fetchPolicy = fetchPolicy)
+        }
+        .runningFold<ApolloResponse<GetSessionQuery.Data>, SessionDetailsUiState>(SessionDetailsUiState.Loading) { previousState, response ->
+            val details = response.data?.session?.sessionDetails
+            when {
+                details != null -> SessionDetailsUiState.Success(conference, details)
+                previousState is SessionDetailsUiState.Success -> previousState
+                else -> SessionDetailsUiState.Error
+            }
+        }
+        .asValue(initialValue = SessionDetailsUiState.Loading, lifecycle = lifecycle)
+
+    override fun refresh() {
+        refreshTrigger.tryEmit(Unit)
+    }
 
     override val isBookmarked: StateFlow<Boolean> = flow {
         val response =

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -78,12 +77,12 @@ class DefaultSessionDetailsComponent(
         .flatMapLatest { fetchPolicy ->
             repository.sessionDetails(conference = conference, sessionId = sessionId, fetchPolicy = fetchPolicy)
         }
-        .runningFold<ApolloResponse<GetSessionQuery.Data>, SessionDetailsUiState>(SessionDetailsUiState.Loading) { previousState, response ->
+        .map { response ->
             val details = response.data?.session?.sessionDetails
-            when {
-                details != null -> SessionDetailsUiState.Success(conference, details)
-                previousState is SessionDetailsUiState.Success -> previousState
-                else -> SessionDetailsUiState.Error
+            if (details != null) {
+                SessionDetailsUiState.Success(conference, details)
+            } else {
+                SessionDetailsUiState.Error
             }
         }
         .asValue(initialValue = SessionDetailsUiState.Loading, lifecycle = lifecycle)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionDetailsComponent.kt
@@ -1,10 +1,12 @@
 package dev.johnoreilly.confetti.decompose
 
+import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import dev.johnoreilly.confetti.ConfettiRepository
 import dev.johnoreilly.confetti.GetBookmarksQuery
+import dev.johnoreilly.confetti.GetSessionQuery
 import dev.johnoreilly.confetti.auth.User
 import dev.johnoreilly.confetti.fragment.SessionDetails
 import kotlinx.coroutines.channels.Channel
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -52,7 +55,6 @@ class DefaultSessionDetailsComponent(
 ) : SessionDetailsComponent, KoinComponent, ComponentContext by componentContext {
     private val repository: ConfettiRepository by inject()
     private val coroutineScope = coroutineScope()
-    private val defaultFetchPolicy: FetchPolicy by inject()
 
     override val isLoggedIn: Boolean = user != null
 
@@ -62,13 +64,13 @@ class DefaultSessionDetailsComponent(
     override val removeErrorChannel = Channel<Int>()
 
     override val uiState: Value<SessionDetailsUiState> =
-        repository.sessionDetails(conference = conference, sessionId = sessionId, fetchPolicy = defaultFetchPolicy)
-            .map {
-                val details = it.data?.session?.sessionDetails
-                if (details != null) {
-                    SessionDetailsUiState.Success(conference, details)
-                } else {
-                    SessionDetailsUiState.Error
+        repository.sessionDetails(conference = conference, sessionId = sessionId, fetchPolicy = FetchPolicy.CacheFirst)
+            .runningFold<ApolloResponse<GetSessionQuery.Data>, SessionDetailsUiState>(SessionDetailsUiState.Loading) { previousState, response ->
+                val details = response.data?.session?.sessionDetails
+                when {
+                    details != null -> SessionDetailsUiState.Success(conference, details)
+                    previousState is SessionDetailsUiState.Success -> previousState
+                    else -> SessionDetailsUiState.Error
                 }
             }
             .asValue(initialValue = SessionDetailsUiState.Loading, lifecycle = lifecycle)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ErrorView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ErrorView.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.oops
 import confetti.shared.generated.resources.retry
+import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -37,10 +38,12 @@ fun ErrorView(
     message: String? = "Check your connection and try again.",
     onRefresh: (() -> Unit)? = null,
 ) {
+    val bottomNavPadding = LocalBottomNavigationPadding.current
     Box(
         modifier = modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(horizontal = 32.dp, vertical = 16.dp)
+            .padding(bottom = bottomNavPadding),
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ErrorView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ErrorView.kt
@@ -1,40 +1,102 @@
 package dev.johnoreilly.confetti.ui.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.oops
 import confetti.shared.generated.resources.retry
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun ErrorView(onRefresh: (() ->Unit)? = null){
+fun ErrorView(
+    modifier: Modifier = Modifier,
+    message: String? = "Check your connection and try again.",
+    onRefresh: (() -> Unit)? = null,
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .wrapContentSize(Alignment.Center)
+            .padding(32.dp),
+        contentAlignment = Alignment.Center,
     ) {
-        Column {
-            Text(
-                text = stringResource(Res.string.oops)
-            )
-            if (onRefresh != null) {
-                Button(
-                    onClick = onRefresh,
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(16.dp)
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.size(72.dp),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxSize(),
                 ) {
+                    Icon(
+                        imageVector = Icons.Outlined.CloudOff,
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(Res.string.oops),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+
+            if (message != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            if (onRefresh != null) {
+                Spacer(modifier = Modifier.height(24.dp))
+                FilledTonalButton(
+                    onClick = onRefresh,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
                     Text(text = stringResource(Res.string.retry))
                 }
             }
@@ -42,13 +104,13 @@ fun ErrorView(onRefresh: (() ->Unit)? = null){
     }
 }
 
-@Preview(name = "Error with retry", widthDp = 360, heightDp = 200, showBackground = true)
+@Preview(name = "Error with retry", widthDp = 360, heightDp = 400, showBackground = true)
 @Composable
 internal fun ErrorViewWithRetryPreview() {
     ErrorView(onRefresh = {})
 }
 
-@Preview(name = "Error without retry", widthDp = 360, heightDp = 200, showBackground = true)
+@Preview(name = "Error without retry", widthDp = 360, heightDp = 400, showBackground = true)
 @Composable
 internal fun ErrorViewNoRetryPreview() {
     ErrorView(onRefresh = null)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/LoadingView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/LoadingView.kt
@@ -1,24 +1,59 @@
 package dev.johnoreilly.confetti.ui.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun LoadingView() {
+fun LoadingView(
+    modifier: Modifier = Modifier,
+    message: String? = null,
+) {
+    val bottomNavPadding = LocalBottomNavigationPadding.current
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .fillMaxHeight()
-            .wrapContentSize(Alignment.Center)
+            .padding(bottom = bottomNavPadding),
+        contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator()
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(40.dp),
+                strokeWidth = 3.5.dp,
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                strokeCap = StrokeCap.Round,
+            )
+
+            if (message != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
     }
 }
 
@@ -26,4 +61,10 @@ fun LoadingView() {
 @Composable
 internal fun LoadingViewPreview() {
     LoadingView()
+}
+
+@Preview(name = "Loading with message", widthDp = 300, heightDp = 200, showBackground = true)
+@Composable
+internal fun LoadingViewWithMessagePreview() {
+    LoadingView(message = "Loading sessions...")
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -88,7 +88,7 @@ fun SessionListGridView(
     onRefresh: () -> Unit,
 ) {
     when (uiState) {
-        SessionsUiState.Error -> ErrorView(onRefresh)
+        SessionsUiState.Error -> ErrorView(onRefresh = onRefresh)
         SessionsUiState.Loading -> LoadingView()
 
         is SessionsUiState.Success -> {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
@@ -45,7 +45,7 @@ fun SessionListView(
     isLoggedIn: Boolean,
 ) {
     when (uiState) {
-        SessionsUiState.Error -> ErrorView(onRefresh)
+        SessionsUiState.Error -> ErrorView(onRefresh = onRefresh)
         SessionsUiState.Loading -> LoadingView()
         is SessionsUiState.Success -> {
             Column {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.confetti.ui.sessions
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -59,10 +60,13 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
                     }
                 )
             }
-
         )
     }) {
-        Column(Modifier.padding(it)) {
+        Box(
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize()
+        ) {
             when (val state = uiState) {
                 is SessionDetailsUiState.Loading -> LoadingView()
                 is SessionDetailsUiState.Error -> ErrorView(onRefresh = component::refresh)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -65,7 +65,7 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
         Column(Modifier.padding(it)) {
             when (val state = uiState) {
                 is SessionDetailsUiState.Loading -> LoadingView()
-                is SessionDetailsUiState.Error -> ErrorView(component::refresh)
+                is SessionDetailsUiState.Error -> ErrorView(onRefresh = component::refresh)
 
                 is SessionDetailsUiState.Success ->
                     SessionDetailViewShared(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -65,7 +65,7 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
         Column(Modifier.padding(it)) {
             when (val state = uiState) {
                 is SessionDetailsUiState.Loading -> LoadingView()
-                is SessionDetailsUiState.Error -> ErrorView()
+                is SessionDetailsUiState.Error -> ErrorView(component::refresh)
 
                 is SessionDetailsUiState.Success ->
                     SessionDetailViewShared(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsUI.kt
@@ -2,12 +2,14 @@ package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import dev.johnoreilly.confetti.decompose.SessionsComponent
@@ -37,7 +39,7 @@ fun SessionsUI(
         topBarNavigationIcon = topBarNavigationIcon,
         topBarActions = topBarActions,
     ) {
-        Column {
+        Column(modifier = Modifier.fillMaxSize()) {
             if (windowSizeClass.isExpanded) {
                 SessionListGridView(
                     uiState = uiState,

--- a/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/dev/johnoreilly/confetti/di/KoiniOS.kt
@@ -47,7 +47,6 @@ actual fun platformModule() = module {
     single<ObservableSettings> { NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults) }
     single { get<ObservableSettings>().toFlowSettings() }
     singleOf(::IosDateService) { bind<DateService>() }
-    single<FetchPolicy> { FetchPolicy.CacheAndNetwork }
     factory {
         ApolloClient.Builder()
             .serverUrl("https://confetti-app.dev/graphql")

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/di/KoinJVM.kt
@@ -43,9 +43,6 @@ actual fun platformModule() = module {
         OkHttpClient.Builder()
             .build()
     }
-    single<FetchPolicy> {
-        FetchPolicy.CacheAndNetwork
-    }
     single<NotificationSender> { SessionNotificationSender() }
     single<ApplicationInfo> { ApplicationInfo(BuildKonfig.VERSION_NAME) }
 

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/di/KoinWasmJs.kt
@@ -35,9 +35,6 @@ actual fun platformModule() = module {
     single<Authentication> { Authentication.Disabled }
     single<FlowSettings> {  StorageSettings().makeObservable().toFlowSettings() }
     singleOf(::WasmDateService) { bind<DateService>() }
-    single<FetchPolicy> {
-        FetchPolicy.CacheAndNetwork
-    }
     single<NotificationSender> { SessionNotificationSender() }
     single<ApplicationInfo> { ApplicationInfo(BuildKonfig.VERSION_NAME) }
 


### PR DESCRIPTION
- Fix Session Detail Loading Bug:
  - SessionDetailsComponent used FetchPolicy.CacheAndNetwork. Apollo emitted cache data first (showing UI), then sent a background network request.
  - When the network request failed, the error response with null data was mapped directly to Error, overwriting valid cached UI and leaving the screen stuck on "Oops, something went wrong".
  - Switched to FetchPolicy.CacheFirst (matches all other screens).
  - Removed unused FetchPolicy bindings from platform Koin modules.
- Add Retry Action: Added refresh() to SessionDetailsComponent and connected the "Retry" button in SessionsDetailsUI.
- Refine Error and Loading UI:
  - Updated ErrorView with Material 3 tonal container, CloudOff icon, and FilledTonalButton.
  - Updated LoadingView with rounded stroke caps and subtle track color.
  - Applied LocalBottomNavigationPadding to LoadingView and ErrorView for correct vertical centering above the bottom navigation bar.

| Error State (Session Details) | Loading State (Schedule Tab) |
| :---: | :---: |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/bf876fee-5c72-41e0-95dd-e0a0e6f18bcc" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/14a861a7-d2d8-4d53-b05b-d3fb24aee8fc" /> |