### PR TITLE
Hold native splash screen during initialization

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Confetti"
+        android:theme="@style/Theme.App.Starting"
         android:localeConfig="@xml/locale_config"
         android:enableOnBackInvokedCallback="true"
             tools:ignore="UnusedAttribute">

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -2,7 +2,6 @@
 
 package dev.johnoreilly.confetti
 
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -64,7 +63,7 @@ class MainActivity : ComponentActivity() {
             } ?: return
 
         splashScreen.setKeepOnScreenCondition {
-            appComponent.stack.value.active.instance is AppComponent.Child.Loading
+            appComponent.stack.value.active.instance is AppComponent.Child.Initializing
         }
 
         setContent {

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/MainActivity.kt
@@ -14,11 +14,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.lifecycleScope
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.childContext
 import com.arkivanov.decompose.defaultComponentContext
 import com.arkivanov.decompose.handleDeepLink
 import dev.johnoreilly.confetti.account.SignInProcess
+import dev.johnoreilly.confetti.decompose.AppComponent
 import dev.johnoreilly.confetti.decompose.DarkThemeConfig
 import dev.johnoreilly.confetti.decompose.DefaultAppComponent
 import dev.johnoreilly.confetti.decompose.ThemeBrand
@@ -31,6 +33,7 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalDecomposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
@@ -59,6 +62,10 @@ class MainActivity : ComponentActivity() {
                 )
                 appComponent
             } ?: return
+
+        splashScreen.setKeepOnScreenCondition {
+            appComponent.stack.value.active.instance is AppComponent.Child.Loading
+        }
 
         setContent {
             App(component = appComponent)

--- a/androidApp/src/main/res/drawable/ic_splash_anim.xml
+++ b/androidApp/src/main/res/drawable/ic_splash_anim.xml
@@ -1,0 +1,28 @@
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_splash_logo">
+    <target android:name="pulse_group">
+        <aapt:attr name="android:animation" xmlns:aapt="http://schemas.android.com/aapt">
+            <set>
+                <objectAnimator
+                    android:propertyName="scaleX"
+                    android:duration="800"
+                    android:valueFrom="1.0"
+                    android:valueTo="1.15"
+                    android:valueType="floatType"
+                    android:repeatCount="infinite"
+                    android:repeatMode="reverse"
+                    android:interpolator="@android:interpolator/fast_out_slow_in" />
+                <objectAnimator
+                    android:propertyName="scaleY"
+                    android:duration="800"
+                    android:valueFrom="1.0"
+                    android:valueTo="1.15"
+                    android:valueType="floatType"
+                    android:repeatCount="infinite"
+                    android:repeatMode="reverse"
+                    android:interpolator="@android:interpolator/fast_out_slow_in" />
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/androidApp/src/main/res/drawable/ic_splash_logo.xml
+++ b/androidApp/src/main/res/drawable/ic_splash_logo.xml
@@ -1,0 +1,91 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="449"
+        android:viewportHeight="448">
+    <group
+            android:name="pulse_group"
+            android:pivotX="224.5"
+            android:pivotY="224.0">
+        <group
+                android:scaleX="0.67"
+                android:scaleY="0.6685078"
+                android:translateX="74.085"
+                android:translateY="74.25426">
+            <path
+                    android:pathData="M115.63,337.28C52.76,274.41 52.76,172.47 115.63,109.6C165.85,59.38 242.45,48.37 304.28,80.84L306.15,81.83L268.04,152.17C236.81,135.25 197.72,140.64 172.2,166.16C140.57,197.8 140.57,249.08 172.2,280.72C197.86,306.37 237.19,311.65 268.44,294.49L269.38,293.96L308.83,363.56C246.34,398.99 167.15,388.8 115.63,337.28Z"
+                    android:fillColor="#ffffff" />
+            <group>
+                <clip-path android:pathData="M115.63,337.28C52.76,274.41 52.76,172.47 115.63,109.6C165.85,59.38 242.45,48.37 304.28,80.84L306.15,81.83L268.04,152.17C236.81,135.25 197.72,140.64 172.2,166.16C140.57,197.8 140.57,249.08 172.2,280.72C197.86,306.37 237.19,311.65 268.44,294.49L269.38,293.96L308.83,363.56C246.34,398.99 167.15,388.8 115.63,337.28Z" />
+                <path
+                        android:pathData="M245.08,184.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#DB4437"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M150.08,414.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#DB4437"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M340.08,463.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#DB4437"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M191.08,221.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#DB4437"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M314.08,236.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#DB4437"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M154.08,148.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#F4B400"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M292.08,496.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#F4B400"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M228.08,132.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#F4B400"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M223.08,362.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#F4B400"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M300.08,358.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#0F9D58"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M211.08,450.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#0F9D58"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M103.08,354.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#0F9D58"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M99.08,278.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#0F9D58"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M287.08,155.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#4285F4"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M302.08,424.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#4285F4"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M185.08,324.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#4285F4"
+                        android:fillAlpha="0.75" />
+                <path
+                        android:pathData="M107.08,211.79l-90.86,-36.71l36.71,-90.86l90.86,36.71z"
+                        android:fillColor="#4285F4"
+                        android:fillAlpha="0.75" />
+            </group>
+        </group>
+    </group>
+</vector>

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -11,4 +11,11 @@
 
     <style name="Theme.Confetti" parent="PlatformAdjusted.Theme.Confetti" />
 
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">?android:attr/colorBackground</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_anim</item>
+        <item name="windowSplashScreenAnimationDuration">800</item>
+        <item name="postSplashScreenTheme">@style/Theme.Confetti</item>
+    </style>
+
 </resources>

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -26,7 +26,7 @@ interface AppComponent {
     fun setUser(user: User?)
 
     sealed class Child {
-        object Loading : Child()
+        object Initializing : Child()
         class Onboarding(val component: OnboardingComponent) : Child()
         class Conferences(val component: ConferencesComponent) : Child()
         class Conference(val component: ConferenceComponent) : Child()
@@ -127,7 +127,7 @@ class DefaultAppComponent(
 
     private fun child(config: Config, componentContext: ComponentContext): Child =
         when (config) {
-            is Config.Loading -> Child.Loading
+            is Config.Loading -> Child.Initializing
 
             is Config.Onboarding ->
                 Child.Onboarding(

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -93,7 +93,7 @@ import org.jetbrains.compose.resources.stringResource
 fun App(component: DefaultAppComponent) {
     Children(stack = component.stack) {
         when (val child = it.instance) {
-            is AppComponent.Child.Loading -> LoadingView()
+            is AppComponent.Child.Initializing -> LoadingView()
             is AppComponent.Child.Onboarding -> OnboardingUI(child.component)
             is AppComponent.Child.Conferences -> ConferenceListView(child.component)
             is AppComponent.Child.Conference -> ConferenceView(child.component)


### PR DESCRIPTION
Improve startup UX. Prevent Compose loading screen flash.

- Use core-splashscreen to hold native Android splash screen.
- Hold splash screen while AppComponent runs async data checks.
- Rename AppComponent.Child.Loading to Initializing.
- Add Animated Vector Drawable for pulsing logo during initialization.

[Screen_recording_20260817_105639.webm](https://github.com/user-attachments/assets/b43c36c8-daae-4db3-88d7-35e1892b03fd)
