### PR TITLE
Fix NPE writing DConfig entities with a null themeColor

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
@@ -561,7 +561,7 @@ class DataStore {
             .set("name", name.toValue())
             .set("timeZone", timeZone.toValue())
             .set("days", days.map { it.toString() }.toValue())
-            .set("themeColor", themeColor)
+            .set("themeColor", themeColor.toValue())
             .build()
     }
 


### PR DESCRIPTION
## Summary
- `DConfig.toEntity()` (`DataStore.kt:564`) called `Entity.Builder.set("themeColor", themeColor)` directly instead of going through the null-safe `toValue()` extension used for every other field (`name`, `timeZone`, `days`).
- Any conference whose `DConfig` doesn't set an explicit `themeColor` (droidcon London 2022, droidcon London 2023, droidcon San Francisco 2023) crashes the import service with a `NullPointerException` on `/update/<conf>` instead of writing a null value — discovered while re-triggering imports for #1810's venue-image fix.

## Test plan
- [x] `./gradlew :backend:datastore:compileKotlinJvm :backend:service-import:compileKotlinJvm` passes
- [ ] After merge + redeploy, re-trigger `curl --data "" https://confetti-app.dev/update/droidconlondon2022` (and london2023, sf2023) and confirm no more 500