### PR TITLE
Fix dead droidcon-subdomain venue images

### DIFF
--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -415,7 +415,7 @@ object Sessionize {
                 ),
                 latitude = 52.500218,
                 longitude = 13.270753,
-                imageUrl = "https://berlin.droidcon.com/wp-content/uploads/2022/05/CitycubeBW.png",
+                imageUrl = "https://upload.wikimedia.org/wikipedia/commons/a/a3/Westend_CityCube_Berlin.JPG",
                 floorPlanUrl = null
             )
         )
@@ -473,7 +473,7 @@ object Sessionize {
         ),
         latitude = 51.5342463,
         longitude = -0.1068864,
-        imageUrl = "https://london.droidcon.com/wp-content/uploads/sites/3/2022/07/Venue2-1.png",
+        imageUrl = "https://upload.wikimedia.org/wikipedia/commons/e/eb/Business_Design_Centre_exterior.jpg",
         floorPlanUrl = null
     )
 
@@ -513,7 +513,7 @@ object Sessionize {
                 latitude = 37.7679982,
                 longitude = -122.3934354,
                 description = emptyMap(),
-                imageUrl = "https://www.nodesummit.com/wp-content/uploads/UCSF-Mission-Bay-Center_node-summit.jpg",
+                imageUrl = "https://media.eventective.com/1891691_lg.jpg",
                 floorPlanUrl = null
             ),
             partnerGroups = emptyList()
@@ -540,7 +540,7 @@ object Sessionize {
                 latitude = 40.7533911,
                 longitude = -73.9860439,
                 description = emptyMap(),
-                imageUrl = "https://nyc.droidcon.com/wp-content/uploads/sites/2/2023/04/nyc-hotel.png",
+                imageUrl = "https://www.tagvenue.com/resize/68/12/widen-1680-noupsize;54147-jay-conference-bryant-park-venue.jpeg",
                 floorPlanUrl = null
             ),
             partnerGroups = emptyList()
@@ -592,7 +592,7 @@ object Sessionize {
                 ),
                 latitude = 51.5342463,
                 longitude = -0.1068864,
-                imageUrl = "https://london.droidcon.com/wp-content/uploads/sites/3/2022/07/Venue2-1.png",
+                imageUrl = "https://upload.wikimedia.org/wikipedia/commons/e/eb/Business_Design_Centre_exterior.jpg",
                 floorPlanUrl = null
             )
         )


### PR DESCRIPTION
## Summary
- `berlin.droidcon.com`, `london.droidcon.com`, and `nyc.droidcon.com` — which several venue `imageUrl`s in the Sessionize import point at — have gone offline (misconfigured domain / 404s), so the venue image doesn't render for droidcon Berlin (2023-2026), London (2022-2025), San Francisco 2023, and New York 2023.
- Replace with stable images: Wikimedia Commons (CC-licensed) for CityCube Berlin and Business Design Centre London; venue-listing photos for Mission Bay Conference Center (SF) and Jay Conference Bryant Park (NYC), which have no free-licensed alternative.

## Test plan
- [x] `./gradlew :backend:service-import:compileKotlinJvm` passes
- [x] Verified each new image URL returns HTTP 200
- [ ] After merge, redeploy `service-import` (auto via `backend-deploy.yml` on push to `main`) then re-trigger `/update/<conf>` for each affected conference so the live datastore picks up the new URLs