### PR TITLE
Load speaker details directly via GetSpeaker query in SpeakerDetailsComponent

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ConfettiRepository.kt
@@ -290,7 +290,21 @@ class ConfettiRepository : KoinComponent {
             .fetchPolicy(fetchPolicy)
     }
 
-    fun speakerQuery(conference: String, id: String): ApolloCall<GetSpeakerQuery.Data> {
-        return apolloClientCache.getClient(conference).query(GetSpeakerQuery(id))
+    fun speakerQuery(
+        conference: String,
+        id: String,
+        fetchPolicy: FetchPolicy = FetchPolicy.CacheFirst,
+    ): ApolloCall<GetSpeakerQuery.Data> {
+        return apolloClientCache.getClient(conference)
+            .query(GetSpeakerQuery(id))
+            .fetchPolicy(fetchPolicy)
+    }
+
+    suspend fun speaker(
+        conference: String,
+        id: String,
+        fetchPolicy: FetchPolicy = FetchPolicy.CacheFirst,
+    ): ApolloResponse<GetSpeakerQuery.Data> {
+        return speakerQuery(conference, id, fetchPolicy).execute()
     }
 }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SpeakerDetailsComponent.kt
@@ -56,10 +56,8 @@ class DefaultSpeakerDetailsComponent(
 
     override val uiState: Value<SpeakerDetailsUiState> = flow {
         val initialBookmarks = repository.bookmarks(conference, user?.uid, user, FetchPolicy.CacheFirst).first()
-        // FixMe: add .speaker(id)
-        val response = repository.conferenceData(conference = conference, FetchPolicy.CacheFirst)
-        val details = response.data?.speakers?.nodes?.map { it.speakerDetails }
-            ?.firstOrNull { it.id == speakerId }
+        val response = repository.speaker(conference = conference, id = speakerId, fetchPolicy = FetchPolicy.CacheFirst)
+        val details = response.data?.speaker?.speakerDetails
 
         if (details != null) {
             val initialBookmarksSet = initialBookmarks.data?.bookmarks?.sessionIds.orEmpty().toSet()


### PR DESCRIPTION
DefaultSpeakerDetailsComponent previously retrieved a speaker by querying the full conference dataset and linearly searching for the speaker ID.

Add speaker(conference, id) to ConfettiRepository and query GetSpeaker directly. This utilizes Apollo normalized cache field policy for O(1) cache lookups and enables granular cache fetching for individual speaker screens.

**Disclosure:** this PR contains code produced by generative Al.