### PR TITLE
Add previews for recent mobile UI changes

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
@@ -1,0 +1,158 @@
+package dev.johnoreilly.confetti.ui
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import dev.johnoreilly.confetti.GetConferencesQuery
+import dev.johnoreilly.confetti.decompose.AccountUiState
+import dev.johnoreilly.confetti.decompose.ConferenceAgentComponent
+import dev.johnoreilly.confetti.decompose.ConferencesComponent
+import dev.johnoreilly.confetti.preview.previewConferenceListState
+import dev.johnoreilly.confetti.ui.account.AccountView
+
+/**
+ * Android-discoverable previews for the mobile UI work landed in August 2026. Shared-source
+ * previews are useful in IDEs, but the Android compose-preview catalog only scans this module's
+ * main classes, so these entries keep the recent Haze and navigation redesigns in visual CI.
+ */
+@Preview(
+    name = "Light",
+    widthDp = 411,
+    heightDp = 914,
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Dark",
+    widthDp = 411,
+    heightDp = 914,
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+annotation class RecentMobileScreen
+
+@RecentMobileScreen
+@Composable
+fun HazeBottomNavigationPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        HazeBottomBarPreviewContent()
+    }
+}
+
+@Preview(
+    name = "Light - high contrast blur target",
+    widthDp = 411,
+    heightDp = 260,
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Dark - high contrast blur target",
+    widthDp = 411,
+    heightDp = 260,
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun HazeBottomNavigationDetailPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        HazeBottomBarContrastPreviewContent()
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun OnboardingHazePreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        OnboardingContent(
+            notificationsEnabled = false,
+            supportsNotifications = true,
+            onNotificationsToggle = {},
+            onComplete = {},
+        )
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun AccountScreenPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        AccountView(
+            state = AccountUiState.Success(
+                conferenceName = "KotlinConf 2026",
+                conferenceDays = "May 20 - 22, 2026",
+                user = null,
+                hasVenue = true,
+            ),
+            onVenueClicked = {},
+            onSwitchConferenceClicked = {},
+            onSettingsClicked = {},
+            onSignInClicked = {},
+            onSignOutClicked = {},
+        )
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun AssistantConversationPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        ConferenceAgentView(
+            component = PreviewConferenceAgentComponent(),
+            onCloseClick = {},
+        )
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun ConferenceSelectionPreview() {
+    ConferenceListView(
+        component = PreviewConferencesComponent(
+            ConferencesComponent.Success(
+                conferenceListByYear = previewConferenceListState.conferenceListByYear,
+                currentConference = "kotlinconf2023",
+            ),
+        ),
+    )
+}
+
+private class PreviewConferencesComponent(
+    state: ConferencesComponent.UiState,
+) : ConferencesComponent {
+    override val uiState: Value<ConferencesComponent.UiState> = MutableValue(state)
+    override val onBack: (() -> Unit)? = {}
+
+    override fun refresh() = Unit
+
+    override fun onConferenceClicked(conference: GetConferencesQuery.Conference) = Unit
+}
+
+private class PreviewConferenceAgentComponent : ConferenceAgentComponent {
+    override val uiState: Value<ConferenceAgentComponent.UiState> = MutableValue(
+        ConferenceAgentComponent.UiState(
+            messages = listOf(
+                ConferenceAgentComponent.Message.System(
+                    "Ask about the schedule, speakers, or venue.",
+                ),
+                ConferenceAgentComponent.Message.User(
+                    "What should I see after the opening keynote?",
+                ),
+                ConferenceAgentComponent.Message.ToolCall("Search sessions after 10:00"),
+                ConferenceAgentComponent.Message.ToolCall("Rank bookmarked topics"),
+                ConferenceAgentComponent.Message.Agent(
+                    "Try the Kotlin Multiplatform session in the main hall at 11:00.",
+                ),
+            ),
+            inputText = "Show me another option",
+        ),
+    )
+
+    override fun updateInputText(text: String) = Unit
+
+    override fun sendMessage() = Unit
+
+    override fun restartChat() = Unit
+}

--- a/androidApp/src/test/kotlin/dev/johnoreilly/confetti/BaseScreenshotTest.kt
+++ b/androidApp/src/test/kotlin/dev/johnoreilly/confetti/BaseScreenshotTest.kt
@@ -39,7 +39,7 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(RobolectricTestRunner::class)
 @Config(
     application = KoinTestApp::class,
-    sdk = [30],
+    sdk = [35],
 )
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class BaseScreenshotTest(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
@@ -73,7 +72,7 @@ import org.jetbrains.compose.resources.stringResource
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
 import dev.johnoreilly.confetti.decompose.AppComponent
 import dev.johnoreilly.confetti.decompose.ConferenceComponent
 import dev.johnoreilly.confetti.decompose.DefaultAppComponent
@@ -190,17 +189,9 @@ fun HomeView(component: HomeComponent) {
             Scaffold(
                 bottomBar = {
                     if (!shouldShowNavRail) {
-                        BottomBar(
-                            component = component,
-                            modifier = Modifier.hazeChild(
-                                state = hazeState,
-                                style = HazeStyle(
-                                    backgroundColor = MaterialTheme.colorScheme.surface,
-                                    tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
-                                    blurRadius = 25.dp,
-                                )
-                            )
-                        )
+                        HazeBottomBar(hazeState = hazeState) {
+                            BottomBarItems(component)
+                        }
                     }
                 },
                 snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -307,47 +298,62 @@ private fun NavigationRail(component: HomeComponent) {
 
 
 @Composable
-private fun BottomBar(component: HomeComponent, modifier: Modifier = Modifier) {
-    Column {
+fun HazeBottomBar(
+    hazeState: HazeState,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Column(modifier = modifier) {
         HorizontalDivider()
         NavigationBar(
-            modifier = modifier,
+            modifier = Modifier.hazeEffect(
+                state = hazeState,
+                style = HazeStyle(
+                    backgroundColor = MaterialTheme.colorScheme.surface,
+                    tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
+                    blurRadius = 25.dp,
+                )
+            ),
             contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
             tonalElevation = 0.dp,
             containerColor = Color.Transparent,
-        ) {
-            NavigationButtons(component = component) { isSelected, icon, text, badgeCount, onClick ->
-                val scale by animateFloatAsState(
-                    targetValue = if (isSelected) 1.12f else 1.0f,
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioMediumBouncy,
-                        stiffness = Spring.StiffnessMediumLow
-                    ),
-                    label = "NavItemScale"
-                )
-                NavigationBarItem(
-                    selected = isSelected,
-                    onClick = onClick,
-                    icon = {
-                        Box(modifier = Modifier.scale(scale)) {
-                            BadgedBox(
-                                badge = {
-                                    if (badgeCount > 0) {
-                                        Badge {
-                                            val badgeText = if (badgeCount > 99) "99+" else badgeCount.toString()
-                                            Text(badgeText)
-                                        }
-                                    }
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun RowScope.BottomBarItems(component: HomeComponent) {
+    NavigationButtons(component = component) { isSelected, icon, text, badgeCount, onClick ->
+        val scale by animateFloatAsState(
+            targetValue = if (isSelected) 1.12f else 1.0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            ),
+            label = "NavItemScale"
+        )
+        NavigationBarItem(
+            selected = isSelected,
+            onClick = onClick,
+            icon = {
+                Box(modifier = Modifier.scale(scale)) {
+                    BadgedBox(
+                        badge = {
+                            if (badgeCount > 0) {
+                                Badge {
+                                    val badgeText = if (badgeCount > 99) "99+" else badgeCount.toString()
+                                    Text(badgeText)
                                 }
-                            ) {
-                                icon()
                             }
                         }
-                    },
-                    label = { Text(text) },
-                )
-            }
-        }
+                    ) {
+                        icon()
+                    }
+                }
+            },
+            label = { Text(text) },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -59,8 +59,8 @@ import dev.johnoreilly.confetti.ui.component.FullScreenPhotoDialog
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -191,7 +191,7 @@ fun ConferenceAgentView(
                 .imePadding()
         ) {
             LazyColumn(
-                modifier = Modifier.fillMaxSize().haze(hazeState),
+                modifier = Modifier.fillMaxSize().hazeSource(hazeState),
                 state = listState,
                 contentPadding = PaddingValues(
                     start = 16.dp,
@@ -227,7 +227,7 @@ fun ConferenceAgentView(
                             inputBarHeightDp = size.height.toDp()
                         }
                     }
-                    .hazeChild(
+                    .hazeEffect(
                         state = hazeState,
                         style = HazeStyle(
                             backgroundColor = MaterialTheme.colorScheme.surface,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HazeBottomBarPreviewContent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HazeBottomBarPreviewContent.kt
@@ -1,0 +1,175 @@
+package dev.johnoreilly.confetti.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material.icons.outlined.People
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+
+/** A deterministic backdrop that makes the real translucent [HazeBottomBar] visible in previews. */
+@Composable
+fun HazeBottomBarPreviewContent() {
+    HazeBottomBarPreviewLayout(showContrastTarget = false)
+}
+
+/**
+ * A close-up fixture with hard edges and oversized text immediately behind the bar. The sharp
+ * reference above the bar and the softened continuation below it make blur distinct from tint.
+ */
+@Composable
+fun HazeBottomBarContrastPreviewContent() {
+    HazeBottomBarPreviewLayout(showContrastTarget = true)
+}
+
+@Composable
+private fun HazeBottomBarPreviewLayout(showContrastTarget: Boolean) {
+    val hazeState = remember { HazeState() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(hazeState),
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text("KotlinConf 2026", style = MaterialTheme.typography.headlineMedium)
+                repeat(7) { index ->
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("${10 + index}:00", color = MaterialTheme.colorScheme.primary)
+                            Spacer(Modifier.height(4.dp))
+                            Text("A session card scrolling behind the navigation bar")
+                        }
+                    }
+                }
+            }
+
+            if (showContrastTarget) {
+                HazeContrastTarget(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .height(150.dp),
+                )
+            }
+        }
+
+        HazeBottomBar(
+            hazeState = hazeState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth(),
+        ) {
+            PreviewNavigationItem(
+                selected = true,
+                label = "Schedule",
+                selectedIcon = { Icon(Icons.Filled.CalendarToday, contentDescription = null) },
+                unselectedIcon = { Icon(Icons.Filled.CalendarToday, contentDescription = null) },
+            )
+            PreviewNavigationItem(
+                selected = false,
+                label = "Speakers",
+                selectedIcon = { Icon(Icons.Filled.People, contentDescription = null) },
+                unselectedIcon = { Icon(Icons.Outlined.People, contentDescription = null) },
+            )
+            PreviewNavigationItem(
+                selected = false,
+                label = "Bookmarks",
+                selectedIcon = { Icon(Icons.Filled.Bookmarks, contentDescription = null) },
+                unselectedIcon = { Icon(Icons.Outlined.Bookmarks, contentDescription = null) },
+            )
+            PreviewNavigationItem(
+                selected = false,
+                label = "Account",
+                selectedIcon = { Icon(Icons.Filled.AccountCircle, contentDescription = null) },
+                unselectedIcon = { Icon(Icons.Outlined.AccountCircle, contentDescription = null) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun HazeContrastTarget(modifier: Modifier = Modifier) {
+    Box(modifier) {
+        Row(modifier = Modifier.fillMaxSize()) {
+            val colors = listOf(
+                Color(0xFF101010),
+                Color(0xFFF8F8F8),
+                Color(0xFFFF3155),
+                Color(0xFF00C8FF),
+            )
+            repeat(16) { index ->
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxSize()
+                        .background(colors[index % colors.size]),
+                )
+            }
+        }
+        Text(
+            text = "SHARP  HAZE  BLUR",
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 18.dp),
+            color = Color.Black,
+            fontWeight = FontWeight.Black,
+            style = MaterialTheme.typography.headlineLarge,
+        )
+    }
+}
+
+@Composable
+private fun RowScope.PreviewNavigationItem(
+    selected: Boolean,
+    label: String,
+    selectedIcon: @Composable () -> Unit,
+    unselectedIcon: @Composable () -> Unit,
+) {
+    NavigationBarItem(
+        selected = selected,
+        onClick = {},
+        icon = {
+            Box(modifier = Modifier.size(24.dp)) {
+                if (selected) selectedIcon() else unselectedIcon()
+            }
+        },
+        label = { Text(label) },
+    )
+}

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HomeScaffold.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/HomeScaffold.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.sp
 import dev.johnoreilly.confetti.utils.isCompact
 import dev.johnoreilly.confetti.utils.isExpanded
 import dev.johnoreilly.confetti.utils.thenNotNull
-import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeSource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,7 +52,7 @@ fun HomeScaffold(
         modifier = Modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)
             .thenNotNull(hazeState) { state ->
-                haze(state)
+                hazeSource(state)
             },
         topBar = {
             CenterAlignedTopAppBar(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/OnboardingUI.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.johnoreilly.confetti.decompose.OnboardingComponent
 import dev.johnoreilly.confetti.permissions.rememberNotificationPermissionState
 import dev.johnoreilly.confetti.ui.component.ConfettiAlertDialog
@@ -39,43 +39,59 @@ import kotlinx.coroutines.launch
 @Composable
 fun OnboardingUI(component: OnboardingComponent) {
     ConferenceMaterialThemeFromSettings(seedColorString = null) {
-        OnboardingContent(component)
+        val notificationsEnabled by component.notificationsEnabled.collectAsState(initial = false)
+        var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+
+        val notificationPermissionState = rememberNotificationPermissionState(
+            notificationsActive = notificationsEnabled,
+            onPermissionDeniedAlways = {
+                showPermissionDeniedDialog = true
+            },
+            onPermissionStatus = { hasPermission ->
+                if (notificationsEnabled != hasPermission) {
+                    component.updateNotificationsEnabled(hasPermission)
+                }
+            }
+        )
+
+        if (showPermissionDeniedDialog) {
+            ConfettiAlertDialog(
+                title = "Permission Required",
+                text = "Notification permission was permanently denied. Please enable it in Settings to receive updates.",
+                confirmText = "Open Settings",
+                onConfirm = {
+                    showPermissionDeniedDialog = false
+                    notificationPermissionState.openSettings()
+                },
+                dismissText = "Cancel",
+                onDismiss = { showPermissionDeniedDialog = false }
+            )
+        }
+
+        OnboardingContent(
+            notificationsEnabled = notificationsEnabled,
+            supportsNotifications = component.supportsNotifications,
+            onNotificationsToggle = { enabled ->
+                if (enabled) {
+                    notificationPermissionState.maybeRequest()
+                } else {
+                    component.updateNotificationsEnabled(false)
+                }
+            },
+            onComplete = component::completeOnboarding,
+        )
     }
 }
 
 @Composable
-private fun OnboardingContent(component: OnboardingComponent) {
+fun OnboardingContent(
+    notificationsEnabled: Boolean,
+    supportsNotifications: Boolean,
+    onNotificationsToggle: (Boolean) -> Unit,
+    onComplete: () -> Unit,
+) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(initialPage = 0) { 3 }
-    val notificationsEnabled by component.notificationsEnabled.collectAsState(initial = false)
-
-    var showPermissionDeniedDialog by remember { mutableStateOf(false) }
-
-    val notificationPermissionState = rememberNotificationPermissionState(
-        notificationsActive = notificationsEnabled,
-        onPermissionDeniedAlways = {
-            showPermissionDeniedDialog = true
-        },
-        onPermissionStatus = { hasPermission ->
-            if (notificationsEnabled != hasPermission) {
-                component.updateNotificationsEnabled(hasPermission)
-            }
-        }
-    )
-
-    if (showPermissionDeniedDialog) {
-        ConfettiAlertDialog(
-            title = "Permission Required",
-            text = "Notification permission was permanently denied. Please enable it in Settings to receive updates.",
-            confirmText = "Open Settings",
-            onConfirm = {
-                showPermissionDeniedDialog = false
-                notificationPermissionState.openSettings()
-            },
-            dismissText = "Cancel",
-            onDismiss = { showPermissionDeniedDialog = false }
-        )
-    }
 
     // Infinite transition to create a slowly moving gradient background
     val infiniteTransition = rememberInfiniteTransition(label = "GradientAnimation")
@@ -120,7 +136,7 @@ private fun OnboardingContent(component: OnboardingComponent) {
             modifier = Modifier
                 .fillMaxSize()
                 .background(backgroundBrush)
-                .haze(hazeState)
+                .hazeSource(hazeState)
         )
 
         // Scaffold as a sibling layout to prevent nested descendant error
@@ -161,7 +177,7 @@ private fun OnboardingContent(component: OnboardingComponent) {
                         .fillMaxWidth()
                         .padding(vertical = 16.dp)
                         .clip(cardShape)
-                        .hazeChild(
+                        .hazeEffect(
                             state = hazeState,
                             style = HazeStyle(
                                 backgroundColor = Color.Transparent,
@@ -184,14 +200,8 @@ private fun OnboardingContent(component: OnboardingComponent) {
                             2 -> OnboardingStep3(
                                 visible = pagerState.currentPage == 2,
                                 notificationsEnabled = notificationsEnabled,
-                                supportsNotifications = component.supportsNotifications,
-                                onNotificationsToggle = { enabled ->
-                                    if (enabled) {
-                                        notificationPermissionState.maybeRequest()
-                                    } else {
-                                        component.updateNotificationsEnabled(false)
-                                    }
-                                }
+                                supportsNotifications = supportsNotifications,
+                                onNotificationsToggle = onNotificationsToggle,
                             )
                         }
                     }
@@ -253,7 +263,7 @@ private fun OnboardingContent(component: OnboardingComponent) {
                                     pagerState.animateScrollToPage(pagerState.currentPage + 1)
                                 }
                             } else {
-                                component.completeOnboarding()
+                                onComplete()
                             }
                         }
                     ) {


### PR DESCRIPTION
## What changed

- migrate the mobile Haze call sites to `hazeSource` and `hazeEffect`
- add Android-discoverable light and dark previews for the recent mobile navigation, onboarding, account, assistant, and conference-selection UI
- add a deterministic high-contrast preview fixture that makes the bottom-navigation blur visually obvious
- run Roborazzi screenshot tests on SDK 35 so Haze uses the real blur path instead of the Android 11 scrim fallback

## Why

The recent mobile UI changes did not have a focused preview catalog, and the original session-card fixture did not contain enough detail underneath the navigation bar to distinguish blur from translucency. Roborazzi was also pinned to SDK 30, where Haze intentionally falls back to a scrim.

## Validation

- `./gradlew :androidApp:compileDebugKotlin :shared:compileAndroidMain`
- `./gradlew :compose-desktop:compileKotlinJvm :compose-web:compileKotlinWasmJs`
- `./gradlew :androidApp:testDebugUnitTest --tests dev.johnoreilly.confetti.SpeakerDetailsScTest`
- rendered the light and dark `HazeBottomNavigationDetailPreview` variants and visually confirmed sharp source stripes become blurred beneath the navigation bar

The module-wide preview render still reports the existing unrelated `activity__MainActivity` Koin initialization failure; the new previews render successfully.