### PR TITLE
Fix startup recursion in notification sender and bypass unauthenticated bookmarks query

### DIFF
--- a/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/work/SessionNotificationSender.kt
+++ b/shared/src/androidMain/kotlin/dev/johnoreilly/confetti/work/SessionNotificationSender.kt
@@ -260,7 +260,6 @@ class SessionNotificationSender(
         coroutineScope.launch {
             if (enabled) {
                 startObservingBookmarks()
-                updateSchedule()
             } else {
                 stopObservingBookmarks()
                 cancelAllAlarms()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -136,12 +136,35 @@ class ConfettiRepository : KoinComponent {
         }
     }
 
+    /**
+     * Empty bookmarks data for unauthenticated users.
+     * Prevents network queries when no user account is active.
+     */
+    private fun emptyBookmarksResponse(): ApolloResponse<GetBookmarksQuery.Data> {
+        return ApolloResponse.Builder(
+            GetBookmarksQuery(),
+            uuid4(),
+        ).data(
+            GetBookmarksQuery.Data(
+                GetBookmarksQuery.Bookmarks(
+                    __typename = "Bookmarks",
+                    sessionIds = emptyList(),
+                    id = "none"
+                )
+            )
+        ).build()
+    }
+
     fun bookmarks(
         conference: String,
         uid: String?,
         tokenProvider: TokenProvider?,
         fetchPolicy: FetchPolicy
     ): Flow<ApolloResponse<GetBookmarksQuery.Data>> {
+        // Return empty bookmarks for unauthenticated users to avoid network roundtrip
+        if (uid == null) {
+            return flow { emit(emptyBookmarksResponse()) }
+        }
         return apolloClientCache.getClient(conference, uid).query(GetBookmarksQuery())
             .tokenProvider(tokenProvider)
             .fetchPolicy(fetchPolicy)
@@ -169,6 +192,11 @@ class ConfettiRepository : KoinComponent {
         tokenProvider: TokenProvider?,
         initialData: GetBookmarksQuery.Data?,
     ): Flow<ApolloResponse<GetBookmarksQuery.Data>> = flow {
+        // Return empty bookmarks for unauthenticated users to avoid network roundtrip
+        if (uid == null) {
+            emit(emptyBookmarksResponse())
+            return@flow
+        }
         val values = apolloClientCache.getClient(conference, uid).query(GetBookmarksQuery())
             .tokenProvider(tokenProvider)
             .watch(initialData)


### PR DESCRIPTION
- Fix infinite recursion in session notifications: Remove self-call in `SessionNotificationSender.kt`. Prevent infinite coroutine loop and garbage collection pressure on startup when notifications are enabled.
- Fast-path empty bookmarks for unauthenticated users: Return empty bookmarks response directly in `ConfettiRepository.kt` when `uid == null`. Prevent redundant network requests from delaying screen render for unauthenticated users.