### PR TITLE
Fix sign-out and navigation loss on configuration changes

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -79,7 +79,7 @@ class DefaultAppComponent(
         coroutineScope.launch {
             if (initialConferenceId != null) {
                 selectAndNavigateToDeepLinkedConference(initialConferenceId, initialSessionId)
-            } else {
+            } else if (stack.value.active.configuration is Config.Loading) {
                 if (!appSettings.isOnboardingCompleted()) {
                     showOnboarding()
                 } else {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -49,7 +49,7 @@ class DefaultAppComponent(
     private val navigation = StackNavigation<Config>()
     private val notificationSender: NotificationSender? by inject()
 
-    private var user: User? = null
+    private var user: User? = authentication.currentUser.value
 
     private val defaultSettingsComponent = DefaultSettingsComponent(
         componentContext = componentContext,
@@ -100,8 +100,11 @@ class DefaultAppComponent(
 
 
     override fun setUser(user: User?) {
+        val previousUid = this.user?.uid
         this.user = user
-        onUserChanged(user?.uid)
+        if (previousUid != user?.uid) {
+            onUserChanged(user?.uid)
+        }
     }
 
     private suspend fun selectAndNavigateToDeepLinkedConference(conferenceId: String, sessionId: String? = null) {


### PR DESCRIPTION
DefaultAppComponent initialized user state to null. When Android restored the navigation stack during a configuration change, child components received a null user before the authentication StateFlow emitted. Because the restored stack configuration already contained the user ID, subsequent user updates did not trigger component recreation, leaving the UI signed out and bookmark mutations failing authorization.

Additionally, DefaultAppComponent.init executed conference navigation unconditionally, destroying the restored child backstack.

Initialize user state synchronously from the authentication StateFlow on component creation and restrict initial navigation to Loading state or deep links.