### PR TITLE
Modernize Schedule, Search, and Bookmarks UI with Material 3 components

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
@@ -29,6 +29,7 @@ interface ConferenceComponent : BackHandlerOwner {
         class Settings(val component: SettingsComponent?) : Child()
         class Agent(val component: ConferenceAgentComponent) : Child()
         class Venue(val component: VenueComponent) : Child()
+        class Search(val component: SearchComponent) : Child()
     }
 }
 
@@ -78,6 +79,7 @@ class DefaultConferenceComponent(
                         onShowSettings = { navigation.push(Config.Settings) },
                         onShowAgent = { navigation.push(Config.Agent) },
                         onVenueSelected = { navigation.push(Config.Venue) },
+                        onShowSearch = { navigation.push(Config.Search) },
                     )
                 )
 
@@ -125,6 +127,18 @@ class DefaultConferenceComponent(
                         conference = conference,
                     )
                 )
+
+            is Config.Search ->
+                Child.Search(
+                    DefaultSearchComponent(
+                        componentContext = componentContext,
+                        conference = conference,
+                        user = user,
+                        onSessionSelected = { navigation.push(Config.SessionDetails(sessionId = it)) },
+                        onSpeakerSelected = { navigation.push(Config.SpeakerDetails(speakerId = it)) },
+                        onSignIn = onSignIn,
+                    )
+                )
         }
 
     override fun onBackClicked() {
@@ -154,5 +168,8 @@ class DefaultConferenceComponent(
 
         @Serializable
         data object Venue : Config()
+
+        @Serializable
+        data object Search : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/HomeComponent.kt
@@ -50,7 +50,6 @@ interface HomeComponent {
         class Speakers(val component: SpeakersComponent) : Child()
         class Bookmarks(val component: BookmarksComponent) : Child()
         class Account(val component: AccountComponent) : Child()
-        class Search(val component: SearchComponent) : Child()
     }
 }
 
@@ -66,6 +65,7 @@ class DefaultHomeComponent(
     private val onShowSettings: () -> Unit,
     private val onShowAgent: () -> Unit,
     private val onVenueSelected: () -> Unit,
+    private val onShowSearch: () -> Unit,
 ) : HomeComponent, KoinComponent, ComponentContext by componentContext {
 
     private val dateService: DateService by inject()
@@ -161,18 +161,6 @@ class DefaultHomeComponent(
                         onSignOut = onSignOut,
                     )
                 )
-
-            Config.Search ->
-                Child.Search(
-                    DefaultSearchComponent(
-                        componentContext = componentContext,
-                        conference = conference,
-                        user = user,
-                        onSessionSelected = onSessionSelected,
-                        onSpeakerSelected = onSpeakerSelected,
-                        onSignIn = onSignIn,
-                    )
-                )
         }
 
     override suspend fun isAgentEnabled(): Boolean {
@@ -198,7 +186,7 @@ class DefaultHomeComponent(
     }
 
     override fun onSearchClicked() {
-        navigation.bringToFront(Config.Search)
+        onShowSearch()
     }
 
     override fun onSwitchConferenceClicked() {
@@ -238,8 +226,5 @@ class DefaultHomeComponent(
 
         @Serializable
         data object Account : Config()
-
-        @Serializable
-        data object Search : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -132,6 +132,13 @@ fun ConferenceView(component: ConferenceComponent) {
                         onCloseClick = component::onBackClicked
                     )
                 }
+                is ConferenceComponent.Child.Search -> {
+                    SearchUI(
+                        component = child.component,
+                        windowSizeClass = calculateWindowSizeClass(),
+                        onBackClick = component::onBackClicked,
+                    )
+                }
             }
         }
     }
@@ -233,13 +240,6 @@ fun HomeView(component: HomeComponent) {
                                         windowSizeClass = windowSizeClass,
                                         topBarNavigationIcon = topBarNavigationIcon,
                                         topBarActions = topBarActions,
-                                    )
-
-                                is HomeComponent.Child.Search ->
-                                    SearchUI(
-                                        component = child.component,
-                                        windowSizeClass = windowSizeClass,
-                                        onBackClick = component::onBackClicked
                                     )
                             }
                         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -37,6 +37,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -82,7 +84,10 @@ fun ConferenceListView(component: ConferencesComponent) {
         }
     }
 
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             if (searchMode) {
                 ConfettiSearch(
@@ -108,7 +113,8 @@ fun ConferenceListView(component: ConferencesComponent) {
                         IconButton(onClick = { searchMode = true }) {
                             Icon(Icons.Outlined.Search, contentDescription = "Search")
                         }
-                    }
+                    },
+                    scrollBehavior = scrollBehavior,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/Bookmark.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/Bookmark.kt
@@ -1,15 +1,13 @@
 package dev.johnoreilly.confetti.ui.bookmarks
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Bookmark
-import androidx.compose.material.icons.outlined.BookmarkAdd
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun Bookmark(
@@ -17,22 +15,22 @@ fun Bookmark(
     modifier: Modifier = Modifier,
     onBookmarkChange: (Boolean) -> Unit,
 ) {
-
-    val iconModifier = modifier.padding(8.dp)
-
-    IconButton(onClick = { onBookmarkChange(!isBookmarked) }) {
+    IconToggleButton(
+        checked = isBookmarked,
+        onCheckedChange = onBookmarkChange,
+        modifier = modifier,
+    ) {
         if (isBookmarked) {
             Icon(
-                imageVector = Icons.Outlined.Bookmark,
+                imageVector = Icons.Filled.Bookmark,
                 contentDescription = "remove bookmark",
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = iconModifier
             )
         } else {
             Icon(
-                imageVector = Icons.Outlined.BookmarkAdd,
+                imageVector = Icons.Outlined.BookmarkBorder,
                 contentDescription = "add bookmark",
-                modifier = iconModifier
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/BookmarksView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/bookmarks/BookmarksView.kt
@@ -13,21 +13,28 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.bookmarks_past
 import confetti.shared.generated.resources.bookmarks_upcoming
 import confetti.shared.generated.resources.no_bookmarks
 import dev.johnoreilly.confetti.decompose.DateSessionsMap
+import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.isService
 import dev.johnoreilly.confetti.preview.MobilePreviews
 import dev.johnoreilly.confetti.preview.bookmarkedSessionsByDate
 import dev.johnoreilly.confetti.preview.sessionDetails
 import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 import dev.johnoreilly.confetti.ui.component.ConfettiHeader
-import dev.johnoreilly.confetti.ui.component.ConfettiTab
 import dev.johnoreilly.confetti.ui.component.EmptyView
 import dev.johnoreilly.confetti.ui.component.LoadingView
 import dev.johnoreilly.confetti.ui.sessions.SessionItemView
@@ -101,16 +108,33 @@ private enum class BookmarksTab(val title: @Composable () -> String) {
 
 @Composable
 private fun BookmarksTabRow(pagerState: PagerState) {
-    TabRow(selectedTabIndex = pagerState.currentPage) {
+    PrimaryTabRow(
+        selectedTabIndex = pagerState.currentPage,
+        containerColor = Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        indicator = {
+            TabRowDefaults.PrimaryIndicator(
+                modifier = Modifier.tabIndicatorOffset(pagerState.currentPage, matchContentSize = true),
+            )
+        },
+        divider = {},
+    ) {
         for ((index, tab) in BookmarksTab.entries.withIndex()) {
             val tabScope = rememberCoroutineScope()
+            val selected = pagerState.currentPage == index
 
-            ConfettiTab(
-                selected = pagerState.currentPage == index,
+            Tab(
+                selected = selected,
                 onClick = {
                     tabScope.launch { pagerState.animateScrollToPage(index) }
                 },
-                text = { Text(text = tab.title()) }
+                text = {
+                    Text(
+                        text = tab.title(),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                    )
+                }
             )
         }
     }
@@ -137,7 +161,12 @@ private fun BookmarksHorizontalPager(
             }
 
         if (displayedSessions.isEmpty()) {
-            EmptyView(stringResource(Res.string.no_bookmarks))
+            EmptyView(
+                text = stringResource(Res.string.no_bookmarks),
+                message = if (page == BookmarksTab.Upcoming.ordinal) {
+                    "Tap the bookmark icon on any session to save it here."
+                } else null,
+            )
         } else {
             LazyColumn(
                 contentPadding = PaddingValues(bottom = LocalBottomNavigationPadding.current)
@@ -147,7 +176,7 @@ private fun BookmarksHorizontalPager(
                     stickyHeader {
                         ConfettiHeader(
                             icon = Icons.Filled.AccessTime,
-                            text = dateTime.time.toString() //DateTimeFormatter.ofPattern("MMM d, HH:mm").format(dateTime)
+                            text = dateTime.time.toString()
                         )
                     }
 
@@ -161,7 +190,9 @@ private fun BookmarksHorizontalPager(
                             onNavigateToSignIn = onSignIn,
                             isLoggedIn = isLoggedIn,
                         )
-                        if (index < sessions.lastIndex) {
+                        val isCurrentBreak = session.isBreak() || session.isService()
+                        val isNextBreak = index < sessions.lastIndex && (sessions[index + 1].isBreak() || sessions[index + 1].isService())
+                        if (index < sessions.lastIndex && !isCurrentBreak && !isNextBreak) {
                             HorizontalDivider()
                         }
                     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiHeader.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/ConfettiHeader.kt
@@ -1,10 +1,11 @@
 package dev.johnoreilly.confetti.ui.component
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -23,35 +24,29 @@ fun ConfettiHeader(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp,
+        color = MaterialTheme.colorScheme.surfaceContainer,
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column {
-            HorizontalDivider()
-            Row(
-                modifier = Modifier
-                    .padding(
-                        horizontal = 16.dp,
-                        vertical = 8.dp,
-                    ),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                icon?.let { icon ->
-                    Icon(
-                        modifier = Modifier
-                            .padding(end = 8.dp),
-                        imageVector = icon,
-                        contentDescription = null,
-                    )
-                }
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
                 )
+                Spacer(modifier = Modifier.width(8.dp))
             }
-            HorizontalDivider()
+            Text(
+                text = text,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/EmptyView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/component/EmptyView.kt
@@ -1,33 +1,93 @@
 package dev.johnoreilly.confetti.ui.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
 
 @Composable
-fun EmptyView(text: String) {
+fun EmptyView(
+    text: String,
+    modifier: Modifier = Modifier,
+    message: String? = null,
+    icon: ImageVector? = Icons.Outlined.Bookmarks,
+) {
+    val bottomNavPadding = LocalBottomNavigationPadding.current
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .fillMaxHeight()
-            .wrapContentSize(Alignment.Center)
+            .padding(horizontal = 32.dp, vertical = 16.dp)
+            .padding(bottom = bottomNavPadding),
+        contentAlignment = Alignment.Center,
     ) {
-        Text(
-            fontSize = 24.sp,
-            text = text
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (icon != null) {
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.size(72.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(32.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            Text(
+                text = text,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+
+            if (message != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
     }
 }
 
-@Preview(name = "Empty", widthDp = 360, heightDp = 200, showBackground = true)
+@Preview(name = "Empty", widthDp = 360, heightDp = 300, showBackground = true)
 @Composable
 internal fun EmptyViewPreview() {
-    EmptyView(text = "No bookmarks yet")
+    EmptyView(
+        text = "No bookmarks yet",
+        message = "Tap the bookmark icon on any session to save it here."
+    )
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -139,6 +139,12 @@ fun SearchView(
                         )
                     }
                 }
+            } else {
+                EmptyView(
+                    text = "Search Confetti",
+                    message = "Find sessions, speakers, and topics",
+                    icon = Icons.Default.Search,
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -76,6 +76,10 @@ import org.jetbrains.compose.resources.stringResource
 import androidx.compose.foundation.layout.PaddingValues
 import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 
+import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.isService
+import dev.johnoreilly.confetti.ui.component.EmptyView
+
 @Composable
 fun SearchView(
     search: String,
@@ -110,22 +114,30 @@ fun SearchView(
             if (loading) {
                 LoadingView()
             } else if (search.isNotBlank()) {
-                LazyColumn(
-                    contentPadding = PaddingValues(bottom = LocalBottomNavigationPadding.current)
-                ) {
-                    sessionItems(
-                        sessions = sessions,
-                        navigateToSession = navigateToSession,
-                        bookmarks = bookmarks,
-                        addBookmark = addBookmark,
-                        removeBookmark = removeBookmark,
-                        onSignIn = onSignIn,
-                        isLoggedIn = isLoggedIn,
+                if (sessions.isEmpty() && speakers.isEmpty()) {
+                    EmptyView(
+                        text = "No results found",
+                        message = "No sessions or speakers match \"$search\"",
+                        icon = Icons.Default.Search,
                     )
-                    speakerItems(
-                        speakers = speakers,
-                        navigateToSpeaker = navigateToSpeaker,
-                    )
+                } else {
+                    LazyColumn(
+                        contentPadding = PaddingValues(bottom = LocalBottomNavigationPadding.current)
+                    ) {
+                        sessionItems(
+                            sessions = sessions,
+                            navigateToSession = navigateToSession,
+                            bookmarks = bookmarks,
+                            addBookmark = addBookmark,
+                            removeBookmark = removeBookmark,
+                            onSignIn = onSignIn,
+                            isLoggedIn = isLoggedIn,
+                        )
+                        speakerItems(
+                            speakers = speakers,
+                            navigateToSpeaker = navigateToSpeaker,
+                        )
+                    }
                 }
             }
         }
@@ -182,7 +194,9 @@ private fun LazyListScope.sessionItems(
             onNavigateToSignIn = onSignIn,
             isLoggedIn = isLoggedIn,
         )
-        if (index < sessions.lastIndex) {
+        val isCurrentBreak = session.isBreak() || session.isService()
+        val isNextBreak = index < sessions.lastIndex && (sessions[index + 1].isBreak() || sessions[index + 1].isService())
+        if (index < sessions.lastIndex && !isCurrentBreak && !isNextBreak) {
             HorizontalDivider()
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -120,11 +120,12 @@ fun SessionDetailViewShared(
 
                     if (session.tags.isNotEmpty()) {
                         Spacer(modifier = Modifier.size(16.dp))
-                        FlowRow {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
                             session.tags.distinct().forEach { tag ->
-                                Box(Modifier.padding(bottom = 8.dp)) {
-                                    Chip(tag)
-                                }
+                                Chip(tag)
                             }
                         }
                     }
@@ -299,15 +300,14 @@ internal fun SocialIcon(
 @Composable
 internal fun Chip(name: String) {
     Surface(
-        modifier = Modifier.padding(end = 10.dp),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.secondaryContainer
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
     ) {
         Text(
             text = name,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            modifier = Modifier.padding(10.dp)
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
         )
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,8 +10,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Celebration
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -48,18 +54,102 @@ fun SessionItemView(
     onNavigateToSignIn: () -> Unit = {},
     isLoggedIn: Boolean,
 ) {
+    if (session.isBreak() || session.isService()) {
+        BreakSessionItemView(session = session)
+    } else {
+        TalkSessionItemView(
+            session = session,
+            sessionSelected = sessionSelected,
+            isBookmarked = isBookmarked,
+            addBookmark = addBookmark,
+            removeBookmark = removeBookmark,
+            onNavigateToSignIn = onNavigateToSignIn,
+            isLoggedIn = isLoggedIn,
+        )
+    }
+}
 
-    var showDialog by remember { mutableStateOf(false) }
-
-    var modifier = Modifier.fillMaxWidth()
-    if (!session.isService() && !session.isBreak()) {
-        modifier = modifier.clickable(onClick = {
-            sessionSelected(session.id)
-        })
+@Composable
+private fun BreakSessionItemView(
+    session: SessionDetails,
+    modifier: Modifier = Modifier,
+) {
+    val icon = when {
+        session.isBreak() -> Icons.Default.Coffee
+        session.title.contains("party", ignoreCase = true) ||
+            session.title.contains("reception", ignoreCase = true) -> Icons.Default.Celebration
+        else -> Icons.Default.Info
     }
 
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.size(36.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = session.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                val location = session.room?.name
+                if (!location.isNullOrBlank()) {
+                    Text(
+                        text = location,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TalkSessionItemView(
+    session: SessionDetails,
+    sessionSelected: (sessionId: String) -> Unit,
+    isBookmarked: Boolean,
+    addBookmark: (String) -> Unit,
+    removeBookmark: (String) -> Unit,
+    onNavigateToSignIn: () -> Unit = {},
+    isLoggedIn: Boolean,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+
     ListItem(
-        modifier = modifier,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = { sessionSelected(session.id) }),
         headlineContent = {
             Text(
                 text = session.title,
@@ -112,22 +202,20 @@ fun SessionItemView(
             }
         },
         trailingContent = {
-            if (!session.isBreak() && !session.isService()) {
-                Bookmark(
-                    isBookmarked = isBookmarked,
-                    onBookmarkChange = { shouldAdd ->
-                        if (!isLoggedIn) {
-                            showDialog = true
-                            return@Bookmark
-                        }
-                        if (shouldAdd) {
-                            addBookmark(session.id)
-                        } else {
-                            removeBookmark(session.id)
-                        }
+            Bookmark(
+                isBookmarked = isBookmarked,
+                onBookmarkChange = { shouldAdd ->
+                    if (!isLoggedIn) {
+                        showDialog = true
+                        return@Bookmark
                     }
-                )
-            }
+                    if (shouldAdd) {
+                        addBookmark(session.id)
+                    } else {
+                        removeBookmark(session.id)
+                    }
+                }
+            )
         }
     )
 
@@ -137,7 +225,6 @@ fun SessionItemView(
             onSignInClicked = onNavigateToSignIn
         )
     }
-
 }
 
 @MobilePreviews

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
@@ -1,8 +1,11 @@
 package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -134,6 +137,7 @@ private fun BreakSessionItemView(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TalkSessionItemView(
     session: SessionDetails,
@@ -153,7 +157,8 @@ private fun TalkSessionItemView(
         headlineContent = {
             Text(
                 text = session.title,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
             )
         },
         supportingContent = {
@@ -163,39 +168,69 @@ private fun TalkSessionItemView(
                     Text(
                         text = speakers,
                         style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
-                }
-
-                session.room?.let { room ->
-                    Text(
-                        text = room.name,
-                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp)
+                        modifier = Modifier.padding(top = 2.dp)
                     )
                 }
 
-                if (session.isLightning()) {
-                    Surface(
-                        modifier = Modifier.padding(top = 8.dp),
-                        shape = MaterialTheme.shapes.small,
-                        color = MaterialTheme.colorScheme.primaryContainer,
+                val hasBadges = session.room != null || session.isLightning() || session.tags.isNotEmpty()
+                if (hasBadges) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.padding(top = 8.dp)
                     ) {
-                        Row(
-                            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Bolt,
-                                contentDescription = "lightning",
-                                modifier = Modifier.size(16.dp)
-                            )
-                            Spacer(Modifier.width(4.dp))
-                            Text(
-                                text = "Lightning / ${session.startsAt.time}-${session.endsAt.time}",
-                                style = MaterialTheme.typography.labelSmall
-                            )
+                        session.room?.let { room ->
+                            Surface(
+                                shape = RoundedCornerShape(6.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ) {
+                                Text(
+                                    text = room.name,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                                )
+                            }
+                        }
+
+                        if (session.isLightning()) {
+                            Surface(
+                                shape = RoundedCornerShape(6.dp),
+                                color = MaterialTheme.colorScheme.secondaryContainer,
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Bolt,
+                                        contentDescription = "lightning",
+                                        modifier = Modifier.size(12.dp),
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                    Spacer(Modifier.width(2.dp))
+                                    Text(
+                                        text = "Lightning (${session.startsAt.time}-${session.endsAt.time})",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                }
+                            }
+                        }
+
+                        session.tags.take(2).forEach { tag ->
+                            Surface(
+                                shape = RoundedCornerShape(6.dp),
+                                color = MaterialTheme.colorScheme.surfaceContainer,
+                            ) {
+                                Text(
+                                    text = tag,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                                )
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListTabRow.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListTabRow.kt
@@ -2,42 +2,49 @@ package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import dev.johnoreilly.confetti.decompose.SessionsUiState
-import dev.johnoreilly.confetti.ui.component.ConfettiTab
-import dev.johnoreilly.confetti.ui.component.pagerTabIndicatorOffset
 import kotlinx.coroutines.launch
 
 @Composable
 fun SessionListTabRow(pagerState: PagerState, uiState: SessionsUiState.Success) {
-    TabRow(
+    PrimaryTabRow(
         selectedTabIndex = pagerState.currentPage,
         containerColor = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurface,
-        indicator = { tabPositions ->
-            TabRowDefaults.Indicator(
-                Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
+        indicator = {
+            TabRowDefaults.PrimaryIndicator(
+                modifier = Modifier.tabIndicatorOffset(pagerState.currentPage, matchContentSize = true),
             )
-        }
+        },
+        divider = {},
     ) {
         uiState.formattedConfDates.forEachIndexed { index, formattedDate ->
             val coroutineScope = rememberCoroutineScope()
+            val selected = pagerState.currentPage == index
 
-            // TODO check normal Tab again
-            ConfettiTab(
-                selected = pagerState.currentPage == index,
+            Tab(
+                selected = selected,
                 onClick = {
                     coroutineScope.launch {
                         pagerState.animateScrollToPage(index)
                     }
                 },
-                text = { Text(text = formattedDate) }
+                text = {
+                    Text(
+                        text = formattedDate,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                    )
+                }
             )
         }
     }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListView.kt
@@ -30,6 +30,8 @@ import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
 import kotlin.math.abs
 
 import androidx.compose.foundation.layout.PaddingValues
+import dev.johnoreilly.confetti.isBreak
+import dev.johnoreilly.confetti.isService
 import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -134,7 +136,9 @@ fun SessionListView(
                                         onNavigateToSignIn = onNavigateToSignIn,
                                         isLoggedIn = isLoggedIn,
                                     )
-                                    if (index < sessions.lastIndex) {
+                                    val isCurrentBreak = session.isBreak() || session.isService()
+                                    val isNextBreak = index < sessions.lastIndex && (sessions[index + 1].isBreak() || sessions[index + 1].isService())
+                                    if (index < sessions.lastIndex && !isCurrentBreak && !isNextBreak) {
                                         HorizontalDivider()
                                     }
                                 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -27,6 +27,9 @@ import dev.johnoreilly.confetti.ui.component.ErrorView
 import dev.johnoreilly.confetti.ui.component.LoadingView
 
 
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionDetailsUI(component: SessionDetailsComponent) {
@@ -35,33 +38,38 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
 
     val uiState by component.uiState.subscribeAsState()
     val isBookmarked by component.isBookmarked.collectAsState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-    Scaffold(topBar = {
-        CenterAlignedTopAppBar(
-            title = { },
-            navigationIcon = {
-                IconButton(onClick = component::onCloseClicked ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                }
-            },
-            actions = {
-                Bookmark(
-                    isBookmarked = isBookmarked,
-                    onBookmarkChange = { shouldAdd ->
-                        if (!component.isLoggedIn) {
-                            showDialog = true
-                            return@Bookmark
-                        }
-                        if (shouldAdd) {
-                            component.addBookmark()
-                        } else {
-                            component.removeBookmark()
-                        }
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = component::onCloseClicked ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                )
-            }
-        )
-    }) {
+                },
+                actions = {
+                    Bookmark(
+                        isBookmarked = isBookmarked,
+                        onBookmarkChange = { shouldAdd ->
+                            if (!component.isLoggedIn) {
+                                showDialog = true
+                                return@Bookmark
+                            }
+                            if (shouldAdd) {
+                                component.addBookmark()
+                            } else {
+                                component.removeBookmark()
+                            }
+                        }
+                    )
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        }
+    ) {
         Box(
             modifier = Modifier
                 .padding(it)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.Role
@@ -140,7 +141,7 @@ fun SettingsUI(
         )
     }
 
-    val scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val uriHandler = LocalUriHandler.current
     /**
      * usePlatformDefaultWidth = false is use as a temporary fix to allow
@@ -150,7 +151,9 @@ fun SettingsUI(
      * https://issuetracker.google.com/issues/221643630
      */
     Scaffold(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
@@ -164,7 +167,7 @@ fun SettingsUI(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Transparent
                 ),
                 scrollBehavior = scrollBehavior,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -64,6 +64,8 @@ import dev.johnoreilly.confetti.ui.component.ConfettiHeader
 import dev.johnoreilly.confetti.ui.sessions.SocialIcon
 import org.jetbrains.compose.resources.stringResource
 
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpeakerDetailsView(
@@ -80,8 +82,10 @@ fun SpeakerDetailsView(
 ) {
     val scrollState = rememberScrollState()
     var showFullScreenPhoto by remember { mutableStateOf(false) }
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             CenterAlignedTopAppBar(
                 title = {},
@@ -90,9 +94,10 @@ fun SpeakerDetailsView(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Transparent
-                )
+                ),
+                scrollBehavior = scrollBehavior,
             )
         },
     ) { innerPadding ->


### PR DESCRIPTION
Modernize conference schedule, session cards, bookmarks, and search experience with Material 3 design patterns and improved navigation.

- Schedule & Tabs:
  - Migrated `SessionListTabRow` and `BookmarksTabRow` to Material 3 `PrimaryTabRow` with `PrimaryIndicator`.
  - Updated `ConfettiHeader` sticky headers to opaque `surfaceContainer` background to eliminate scroll bleed-through.
- Session Items & Badges:
  - Added structured metadata badges for room location, lightning talks with time range, and topic tags.
  - Styled break and service events (lunch, coffee, parties) as distinct tonal cards with leading iconography.
  - Modernized `Bookmark` button to Material 3 `IconToggleButton`.
- Search & Navigation:
  - Opened `Search` as a full-screen destination on `ConferenceComponent` with predictive back navigation.
  - Added dedicated empty search results state to `SearchView`.
- Collapsible Top Bars:
  - Enabled `enterAlwaysScrollBehavior` on detail and settings screens (`SessionsDetailsUI`, `SpeakersDetailsView`, `SettingsUI`, `ConferenceListView`).

| Screen | Screenshot |
| :--- | :---: |
| Schedule | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/3a26b357-8447-4c77-801c-889aa189e3b1" /> |
| Session Details | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/fd2496bf-1b65-4e21-9a3d-348cc2a42fe7" /> |
| Bookmarks | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0ce228ad-b262-48bc-9d40-61b366cc87ea" /> |
| Search | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/600d96c5-596a-4154-a008-cb95011c0698" /> |