### PR TITLE
Remove top bar dividers and handle IME padding in Search and Conference List

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -179,11 +179,6 @@ fun ConferenceAgentView(
             }
         }
 
-        HorizontalDivider(
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-            thickness = 1.dp
-        )
-
         Box(
             modifier = Modifier
                 .weight(1f)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -140,6 +141,7 @@ private fun ConferenceListContent(component: ConferencesComponent) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = paddingValues.calculateTopPadding())
+                .imePadding()
         ) {
             when (val uiState1 = uiState) {
                 ConferencesComponent.Error -> {} //ErrorView(component::refresh)

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/search/SearchView.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -114,6 +115,7 @@ fun SearchView(
             modifier = Modifier
                 .padding(top = innerPadding.calculateTopPadding())
                 .fillMaxSize()
+                .imePadding()
         ) {
             if (loading) {
                 LoadingView()

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -186,8 +186,6 @@ fun SettingsUI(
                 .padding(top = innerPadding.calculateTopPadding())
                 .fillMaxSize()
         ) {
-            HorizontalDivider(Modifier.padding(top = 8.dp))
-
             LazyColumn(modifier = Modifier.weight(1f)) {
                 item {
                     SettingsPanel(


### PR DESCRIPTION
Remove HorizontalDivider below top bar in SettingsUI and ConferenceAgentView to align top bar layout across screens.

Add imePadding() to content containers in SearchView and ConferenceListView so content and empty state prompts dynamically adjust height above the software keyboard.