### PR TITLE
Remove legacy top dividers from main navigation and assistant bottom bars

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -303,23 +303,20 @@ fun HazeBottomBar(
     modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit,
 ) {
-    Column(modifier = modifier) {
-        HorizontalDivider()
-        NavigationBar(
-            modifier = Modifier.hazeEffect(
-                state = hazeState,
-                style = HazeStyle(
-                    backgroundColor = MaterialTheme.colorScheme.surface,
-                    tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
-                    blurRadius = 25.dp,
-                )
-            ),
-            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            tonalElevation = 0.dp,
-            containerColor = Color.Transparent,
-            content = content,
-        )
-    }
+    NavigationBar(
+        modifier = modifier.hazeEffect(
+            state = hazeState,
+            style = HazeStyle(
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                tint = HazeTint(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)),
+                blurRadius = 25.dp,
+            )
+        ),
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        tonalElevation = 0.dp,
+        containerColor = Color.Transparent,
+        content = content,
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceAgentView.kt
@@ -231,10 +231,6 @@ fun ConferenceAgentView(
                         )
                     )
             ) {
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-                    thickness = 1.dp
-                )
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
Remove HorizontalDivider from HazeBottomBar (App.kt) and ConferenceAgentView input bar. Only these two screens contained top bottom-bar dividers, which were leftover legacy elements forgotten during recent UI modernizations.

Home | Assistant
---|---
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/023c519c-071e-473d-aa14-5d83c0fe65d8" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/a106654f-3a0e-4a52-9438-6c87f4a3f213" />
