### PR TITLE
Add embedded field policies for nested sub-objects in extra.graphqls

### DIFF
--- a/shared/src/commonMain/graphql/extra.graphqls
+++ b/shared/src/commonMain/graphql/extra.graphqls
@@ -9,7 +9,7 @@ extend type Venue
 @typePolicy(keyFields: "id")
 
 extend type Session
-@typePolicy(keyFields: "id")
+@typePolicy(keyFields: "id", embeddedFields: "links")
 @cacheControl(maxAge: 14400)
 
 extend type Bookmarks
@@ -17,8 +17,17 @@ extend type Bookmarks
 @cacheControl(maxAge: 3600)
 
 extend type Speaker
-@typePolicy(keyFields: "id")
+@typePolicy(keyFields: "id", embeddedFields: "socials")
 @cacheControl(maxAge: 14400)
+
+extend type PartnerGroup
+@typePolicy(embeddedFields: "partners")
+
+extend type SessionConnection
+@typePolicy(embeddedFields: "pageInfo")
+
+extend type SpeakerConnection
+@typePolicy(embeddedFields: "pageInfo")
 
 extend type Room
 @typePolicy(keyFields: "id")


### PR DESCRIPTION
Configure embeddedFields for types without independent primary keys (Session.links, Speaker.socials, PartnerGroup.partners, and connection pageInfo).

Without embedded field policies, Apollo normalized cache assigns composite generated keys and normalizes sub-objects into standalone cache records. Embedding them directly within their parent record reduces cache record count, memory footprint, and database lookups.

**Disclosure:** this PR contains code produced by generative Al.