### PR TITLE
Revert "Revert "Remove Startup Loading Delays and Improve Cache-First Offline Operation""

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/fetchPolicy.kt
@@ -7,18 +7,23 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.apollographql.cache.normalized.FetchPolicy
-import com.apollographql.cache.normalized.cacheInfo
-import com.apollographql.cache.normalized.errorsAsException
 import com.apollographql.cache.normalized.fetchFromCache
 import com.apollographql.cache.normalized.fetchPolicy
 import com.apollographql.cache.normalized.fetchPolicyInterceptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.launch
+
+private val backgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 /**
- * Use our custom fetch policy interceptor for the [FetchPolicy.CacheFirst] policy, and the Apollo built-in interceptors
- * for the other policies.
+ * Configure execution options to use [CacheFirstInterceptor] for [FetchPolicy.CacheFirst]
+ * and default Apollo interceptors for other policies.
  */
 fun <T> MutableExecutionOptions<T>.fetchPolicy(fetchPolicy: FetchPolicy) = when (fetchPolicy) {
     FetchPolicy.CacheFirst -> {
@@ -31,32 +36,29 @@ fun <T> MutableExecutionOptions<T>.fetchPolicy(fetchPolicy: FetchPolicy) = when 
 }
 
 /**
- * Returns by priority:
- * - the cached data if it's fresh
- * - the network data if it could be fetched
- * - the stale cached data
+ * Interceptor for [FetchPolicy.CacheFirst] operations.
+ *
+ * Emits cached data immediately to show the UI without delay.
+ * Updates the cache in the background. Network errors during background
+ * sync are ignored to keep valid cached data visible.
  */
 private object CacheFirstInterceptor : ApolloInterceptor {
     override fun <D : Operation.Data> intercept(
         request: ApolloRequest<D>,
         chain: ApolloInterceptorChain
     ): Flow<ApolloResponse<D>> = flow {
-        val cacheResponse = chain.proceed(request.newBuilder().fetchFromCache(true).build()).single()
-        if (cacheResponse.cacheInfo!!.isCacheHit && !cacheResponse.cacheInfo!!.isStale) {
+        val cacheResponse = chain.proceed(request.newBuilder().fetchFromCache(true).build()).singleOrNull()
+
+        if (cacheResponse?.data != null) {
+            // Emit cached data immediately to prevent startup loading delay.
             emit(cacheResponse)
+
+            // Refresh cache in background.
+            backgroundScope.launch { chain.proceed(request).collect() }
         } else {
-            // If the first emission is an exception, emit the cache response.
-            // For exceptions on subsequent emissions, emit the network responses.
-            var first = true
+            // Cache miss requires initial network fetch
             chain.proceed(request).collect { networkResponse ->
-                emit(
-                    if (networkResponse.exception == null || !first) {
-                        networkResponse
-                    } else {
-                        cacheResponse.errorsAsException()
-                    }
-                )
-                first = false
+                emit(networkResponse)
             }
         }
     }


### PR DESCRIPTION
Revert of #1831. Restores the cache-first code to continue the review and discussion from the original pull request (#1805) and the [Slack thread](https://kotlinlang.slack.com/archives/C051P2HUVKP/p1786531035564689).

### Original Description

Conference attendees often encounter congested venue networks with poor connectivity. When opening the app between presentations, users need to see the schedule immediately without waiting for network responses.

Previously, CacheFirst treated cached queries as stale and blocked screen transitions until a network request completed on launch. This caused multi-second startup delays and loading errors when offline.

This change updates CacheFirstInterceptor to emit cached data from local storage immediately with zero delay, then trigger a background network sync asynchronously.

As a result, screens render instantly using cached data, while background requests update local storage silently and ignore network failures when offline.

### Rationale for Immediate Cache Rendering

- Schedule updates happen, but are infrequent enough during an event that a user tapping a moving item in that sub-second refresh window is very unlikely.
- When updates do happen, Compose stable keys (`key = { it.id }`) minimize visible flicker by diffing items in place rather than doing a full redraw.
- Conference Wi-Fi often shows full signal, but actual throughput is dead. A connectivity check would incorrectly report online, leaving the user blocked on a loading spinner while moving between rooms.

Because of this, my intuition is that immediate cache rendering offers a significantly better UX during a live conference environment.