### PR TITLE
Use lightweight SessionSpeakerDetails fragment in SessionDetails

### DIFF
--- a/common/car/src/main/java/dev/johnoreilly/confetti/car/bookmarks/BookmarksScreen.kt
+++ b/common/car/src/main/java/dev/johnoreilly/confetti/car/bookmarks/BookmarksScreen.kt
@@ -76,7 +76,7 @@ class BookmarksScreen(
                 listBuilder.addItem(
                     Row.Builder()
                         .setTitle(session.title)
-                        .addText(session.speakers.map { it.speakerDetails.name }.toString())
+                        .addText(session.speakers.map { it.sessionSpeakerDetails.name }.toString())
                         .setOnClickListener {
                             component.onSessionClicked(id = session.id)
                         }

--- a/common/car/src/main/java/dev/johnoreilly/confetti/car/sessions/SessionsScreen.kt
+++ b/common/car/src/main/java/dev/johnoreilly/confetti/car/sessions/SessionsScreen.kt
@@ -92,7 +92,7 @@ class SessionsScreen(
             val listBuilder = ItemList.Builder()
 
             sessions.forEach { session ->
-                val speakers = session.speakers.map { it.speakerDetails.name }
+                val speakers = session.speakers.map { it.sessionSpeakerDetails.name }
 
                 listBuilder.addItem(
                     Row.Builder().apply {

--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -103,6 +103,17 @@ query GetVenue {
     }
 }
 
+fragment SessionSpeakerDetails on Speaker {
+    id
+    name
+    photoUrl
+    photoUrlThumbnail
+    tagline
+    company
+    companyLogoUrl
+    city
+}
+
 fragment SessionDetails on Session {
     id
     title
@@ -112,7 +123,7 @@ fragment SessionDetails on Session {
     sessionDescription: description
     language
     speakers {
-        ...SpeakerDetails
+        ...SessionSpeakerDetails
     }
     room {
         name

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/Model.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/Model.kt
@@ -3,6 +3,7 @@
 package dev.johnoreilly.confetti
 
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -18,7 +19,7 @@ fun SessionDetails.isLightning() = !isService() &&
 
 fun SessionDetails.sessionSpeakerLocation(): String {
     var text = if (speakers.isNotEmpty())
-        speakers.joinToString(", ") { it.speakerDetails.name }
+        speakers.joinToString(", ") { it.sessionSpeakerDetails.name }
     else
         ""
     text += " (${room?.name})"
@@ -27,7 +28,7 @@ fun SessionDetails.sessionSpeakerLocation(): String {
 
 fun SessionDetails.sessionSpeakers(): String? {
     return if (speakers.isNotEmpty()) {
-        speakers.joinToString(", ") { it.speakerDetails.name }
+        speakers.joinToString(", ") { it.sessionSpeakerDetails.name }
     } else {
         null
     }
@@ -35,6 +36,10 @@ fun SessionDetails.sessionSpeakers(): String? {
 
 
 fun SpeakerDetails.fullNameAndCompany(): String {
+    return name + if (company.isNullOrBlank()) "" else ", " + this.company
+}
+
+fun SessionSpeakerDetails.fullNameAndCompany(): String {
     return name + if (company.isNullOrBlank()) "" else ", " + this.company
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti
 
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 
 /**
@@ -13,3 +14,4 @@ import dev.johnoreilly.confetti.fragment.SpeakerDetails
  * need to pay for.
  */
 expect fun SpeakerDetails.avatarUrl(): String?
+expect fun SessionSpeakerDetails.avatarUrl(): String?

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/agent/ConferenceTools.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/agent/ConferenceTools.kt
@@ -30,7 +30,7 @@ private fun SessionDetails.summary(): String = buildString {
     room?.let { append("Room: ").append(it.name).append('\n') }
     if (speakers.isNotEmpty()) {
         append("Speakers: ")
-            .append(speakers.joinToString { it.speakerDetails.name })
+            .append(speakers.joinToString { it.sessionSpeakerDetails.name })
             .append('\n')
     }
     sessionDescription?.let { append("Description: ").append(it).append('\n') }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SearchComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SearchComponent.kt
@@ -145,7 +145,7 @@ class DefaultSearchComponent(
             yield(details.room?.name.orEmpty())
 
             details.speakers.forEach {
-                yield(it.speakerDetails.name)
+                yield(it.sessionSpeakerDetails.name)
             }
         }.any {
             it.adjustWith(ignoreDiacritics).contains(filter, ignoreCase)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -217,7 +217,7 @@ class SessionsSimpleComponent(
             details.sessionDescription.orEmpty().contains(filter, ignoreCase) ||
             details.room?.name?.contains(filter, ignoreCase) == true ||
             details.speakers.any { speaker ->
-                speaker.speakerDetails.name.contains(filter, ignoreCase)
+                speaker.sessionSpeakerDetails.name.contains(filter, ignoreCase)
             }
     }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
@@ -6,16 +6,43 @@ import dev.johnoreilly.confetti.decompose.SessionsUiState
 import dev.johnoreilly.confetti.decompose.Venue
 import dev.johnoreilly.confetti.fragment.RoomDetails
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
 
 const val JohnUrl = "https://sessionize.com/image/48e7-400o400o2-HkquSQhsfczBGkrABwVTBc.jpg"
+
+val johnOreillySpeaker = SpeakerDetails(
+    id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
+    name = "John O'Reilly",
+    photoUrl = JohnUrl,
+    photoUrlThumbnail = JohnUrl,
+    tagline = "Software Engineer",
+    company = null,
+    companyLogoUrl = null,
+    city = null,
+    bio = "John is a Kotlin GDE that has been developing Android apps since 2010. He worked on server side Java applications in the 2000s and desktop clients in the 1990s. He's also been exploring and advocating for all things Kotlin Multiplatform since 2018.",
+    socials = listOf(
+        SpeakerDetails.Social(__typename = "Social", name = "Twitter", url = "https://twitter.com/joreilly", icon = null),
+        SpeakerDetails.Social(__typename = "Social", name = "Github", url = "https://github.com/joreilly", icon = null),
+    ),
+    sessions = listOf(
+        SpeakerDetails.Session(
+            __typename = "Session",
+            id = "368995",
+            title = "Confetti: building a Kotlin Multiplatform conference app in 40min",
+            startsAt = LocalDateTime.parse("2023-04-13T14:00"),
+        ),
+    ),
+    __typename = "Speaker",
+)
+
 val JohnOreilly = SessionDetails.Speaker(
     __typename = "Speaker",
     id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
-    speakerDetails = SpeakerDetails(
+    sessionSpeakerDetails = SessionSpeakerDetails(
         id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
         name = "John O'Reilly",
         photoUrl = JohnUrl,
@@ -24,28 +51,40 @@ val JohnOreilly = SessionDetails.Speaker(
         company = null,
         companyLogoUrl = null,
         city = null,
-        bio = "John is a Kotlin GDE that has been developing Android apps since 2010. He worked on server side Java applications in the 2000s and desktop clients in the 1990s. He's also been exploring and advocating for all things Kotlin Multiplatform since 2018.",
-        socials = listOf(
-            SpeakerDetails.Social(__typename = "Social", name = "Twitter", url = "https://twitter.com/joreilly", icon = null),
-            SpeakerDetails.Social(__typename = "Social", name = "Github", url = "https://github.com/joreilly", icon = null),
-        ),
-        sessions = listOf(
-            SpeakerDetails.Session(
-                __typename = "Session",
-                id = "368995",
-                title = "Confetti: building a Kotlin Multiplatform conference app in 40min",
-                startsAt = LocalDateTime.parse("2023-04-13T14:00"),
-            ),
-        ),
         __typename = "Speaker",
     )
 )
 
 const val MartinUrl = "https://sessionize.com/image/7c96-400o400o2-UiWeCMZDxPejrFsozKmLYr.jpeg"
+
+val martinBonninSpeaker = SpeakerDetails(
+    id = "56fda597-4927-4d25-9a80-4795d15ef080",
+    name = "Martin Bonnin",
+    photoUrl = MartinUrl,
+    photoUrlThumbnail = MartinUrl,
+    tagline = "Software Engineer",
+    company = null,
+    companyLogoUrl = null,
+    city = null,
+    bio = "Martin is a maintainer of Apollo Kotlin. He has been writing Android applications since Cupcake and fell in love with Kotlin in 2017. Martin loves naming things and the sound of his laptop fan compiling all these type-safe programs. When not busy rewriting all his bash scripts in Kotlin, Martin loves to hike the Pyrénées or play a good game of Hearthstone.",
+    socials = listOf(
+        SpeakerDetails.Social(__typename = "Social", name = "Twitter", url = "https://twitter.com/martin_bonnin", icon = null),
+    ),
+    sessions = listOf(
+        SpeakerDetails.Session(
+            __typename = "Session",
+            id = "368995",
+            title = "Confetti: building a Kotlin Multiplatform conference app in 40min",
+            startsAt = LocalDateTime.parse("2023-04-13T14:00"),
+        ),
+    ),
+    __typename = "Speaker",
+)
+
 val MartinBonnin = SessionDetails.Speaker(
     __typename = "Speaker",
     id = "56fda597-4927-4d25-9a80-4795d15ef080",
-    speakerDetails = SpeakerDetails(
+    sessionSpeakerDetails = SessionSpeakerDetails(
         id = "56fda597-4927-4d25-9a80-4795d15ef080",
         name = "Martin Bonnin",
         photoUrl = MartinUrl,
@@ -54,24 +93,9 @@ val MartinBonnin = SessionDetails.Speaker(
         company = null,
         companyLogoUrl = null,
         city = null,
-        bio = "Martin is a maintainer of Apollo Kotlin. He has been writing Android applications since Cupcake and fell in love with Kotlin in 2017. Martin loves naming things and the sound of his laptop fan compiling all these type-safe programs. When not busy rewriting all his bash scripts in Kotlin, Martin loves to hike the Pyrénées or play a good game of Hearthstone.",
-        socials = listOf(
-            SpeakerDetails.Social(__typename = "Social", name = "Twitter", url = "https://twitter.com/martin_bonnin", icon = null),
-        ),
-        sessions = listOf(
-            SpeakerDetails.Session(
-                __typename = "Session",
-                id = "368995",
-                title = "Confetti: building a Kotlin Multiplatform conference app in 40min",
-                startsAt = LocalDateTime.parse("2023-04-13T14:00"),
-            ),
-        ),
         __typename = "Speaker",
     )
 )
-
-val johnOreillySpeaker: SpeakerDetails = JohnOreilly.speakerDetails
-val martinBonninSpeaker: SpeakerDetails = MartinBonnin.speakerDetails
 
 val sessionDetails = SessionDetails(
     id = "368995",

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionDetailsViewShared.kt
@@ -50,6 +50,7 @@ import confetti.shared.generated.resources.Res
 import confetti.shared.generated.resources.speakers
 import dev.johnoreilly.confetti.avatarUrl
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.fullNameAndCompany
 import dev.johnoreilly.confetti.preview.MobilePreviews
@@ -141,7 +142,7 @@ fun SessionDetailViewShared(
 
                     Column(modifier = Modifier.padding(contentPadding)) {
                         session.speakers.forEach { speaker ->
-                            SessionSpeakerInfo(conference, speaker.speakerDetails, onSpeakerClick)
+                            SessionSpeakerInfo(conference, speaker.sessionSpeakerDetails, onSpeakerClick)
                         }
                     }
 
@@ -174,7 +175,7 @@ fun SessionDetailViewShared(
 @Composable
 internal fun SessionSpeakerInfo(
     conference: String,
-    speaker: SpeakerDetails,
+    speaker: SessionSpeakerDetails,
     onSpeakerClick: (speakerId: String) -> Unit,
 ) {
     var showFullScreenPhoto by remember { mutableStateOf(false) }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionListGridView.kt
@@ -464,11 +464,11 @@ private fun Speakers(conference: String, session: SessionDetails) {
                 .padding(2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            val url = speaker.speakerDetails.avatarUrl()
+            val url = speaker.sessionSpeakerDetails.avatarUrl()
             if (url?.isNotEmpty() == true) {
                 AsyncImage(
                     model = url,
-                    contentDescription = speaker.speakerDetails.name,
+                    contentDescription = speaker.sessionSpeakerDetails.name,
                     contentScale = ContentScale.Fit,
                     modifier = Modifier
                         .size(20.dp)
@@ -478,7 +478,7 @@ private fun Speakers(conference: String, session: SessionDetails) {
 
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = speaker.speakerDetails.name,
+                text = speaker.sessionSpeakerDetails.name,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary
             )

--- a/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/jvmMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti
 
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 
 actual fun SpeakerDetails.avatarUrl(): String? = photoUrl
+actual fun SessionSpeakerDetails.avatarUrl(): String? = photoUrl

--- a/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/mobileMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti
 
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 
 actual fun SpeakerDetails.avatarUrl(): String? = photoUrl
+actual fun SessionSpeakerDetails.avatarUrl(): String? = photoUrl

--- a/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
+++ b/shared/src/wasmJsMain/kotlin/dev/johnoreilly/confetti/SpeakerAvatar.kt
@@ -1,5 +1,7 @@
 package dev.johnoreilly.confetti
 
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 
 actual fun SpeakerDetails.avatarUrl(): String? = photoUrlThumbnail
+actual fun SessionSpeakerDetails.avatarUrl(): String? = photoUrlThumbnail

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionCard.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionCard.kt
@@ -148,7 +148,7 @@ private fun SessionCardContent(
         if (session?.speakers?.isNotEmpty() ?: true) {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 Text(
-                    session?.speakers.orEmpty().joinToString(", ") { it.speakerDetails.name },
+                    session?.speakers.orEmpty().joinToString(", ") { it.sessionSpeakerDetails.name },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontWeight = FontWeight.Normal,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/components/SessionSpeakerChip.kt
@@ -15,6 +15,7 @@ import androidx.wear.compose.material3.CircularProgressIndicator
 import androidx.wear.compose.material3.Icon
 import androidx.wear.compose.material3.SurfaceTransformation
 import coil.compose.SubcomposeAsyncImage
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.fragment.SpeakerDetails
 import dev.johnoreilly.confetti.fullNameAndCompany
 import dev.johnoreilly.confetti.ui.icons.ConfettiIcons
@@ -25,10 +26,15 @@ val SpeakerDetails.wearPhotoUrl: String?
         "$it?size=Watch"
     } ?: photoUrl
 
+val SessionSpeakerDetails.wearPhotoUrl: String?
+    get() = photoUrlThumbnail?.let {
+        "$it?size=Watch"
+    } ?: photoUrl
+
 @Composable
 fun SessionSpeakerChip(
     modifier: Modifier = Modifier,
-    speaker: SpeakerDetails,
+    speaker: SessionSpeakerDetails,
     navigateToSpeaker: (String) -> Unit,
     transformation: SurfaceTransformation? = null,
 ) {

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
@@ -85,10 +85,24 @@ object TestFixtures {
     )
 
     const val JohnUrl = "https://sessionize.com/image/48e7-400o400o2-HkquSQhsfczBGkrABwVTBc.jpg"
+    val JohnOreillySpeakerDetails = SpeakerDetails(
+        id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
+        name = "John O'Reilly",
+        photoUrl = JohnUrl,
+        photoUrlThumbnail = JohnUrl,
+        tagline = "AI Unicorn Founder",
+        company = null,
+        companyLogoUrl = null,
+        city = null,
+        bio = "John is a Kotlin GDE that has been developing Android apps since 2010. He worked on server side Java applications in the 2000s and desktop clients in the 1990s. He's also been exploring and advocating for all things Kotlin Multiplatform since 2018.",
+        socials = emptyList(),
+        sessions = emptyList(),
+        __typename = "Speaker",
+    )
     val JohnOreilly = SessionDetails.Speaker(
         __typename = "Speaker",
         id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
-        speakerDetails = SpeakerDetails(
+        sessionSpeakerDetails = dev.johnoreilly.confetti.fragment.SessionSpeakerDetails(
             id = "0392772c-28d4-47f6-bd39-47d743fb4a81",
             name = "John O'Reilly",
             photoUrl = JohnUrl,
@@ -97,18 +111,29 @@ object TestFixtures {
             company = null,
             companyLogoUrl = null,
             city = null,
-            bio = "John is a Kotlin GDE that has been developing Android apps since 2010. He worked on server side Java applications in the 2000s and desktop clients in the 1990s. He's also been exploring and advocating for all things Kotlin Multiplatform since 2018.",
-            socials = emptyList(),
-            sessions = emptyList(),
             __typename = "Speaker",
         )
     )
 
     const val MartinUrl = "https://sessionize.com/image/7c96-400o400o2-UiWeCMZDxPejrFsozKmLYr.jpeg"
+    val MartinBonninSpeakerDetails = SpeakerDetails(
+        id = "56fda597-4927-4d25-9a80-4795d15ef080",
+        name = "Martin Bonnin",
+        photoUrl = MartinUrl,
+        photoUrlThumbnail = MartinUrl,
+        tagline = "Software Engineer",
+        company = null,
+        companyLogoUrl = null,
+        city = null,
+        bio = "Martin is a maintainer of Apollo Kotlin. He has been writing Android applications since Cupcake and fell in love with Kotlin in 2017. Martin loves naming things and the sound of his laptop fan compiling all these type-safe programs. When not busy rewriting all his bash scripts in Kotlin, Martin loves to hike the Pyrénées or play a good game of Hearthstone.",
+        socials = emptyList(),
+        sessions = emptyList(),
+        __typename = "Speaker",
+    )
     val MartinBonnin = SessionDetails.Speaker(
         __typename = "Speaker",
         id = "56fda597-4927-4d25-9a80-4795d15ef080",
-        speakerDetails = SpeakerDetails(
+        sessionSpeakerDetails = dev.johnoreilly.confetti.fragment.SessionSpeakerDetails(
             id = "56fda597-4927-4d25-9a80-4795d15ef080",
             name = "Martin Bonnin",
             photoUrl = MartinUrl,
@@ -117,9 +142,6 @@ object TestFixtures {
             company = null,
             companyLogoUrl = null,
             city = null,
-            bio = "Martin is a maintainer of Apollo Kotlin. He has been writing Android applications since Cupcake and fell in love with Kotlin in 2017. Martin loves naming things and the sound of his laptop fan compiling all these type-safe programs. When not busy rewriting all his bash scripts in Kotlin, Martin loves to hike the Pyrénées or play a good game of Hearthstone.",
-            socials = emptyList(),
-            sessions = emptyList(),
             __typename = "Speaker",
         )
     )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/sessiondetails/SessionDetailsView.kt
@@ -109,7 +109,7 @@ fun SessionDetailView(
                                 .minimumVerticalContentPadding(
                                     ButtonDefaults.minimumVerticalListContentPadding
                                 ),
-                            speaker = speaker.speakerDetails,
+                            speaker = speaker.sessionSpeakerDetails,
                             navigateToSpeaker = navigateToSpeaker,
                             transformation = SurfaceTransformation(transformationSpec),
                         )

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/speakerdetails/SpeakerDetailsView.kt
@@ -238,7 +238,7 @@ fun SpeakerDetailsViewPreview() {
         SpeakerDetailsView(
             uiState = SpeakerDetailsUiState.Success(
                 conference = TestFixtures.conference,
-                details = TestFixtures.JohnOreilly.speakerDetails,
+                details = TestFixtures.JohnOreillySpeakerDetails,
             )
         )
     }

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/ui/ComponentCatalog.kt
@@ -101,7 +101,7 @@ fun SessionCardBookmarkedPreview() {
 fun SessionSpeakerChipPreview() {
     ConfettiThemeFixed {
         SessionSpeakerChip(
-            speaker = TestFixtures.JohnOreilly.speakerDetails,
+            speaker = TestFixtures.JohnOreilly.sessionSpeakerDetails,
             navigateToSpeaker = {},
         )
     }

--- a/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/SpeakerDetailsScreenTest.kt
+++ b/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/SpeakerDetailsScreenTest.kt
@@ -16,7 +16,7 @@ fun SpeakerDetailsScreen() {
         SpeakerDetailsView(
             uiState = SpeakerDetailsUiState.Success(
                 conference = TestFixtures.conference,
-                details = TestFixtures.JohnOreilly.speakerDetails,
+                details = TestFixtures.JohnOreillySpeakerDetails,
             )
         )
     }

--- a/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/ui/ThemePreview.kt
+++ b/wearApp/src/screenshotTest/java/dev/johnoreilly/confetti/wear/ui/ThemePreview.kt
@@ -43,7 +43,7 @@ fun ThemePreview(seedColor: Theme) {
             SectionHeader("Section Header")
             Text("Confetti: building a Kotlin Multiplatform conference app in 40min")
             ConferenceCard(conference = TestFixtures.conferences.first(), navigateToConference = {})
-            SessionSpeakerChip(speaker = TestFixtures.JohnOreilly.speakerDetails, navigateToSpeaker = {})
+            SessionSpeakerChip(speaker = TestFixtures.JohnOreilly.sessionSpeakerDetails, navigateToSpeaker = {})
             SessionCard(
                 session = TestFixtures.sessionDetails,
                 sessionSelected = {},

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/SpeakerDetailsTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/SpeakerDetailsTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import dev.johnoreilly.confetti.decompose.SpeakerDetailsUiState
-import dev.johnoreilly.confetti.wear.preview.TestFixtures.JohnOreilly
+import dev.johnoreilly.confetti.wear.preview.TestFixtures
 import dev.johnoreilly.confetti.wear.screenshots.BaseScreenshotTest
 import dev.johnoreilly.confetti.wear.screenshots.WearDevice
 import dev.johnoreilly.confetti.wear.speakerdetails.SpeakerDetailsView
@@ -34,7 +34,7 @@ class SpeakerDetailsTest : BaseScreenshotTest() {
             TestScaffold {
                 SpeakerDetailsView(
                     columnState = columnState,
-                    uiState = SpeakerDetailsUiState.Success("myconf", JohnOreilly.speakerDetails),
+                    uiState = SpeakerDetailsUiState.Success("myconf", TestFixtures.JohnOreillySpeakerDetails),
                 )
             }
         }
@@ -52,7 +52,7 @@ class SpeakerDetailsTest : BaseScreenshotTest() {
         composeRule.setContent {
             TestScaffold {
                 SpeakerDetailsView(
-                    uiState = SpeakerDetailsUiState.Success("myconf", JohnOreilly.speakerDetails),
+                    uiState = SpeakerDetailsUiState.Success("myconf", TestFixtures.JohnOreillySpeakerDetails),
                 )
             }
         }

--- a/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/screenshots/FetchDataTest.kt
+++ b/wearApp/src/test/kotlin/dev/johnoreilly/confetti/wear/screenshots/FetchDataTest.kt
@@ -11,6 +11,7 @@ import dev.johnoreilly.confetti.ApolloClientCache
 import dev.johnoreilly.confetti.GetConferencesQuery
 import dev.johnoreilly.confetti.GetSessionsQuery
 import dev.johnoreilly.confetti.fragment.SessionDetails
+import dev.johnoreilly.confetti.fragment.SessionSpeakerDetails
 import dev.johnoreilly.confetti.wear.app.KoinTestApp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -82,17 +83,16 @@ class FetchDataTest : KoinTest {
         return """
             SessionDetails.Speaker(
                 __typename = "$__typename",
-                speakerDetails = SpeakerDetails(
-                    id = ${speakerDetails.id.quoted()},
-                    name = ${speakerDetails.name.quoted()},
-                    photoUrl = ${speakerDetails.photoUrl.quoted()},
-                    company = ${speakerDetails.company.quoted()},
-                    companyLogoUrl = ${speakerDetails.companyLogoUrl.quoted()},
-                    city = ${speakerDetails.city.quoted()},
-                    bio = ${speakerDetails.bio.quoted()},
-                    socials = listOf(
-                        ${speakerDetails.socials.joinToString(", ") { "SpeakerDetails.Social(${it.name}, ${it.url})" }}
-                    )
+                sessionSpeakerDetails = SessionSpeakerDetails(
+                    id = ${sessionSpeakerDetails.id.quoted()},
+                    name = ${sessionSpeakerDetails.name.quoted()},
+                    photoUrl = ${sessionSpeakerDetails.photoUrl.quoted()},
+                    photoUrlThumbnail = ${sessionSpeakerDetails.photoUrlThumbnail.quoted()},
+                    tagline = ${sessionSpeakerDetails.tagline.quoted()},
+                    company = ${sessionSpeakerDetails.company.quoted()},
+                    companyLogoUrl = ${sessionSpeakerDetails.companyLogoUrl.quoted()},
+                    city = ${sessionSpeakerDetails.city.quoted()},
+                    __typename = "${sessionSpeakerDetails.__typename}",
                 )
             )
         """.trimIndent()


### PR DESCRIPTION
SessionDetails previously embedded the full SpeakerDetails fragment, which recursively fetched each speaker's bio, socials, and all associated sessions. This created circular data dependencies (Session -> Speaker -> Session) and heavily inflated the GraphQL response payload for conference schedule queries.

Introduce SessionSpeakerDetails containing only presentation fields (id, name, photos, tagline, company, city). Replace SpeakerDetails with SessionSpeakerDetails in SessionDetails.speakers across shared, car, and wear modules.

**Disclosure:** this PR contains code produced by generative Al.