### PR TITLE
Fix Dark Mode Support On Onboarding and Conference List Screens

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -74,6 +74,14 @@ import kotlinx.datetime.LocalDate
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ConferenceListView(component: ConferencesComponent) {
+    ConferenceMaterialThemeFromSettings(seedColorString = null) {
+        ConferenceListContent(component)
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun ConferenceListContent(component: ConferencesComponent) {
     var searchQuery by remember { mutableStateOf("") }
     var searchMode by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
@@ -261,14 +269,14 @@ fun YearHeader(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        color = MaterialTheme.colorScheme.background,
+        color = MaterialTheme.colorScheme.surface,
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
             text = text,
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            style = MaterialTheme.typography.titleSmall,
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.Bold
         )

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -38,6 +38,13 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun OnboardingUI(component: OnboardingComponent) {
+    ConferenceMaterialThemeFromSettings(seedColorString = null) {
+        OnboardingContent(component)
+    }
+}
+
+@Composable
+private fun OnboardingContent(component: OnboardingComponent) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(initialPage = 0) { 3 }
     val notificationsEnabled by component.notificationsEnabled.collectAsState(initial = false)
@@ -103,7 +110,11 @@ fun OnboardingUI(component: OnboardingComponent) {
 
     val hazeState = remember { HazeState() }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
         // Animated moving gradient background container with haze modifier
         Box(
             modifier = Modifier


### PR DESCRIPTION
Apply settings-aware ConferenceMaterialThemeFromSettings to OnboardingUI and ConferenceListView. Set explicit surface background color on OnboardingUI root container and update sticky YearHeader background color to surface with primary text for dark mode contrast.