### PR TITLE
Add temporary debug logging for bookmark add/remove failure

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
@@ -58,6 +58,7 @@ class DataStore {
         return try {
             datastore.get(key)
         } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] readBookmarksEntity threw for uid=$uid conference=$conference key=$key: ${e.stackTraceToString()}")
             null
         }
     }
@@ -67,6 +68,7 @@ class DataStore {
     }
 
     fun addBookmark(uid: String, conference: String, sessionId: String): Set<String> {
+        println("[BOOKMARK_DEBUG] addBookmark start uid=$uid conference=$conference sessionId=$sessionId")
         var entityBuilder: Entity.Builder? = readBookmarksEntity(uid, conference)?.let {
             Entity.newBuilder(it)
         }
@@ -79,31 +81,46 @@ class DataStore {
         }
         entityBuilder.set(sessionId, BooleanValue.of(true))
         val newEntity = entityBuilder.build()
-        datastore.runInTransaction {
-            it.put(newEntity)
+        try {
+            datastore.runInTransaction {
+                it.put(newEntity)
+            }
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] addBookmark transaction FAILED uid=$uid conference=$conference sessionId=$sessionId: ${e.stackTraceToString()}")
+            throw e
         }
 
+        println("[BOOKMARK_DEBUG] addBookmark SUCCESS uid=$uid conference=$conference sessionId=$sessionId names=${newEntity.names}")
         return newEntity.names
     }
 
     fun removeBookmark(uid: String, conference: String, sessionId: String): Set<String> {
+        println("[BOOKMARK_DEBUG] removeBookmark start uid=$uid conference=$conference sessionId=$sessionId")
         val entity = readBookmarksEntity(uid, conference)
 
         if (entity == null) {
+            println("[BOOKMARK_DEBUG] removeBookmark no existing entity for uid=$uid conference=$conference")
             return emptySet()
         }
 
         if (!entity.contains(sessionId)) {
+            println("[BOOKMARK_DEBUG] removeBookmark entity does not contain sessionId=$sessionId (existing names=${entity.names})")
             return emptySet()
         }
 
         val newEntity = Entity.newBuilder(entity)
             .remove(sessionId)
             .build()
-        datastore.runInTransaction {
-            it.put(newEntity)
+        try {
+            datastore.runInTransaction {
+                it.put(newEntity)
+            }
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] removeBookmark transaction FAILED uid=$uid conference=$conference sessionId=$sessionId: ${e.stackTraceToString()}")
+            throw e
         }
 
+        println("[BOOKMARK_DEBUG] removeBookmark SUCCESS uid=$uid conference=$conference sessionId=$sessionId names=${newEntity.names}")
         return newEntity.names
     }
 

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
@@ -82,18 +82,30 @@ class DataStoreDataSource(private val conf: String, private val uid: String? = n
 
     override fun addBookmark(sessionId: String): Set<String> {
         if (uid == null) {
+            println("[BOOKMARK_DEBUG] DataStoreDataSource.addBookmark conf=$conf sessionId=$sessionId called with null uid")
             return emptySet()
         }
 
-        return datastore.addBookmark(uid, conf, sessionId)
+        return try {
+            datastore.addBookmark(uid, conf, sessionId)
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] DataStoreDataSource.addBookmark conf=$conf uid=$uid sessionId=$sessionId rethrowing: ${e.stackTraceToString()}")
+            throw e
+        }
     }
 
     override fun removeBookmark(sessionId: String): Set<String> {
         if (uid == null) {
+            println("[BOOKMARK_DEBUG] DataStoreDataSource.removeBookmark conf=$conf sessionId=$sessionId called with null uid")
             return emptySet()
         }
 
-        return datastore.removeBookmark(uid, conf, sessionId)
+        return try {
+            datastore.removeBookmark(uid, conf, sessionId)
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] DataStoreDataSource.removeBookmark conf=$conf uid=$uid sessionId=$sessionId rethrowing: ${e.stackTraceToString()}")
+            throw e
+        }
     }
 
     override fun speaker(id: String): Speaker {

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
@@ -80,11 +80,23 @@ object LocalDateTimeCoercing : Coercing<LocalDateTime> {
 @GraphQLName("Mutation")
 class RootMutation {
     fun addBookmark(dfe: ExecutionContext, sessionId: String): Bookmarks {
-        return Bookmarks(dfe.source().addBookmark(sessionId).toList())
+        println("[BOOKMARK_DEBUG] RootMutation.addBookmark resolver invoked sessionId=$sessionId uid=${dfe.uid()}")
+        return try {
+            Bookmarks(dfe.source().addBookmark(sessionId).toList())
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] RootMutation.addBookmark resolver threw sessionId=$sessionId uid=${dfe.uid()}: ${e.stackTraceToString()}")
+            throw e
+        }
     }
 
     fun removeBookmark(dfe: ExecutionContext, sessionId: String): Bookmarks {
-        return Bookmarks(dfe.source().removeBookmark(sessionId).toList())
+        println("[BOOKMARK_DEBUG] RootMutation.removeBookmark resolver invoked sessionId=$sessionId uid=${dfe.uid()}")
+        return try {
+            Bookmarks(dfe.source().removeBookmark(sessionId).toList())
+        } catch (e: Exception) {
+            println("[BOOKMARK_DEBUG] RootMutation.removeBookmark resolver threw sessionId=$sessionId uid=${dfe.uid()}: ${e.stackTraceToString()}")
+            throw e
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Bookmarking silently fails for droidcon Berlin 2026 on Android: tapping the bookmark icon sends a mutation that returns HTTP 200, but nothing persists (confirmed via the Bookmarks tab and direct Cloud Run access-log inspection), and no exception is currently logged anywhere in the path.
- `DataStore.readBookmarksEntity` silently swallows any exception from `datastore.get(key)` (`catch (e: Exception) { null }`), and neither `addBookmark`/`removeBookmark` nor their callers log success or failure at all.
- Adds `println`-based `[BOOKMARK_DEBUG]` logging (Cloud Run captures stdout) at three layers: the `RootMutation` resolver, `DataStoreDataSource`, and `DataStore` itself, so the real exception (if any) surfaces in Cloud Run logs on the next reproduction attempt.

## Test plan
- [x] `./gradlew :backend:service-graphql:compileKotlin :backend:datastore:compileKotlinJvm` passes
- [ ] Deploy, reproduce the bookmark tap on droidcon Berlin 2026, grep Cloud Run logs for `[BOOKMARK_DEBUG]` to capture the real failure
- [ ] Revert this temporary logging once root cause is identified and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)