### PR TITLE
Fix R8 duplicate class in release build: PreviewConferencesComponent

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
@@ -110,7 +110,7 @@ fun AssistantConversationPreview() {
 @Composable
 fun ConferenceSelectionPreview() {
     ConferenceListView(
-        component = PreviewConferencesComponent(
+        component = PreviewMobileConferencesComponent(
             ConferencesComponent.Success(
                 conferenceListByYear = previewConferenceListState.conferenceListByYear,
                 currentConference = "kotlinconf2023",
@@ -119,7 +119,7 @@ fun ConferenceSelectionPreview() {
     )
 }
 
-private class PreviewConferencesComponent(
+private class PreviewMobileConferencesComponent(
     state: ConferencesComponent.UiState,
 ) : ConferencesComponent {
     override val uiState: Value<ConferencesComponent.UiState> = MutableValue(state)


### PR DESCRIPTION
## Summary
- `androidApp/.../RecentMobileUiPreviews.kt` (#1823) declared a `private class PreviewConferencesComponent` in package `dev.johnoreilly.confetti.ui`, the same package as an existing `private class PreviewConferencesComponent` in `shared/.../ConferenceListView.kt`.
- Kotlin does not mangle private top-level class names at the bytecode level, so both compiled to `dev/johnoreilly/confetti/ui/PreviewConferencesComponent.class`, and R8 failed `:androidApp:minifyReleaseWithR8` with "Type ... is defined multiple times" once shared's classes were merged into androidApp.
- Renamed the androidApp copy to `PreviewMobileConferencesComponent`.

## Test plan
- [x] `./gradlew :androidApp:bundleRelease -PversionNum=271` now succeeds (previously failed with the R8 duplicate-class error)