### PR TITLE
Fix System Navigation Bar Padding

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti.ui
 
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -199,8 +201,14 @@ fun HomeView(component: HomeComponent) {
                 snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
                 contentWindowInsets = WindowInsets(0.dp)
             ) { innerPadding ->
+                val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                val bottomPadding = if (!shouldShowNavRail) {
+                    innerPadding.calculateBottomPadding()
+                } else {
+                    navigationBarsPadding
+                }
                 CompositionLocalProvider(
-                    LocalBottomNavigationPadding provides innerPadding.calculateBottomPadding()
+                    LocalBottomNavigationPadding provides bottomPadding
                 ) {
                     Column(
                         modifier = Modifier

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -6,11 +6,15 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -117,15 +121,17 @@ fun ConferenceListView(component: ConferencesComponent) {
                     scrollBehavior = scrollBehavior,
                 )
             }
-        }
+        },
+        contentWindowInsets = WindowInsets(0.dp)
     ) { paddingValues ->
 
+        val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
         val uiState by component.uiState.subscribeAsState()
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
+                .padding(top = paddingValues.calculateTopPadding())
         ) {
             when (val uiState1 = uiState) {
                 ConferencesComponent.Error -> {} //ErrorView(component::refresh)
@@ -144,7 +150,10 @@ fun ConferenceListView(component: ConferencesComponent) {
                         }.filterValues { it.isNotEmpty() }
                     }
 
-                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(bottom = 16.dp + navigationBarsPadding)
+                    ) {
                         filteredConferenceListByYear.keys.sortedDescending().forEach { year ->
                             val conferenceList = filteredConferenceListByYear[year]
                             conferenceList?.let {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -107,9 +109,11 @@ fun SearchView(
         },
         contentWindowInsets = WindowInsets(0.dp)
     ) { innerPadding ->
+        val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
         Box(
             modifier = Modifier
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
+                .fillMaxSize()
         ) {
             if (loading) {
                 LoadingView()
@@ -122,7 +126,7 @@ fun SearchView(
                     )
                 } else {
                     LazyColumn(
-                        contentPadding = PaddingValues(bottom = LocalBottomNavigationPadding.current)
+                        contentPadding = PaddingValues(bottom = 16.dp + navigationBarsPadding)
                     ) {
                         sessionItems(
                             sessions = sessions,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -9,7 +9,11 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -74,13 +78,16 @@ fun SessionDetailViewShared(
     onSpeakerClick: (speakerId: String) -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
-    Column {
+    Column(modifier = Modifier.fillMaxSize()) {
         session?.let { session ->
             val contentPadding = remember { PaddingValues(horizontal = 16.dp) }
             Column(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxSize()
                     .verticalScroll(state = scrollState)
+                    .padding(bottom = 16.dp + navigationBarsPadding)
             ) {
                 Column(modifier = Modifier.padding(contentPadding)) {
                     SelectionContainer {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -43,6 +43,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.johnoreilly.confetti.ui.LocalBottomNavigationPadding
 import coil3.compose.AsyncImage
 import dev.johnoreilly.confetti.decompose.SessionsUiState
 import dev.johnoreilly.confetti.fragment.RoomDetails
@@ -187,7 +188,7 @@ private fun SessionScheduleGrid(
                     Modifier
                         .width(TimeAxisWidth)
                         .height(totalHeight)
-                        .padding(bottom = 16.dp)
+                        .padding(bottom = 16.dp + LocalBottomNavigationPadding.current)
                 ) {
                     var slotStart = gridStart
                     while (slotStart <= gridEnd) {
@@ -236,7 +237,7 @@ private fun SessionScheduleGrid(
                         Modifier
                             .width(RoomColumnWidth * rooms.size)
                             .height(totalHeight)
-                            .padding(bottom = 16.dp)
+                            .padding(bottom = 16.dp + LocalBottomNavigationPadding.current)
                     ) {
                         var slotStart = gridStart
                         while (slotStart <= gridEnd) {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionsDetailsUI.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.confetti.ui.sessions
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -18,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import dev.johnoreilly.confetti.decompose.SessionDetailsComponent
 import dev.johnoreilly.confetti.decompose.SessionDetailsUiState
@@ -68,11 +70,12 @@ fun SessionDetailsUI(component: SessionDetailsComponent) {
                 },
                 scrollBehavior = scrollBehavior,
             )
-        }
-    ) {
+        },
+        contentWindowInsets = WindowInsets(0.dp)
+    ) { innerPadding ->
         Box(
             modifier = Modifier
-                .padding(it)
+                .padding(top = innerPadding.calculateTopPadding())
                 .fillMaxSize()
         ) {
             when (val state = uiState) {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -7,8 +7,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -173,11 +177,14 @@ fun SettingsUI(
                 scrollBehavior = scrollBehavior,
             )
         },
-    ) {
+        contentWindowInsets = WindowInsets(0.dp)
+    ) { innerPadding ->
+        val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
         Column(
             Modifier
                 .clipToBounds()
-                .padding(it)
+                .padding(top = innerPadding.calculateTopPadding())
+                .fillMaxSize()
         ) {
             HorizontalDivider(Modifier.padding(top = 8.dp))
 
@@ -250,7 +257,7 @@ fun SettingsUI(
             }) {
                 Row(
                     modifier = Modifier
-                        .padding(top = 16.dp),
+                        .padding(top = 16.dp, bottom = 16.dp + navigationBarsPadding),
                 ) {
                     Column(
                         Modifier.fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/speakers/SpeakersDetailsView.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -100,13 +103,16 @@ fun SpeakerDetailsView(
                 scrollBehavior = scrollBehavior,
             )
         },
+        contentWindowInsets = WindowInsets(0.dp)
     ) { innerPadding ->
+        val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
         val contentPaddings = remember { PaddingValues(horizontal = 16.dp, vertical = 8.dp) }
         Column(
             modifier = Modifier
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
                 .fillMaxSize()
-                .verticalScroll(state = scrollState),
+                .verticalScroll(state = scrollState)
+                .padding(bottom = 16.dp + navigationBarsPadding),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             SelectionContainer {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/venue/VenueView.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -50,6 +53,7 @@ fun VenueView(venue: Venue) {
     val uriHandler = LocalUriHandler.current
     var showFullScreenPhoto by remember { mutableStateOf(false) }
 
+    val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -58,7 +62,7 @@ fun VenueView(venue: Venue) {
                 start = 16.dp,
                 top = 16.dp,
                 end = 16.dp,
-                bottom = 16.dp + LocalBottomNavigationPadding.current
+                bottom = 16.dp + maxOf(LocalBottomNavigationPadding.current, navigationBarsPadding)
             ),
         horizontalAlignment = Alignment.Start
     ) {


### PR DESCRIPTION
Fix system navigation bar edge-to-edge padding across all screens (Search, Session Details, Speaker Details, Settings, Conference List, Venue, and Schedule Grid). Allow scrollable content to draw behind transparent navigation bar while preventing the last item from being obscured. Add navigation bar insets to tablet layout.