### PR TITLE
Enable Gradle configuration cache and migrate Kotlin daemon options

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
 #Gradle
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 
 #Kotlin
+kotlin.daemon.jvmargs=-Xmx4096M
 kotlin.code.style=official
 kotlin.native.binary.smallBinary=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 #Gradle
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.parallel=true
 


### PR DESCRIPTION
Enable configuration cache in gradle.properties to reduce build configuration time across invocations.

Migrate deprecated -Dkotlin.daemon.jvm.options in org.gradle.jvmargs to dedicated kotlin.daemon.jvmargs property.