### PR TITLE
Bump compose-ai-tools to 1.9.0

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.7.0
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.9.0
         with:
           # Pin the render CLI to the applied Gradle plugin version (single
           # source of truth: composeai-preview in gradle/libs.versions.toml)
@@ -131,7 +131,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
       - name: Warm Gradle wrapper
         run: ./gradlew help
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.7.0
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.9.0
         with:
           cli-version: catalog
           catalog-key: composeai-preview

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       # Install the compose-preview CLI, pinned to the applied plugin version
       # (composeai-preview in gradle/libs.versions.toml) so the CLI and plugin
       # stay in lockstep — exactly as compose-preview.yml does for the apply action.
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v1.7.0
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v1.9.0
         with:
           version: catalog
           catalog-key: composeai-preview
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           repository: yschimke/compose-ai-tools
-          ref: main
+          ref: v1.9.0
           path: compose-ai-tools
           persist-credentials: false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ generativeai = "0.9.0-1.1.0"
 buildkonfig = "0.22.0"
 roborazzi = "1.72.0"
 screenshot = "0.0.1-alpha15"
-composeai-preview = "1.7.0"
+composeai-preview = "1.9.0"
 koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 


### PR DESCRIPTION
## Summary

- bump the compose preview Gradle plugin and annotations to 1.9.0
- bump both Compose Preview CI action calls to v1.9.0
- pin the catalog installer and export driver to v1.9.0
- retain the existing per-module live catalogs

## Module coverage

Repository-wide 1.9.0 discovery succeeds and finds 206 previews: 65 in `androidApp` and 141 in `wearApp`. The other discovered modules currently contribute no previews.

The catalog workflow remains per-module because `modules: all` cannot currently publish live bundles. That upstream limitation is tracked in [compose-ai-tools#4054](https://github.com/yschimke/compose-ai-tools/issues/4054).

## Validation

- `compose-preview 1.9.0 list --json` completed successfully across all discovered modules
- `androidApp`: 65 previews discovered
- `wearApp`: 141 previews discovered
- both modified GitHub Actions workflows parse as YAML
- `git diff --check`

## Post-merge

- [ ] Dispatch the **Design Artifacts** workflow on `main` to regenerate the `confetti-wear` and `confetti-mobile` catalogs with 1.9.0.
