### PR TITLE
Navigate to session details when opening notification

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/DeepLink.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/DeepLink.kt
@@ -1,0 +1,31 @@
+package dev.johnoreilly.confetti
+
+import android.net.Uri
+
+data class DeepLinkInfo(
+    val conferenceId: String,
+    val sessionId: String? = null,
+)
+
+/**
+ * From a deep link like `https://confetti-app.dev/conference/devfeststockholm2023`
+ * or `https://confetti-app.dev/conference/devfeststockholm2023/session/123`
+ * extracts conference and optional session IDs.
+ */
+fun Uri.extractDeepLinkInfoOrNull(): DeepLinkInfo? {
+    if (host != "confetti-app.dev") return null
+    val path = path ?: return null
+    if (path.firstOrNull() != '/') return null
+    val parts = path.substring(1).split('/')
+    if (parts.getOrNull(0) != "conference") return null
+    val conferenceId = parts.getOrNull(1) ?: return null
+    if (!conferenceId.all { it.isLetterOrDigit() }) return null
+
+    val sessionId = if (parts.getOrNull(2) == "session") {
+        parts.getOrNull(3)
+    } else {
+        null
+    }
+
+    return DeepLinkInfo(conferenceId = conferenceId, sessionId = sessionId)
+}

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -39,12 +39,13 @@ class MainActivity : ComponentActivity() {
 
         val appComponent =
             handleDeepLink { uri ->
-                val initialConferenceId = uri?.extractConferenceIdOrNull()
-                val rootComponentContext = defaultComponentContext(discardSavedState = initialConferenceId != null)
+                val deepLinkInfo = uri?.extractDeepLinkInfoOrNull()
+                val rootComponentContext = defaultComponentContext(discardSavedState = deepLinkInfo != null)
 
                 val appComponent = DefaultAppComponent(
                     componentContext = rootComponentContext.childContext("app"),
-                    initialConferenceId = initialConferenceId,
+                    initialConferenceId = deepLinkInfo?.conferenceId,
+                    initialSessionId = deepLinkInfo?.sessionId,
                     onSignOut = {
                         lifecycleScope.launch {
                             signInProcess.signOut()
@@ -62,20 +63,6 @@ class MainActivity : ComponentActivity() {
         setContent {
             App(component = appComponent)
         }
-    }
-
-    /**
-     * From a deep link like `https://confetti-app.dev/conference/devfeststockholm2023` extracts `devfeststockholm2023`.
-     */
-    private fun Uri.extractConferenceIdOrNull(): String? {
-        if (host != "confetti-app.dev") return null
-        val path = path ?: return null
-        if (path.firstOrNull() != '/') return null
-        val parts = path.substring(1).split('/')
-        if (parts[0] != "conference") return null
-        val conferenceId = parts.getOrNull(1) ?: return null
-        if (!conferenceId.all { it.isLetterOrDigit() }) return null
-        return conferenceId
     }
 }
 

--- a/androidApp/src/test/kotlin/dev/johnoreilly/confetti/SessionNotificationTest.kt
+++ b/androidApp/src/test/kotlin/dev/johnoreilly/confetti/SessionNotificationTest.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import dev.johnoreilly.confetti.work.SessionAlarmReceiver
 import dev.johnoreilly.confetti.work.SessionAlarmManager
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.core.context.GlobalContext.stopKoin
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
@@ -17,6 +19,11 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [30])
 class SessionNotificationTest {
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
 
     @Test
     fun testScheduleAndCancelAlarm() {
@@ -56,5 +63,46 @@ class SessionNotificationTest {
         sessionAlarmManager.cancelAlarm(sessionId)
 
         assertNull(shadowAlarmManager.getNextScheduledAlarm())
+    }
+
+    @Test
+    fun testNotificationContentIntentDeepLink() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val builder = dev.johnoreilly.confetti.notifications.SessionNotificationBuilder(context)
+
+        val notification = builder.createNotification(
+            title = "Keynote",
+            roomName = "Main Stage",
+            startsAtTime = "09:00",
+            sessionId = "session_999",
+            conferenceId = "droidconberlin2026",
+            notificationId = 42
+        ).build()
+
+        val contentIntent = notification.contentIntent
+        assertNotNull(contentIntent)
+        val shadowPendingIntent = shadowOf(contentIntent)
+        val intent = shadowPendingIntent.savedIntent
+        assertNotNull(intent)
+        assertEquals(android.content.Intent.ACTION_VIEW, intent.action)
+        assertEquals("https://confetti-app.dev/conference/droidconberlin2026/session/session_999", intent.dataString)
+    }
+
+    @Test
+    fun testExtractDeepLinkWithSessionId() {
+        val uri = android.net.Uri.parse("https://confetti-app.dev/conference/droidconberlin2026/session/session_999")
+        val info = uri.extractDeepLinkInfoOrNull()
+        assertNotNull(info)
+        assertEquals("droidconberlin2026", info?.conferenceId)
+        assertEquals("session_999", info?.sessionId)
+    }
+
+    @Test
+    fun testExtractDeepLinkConferenceOnly() {
+        val uri = android.net.Uri.parse("https://confetti-app.dev/conference/droidconberlin2026")
+        val info = uri.extractDeepLinkInfoOrNull()
+        assertNotNull(info)
+        assertEquals("droidconberlin2026", info?.conferenceId)
+        assertNull(info?.sessionId)
     }
 }

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -45,11 +45,12 @@ class AppDelegate : NSObject, UIApplicationDelegate, ObservableObject {
                 }
             },
             initialConferenceId: nil,
-            settingsComponent: nil
+            settingsComponent: nil,
+            initialSessionId: nil
         )
     }
 
-    func onConferenceDeepLink(conferenceId: String) {
+    func onConferenceDeepLink(conferenceId: String, sessionId: String? = nil) {
         applicationLifecycle.destroy()
         applicationLifecycle = ApplicationLifecycle()
         appComponent = DefaultAppComponent(
@@ -62,7 +63,8 @@ class AppDelegate : NSObject, UIApplicationDelegate, ObservableObject {
             onSignOut: {},
             onSignIn: {},
             initialConferenceId: conferenceId,
-            settingsComponent: nil
+            settingsComponent: nil,
+            initialSessionId: sessionId
         )
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -21,13 +21,17 @@ struct iOSApp: App {
             ConfettiIosApp(appDelegate: appDelegate)
                 .onOpenURL(perform: { url in
                     let pathComponents = url.pathComponents
-                    if pathComponents.count != 3 { return }
+                    if pathComponents.count < 3 { return }
                     if pathComponents[1] != "conference" { return }
                     let conferenceId = pathComponents[2]
                     for char in conferenceId {
                         if !char.isLetter && !char.isNumber { return }
                     }
-                    appDelegate.onConferenceDeepLink(conferenceId: conferenceId)
+                    var sessionId: String? = nil
+                    if pathComponents.count >= 5 && pathComponents[3] == "session" {
+                        sessionId = pathComponents[4]
+                    }
+                    appDelegate.onConferenceDeepLink(conferenceId: conferenceId, sessionId: sessionId)
                 })
         }
         .onChange(of: phase) { newPhase in

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -38,7 +38,8 @@ class DefaultAppComponent(
     private val onSignOut: () -> Unit,
     private val onSignIn: () -> Unit,
     initialConferenceId: String? = null,
-    private val settingsComponent: SettingsComponent? = null
+    private val settingsComponent: SettingsComponent? = null,
+    initialSessionId: String? = null,
 ) : AppComponent, KoinComponent, ComponentContext by componentContext {
 
     private val coroutineScope = coroutineScope()
@@ -77,7 +78,7 @@ class DefaultAppComponent(
 
         coroutineScope.launch {
             if (initialConferenceId != null) {
-                selectAndNavigateToDeepLinkedConference(initialConferenceId)
+                selectAndNavigateToDeepLinkedConference(initialConferenceId, initialSessionId)
             } else {
                 if (!appSettings.isOnboardingCompleted()) {
                     showOnboarding()
@@ -103,11 +104,11 @@ class DefaultAppComponent(
         onUserChanged(user?.uid)
     }
 
-    private suspend fun selectAndNavigateToDeepLinkedConference(conferenceId: String) {
+    private suspend fun selectAndNavigateToDeepLinkedConference(conferenceId: String, sessionId: String? = null) {
         // todo, consider changing how conference theme colors are decided so that only knowing the conference
         //  ID is enough to also get the right color
         repository.setConference(conference = conferenceId, conferenceThemeColor = null)
-        showConference(conference = conferenceId, conferenceThemeColor = null)
+        showConference(conference = conferenceId, conferenceThemeColor = null, initialSessionId = sessionId)
     }
 
     private fun onUserChanged(uid: String?) {
@@ -174,7 +175,8 @@ class DefaultAppComponent(
                             authentication.signOut()
                         },
                         onSignIn = onSignIn,
-                        settingsComponent = defaultSettingsComponent
+                        settingsComponent = defaultSettingsComponent,
+                        initialSessionId = config.initialSessionId,
                     )
                 )
         }
@@ -191,8 +193,15 @@ class DefaultAppComponent(
         navigation.push(Config.Conferences(isSwitching = true))
     }
 
-    private fun showConference(conference: String, conferenceThemeColor: String?) {
-        navigation.replaceAll(Config.Conference(uid = user?.uid, conference = conference, conferenceThemeColor = conferenceThemeColor))
+    private fun showConference(conference: String, conferenceThemeColor: String?, initialSessionId: String? = null) {
+        navigation.replaceAll(
+            Config.Conference(
+                uid = user?.uid,
+                conference = conference,
+                conferenceThemeColor = conferenceThemeColor,
+                initialSessionId = initialSessionId,
+            )
+        )
     }
 
     @Serializable
@@ -211,6 +220,7 @@ class DefaultAppComponent(
             val uid: String?, // Unused, but needed to recreated the component when the user changes
             val conference: String,
             val conferenceThemeColor: String?,
+            val initialSessionId: String? = null,
         ) : Config()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/ConferenceComponent.kt
@@ -39,7 +39,8 @@ class DefaultConferenceComponent(
     private val onSwitchConference: () -> Unit,
     private val onSignOut: () -> Unit,
     private val onSignIn: () -> Unit,
-    private val settingsComponent: SettingsComponent?
+    private val settingsComponent: SettingsComponent?,
+    initialSessionId: String? = null,
 ) : ConferenceComponent, ComponentContext by componentContext {
 
     private val navigation = StackNavigation<Config>()
@@ -49,7 +50,13 @@ class DefaultConferenceComponent(
         childStack(
             source = navigation,
             serializer = Config.serializer(),
-            initialConfiguration = Config.Home,
+            initialStack = {
+                if (initialSessionId != null) {
+                    listOf(Config.Home, Config.SessionDetails(sessionId = initialSessionId))
+                } else {
+                    listOf(Config.Home)
+                }
+            },
             handleBackButton = true,
             childFactory = ::child,
         )


### PR DESCRIPTION
Pass session identifier from notification deep link URI into conference navigation stack. When user selects upcoming session reminder, display talk details directly with conference home underneath in back stack.

Test: `dev.johnoreilly.confetti.SessionNotificationTest`