### PR TITLE
Add swiftCon 2026 conference

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -50,6 +50,7 @@ enum class ConferenceId(val id: String) {
     AndroidMakers2026("androidmakers2026"),
     DroidconUSA2026("droidconusa2026"),
     DroidconBerlin2026("droidconberlin2026"),
+    SwiftCon2026("swiftcon2026"),
     ;
 
     companion object {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -153,6 +153,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.AndroidMakers2026 -> Sessionize.importAndroidMakers2026()
         ConferenceId.DroidconUSA2026 -> Sessionize.importDroidconUSA2026()
         ConferenceId.DroidconBerlin2026 -> Sessionize.importDroidconBerlin2026()
+        ConferenceId.SwiftCon2026 -> Sessionize.importSwiftCon2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -462,6 +462,20 @@ object Sessionize {
         )
     }
 
+    suspend fun importSwiftCon2026(): Int {
+        return importDroidconBerlin(
+            ConferenceId.SwiftCon2026.id,
+            "swiftCon 2026",
+            "https://sessionize.com/api/v2/0ymtl17i/view/All",
+            "0xFFFF4600",
+            days = listOf(
+                LocalDate(2026, 10, 7),
+                LocalDate(2026, 10, 8),
+                LocalDate(2026, 10, 9)
+            )
+        )
+    }
+
 
     private val businessDesignCenter = DVenue(
         id = "main",


### PR DESCRIPTION
## Summary
- Adds a new conference, swiftCon 2026, sourced from Sessionize (`https://sessionize.com/api/v2/0ymtl17i/view/All`).
- Same location and dates as droidcon Berlin 2026: CityCube Berlin, Oct 7-9 2026 (Europe/Berlin), reusing the existing `importDroidconBerlin` helper/venue.
- Theme color `0xFFFF4600`, matching the orange "Get Tickets" CTA button color (`rgb(255, 70, 0)`) on https://www.nextappcon.com/swiftcon.

## Test plan
- [x] `./gradlew :backend:datastore:compileKotlinJvm :backend:service-import:compileKotlinJvm` succeeds
- [ ] After merge, trigger the import: `curl --data "" https://confetti-app.dev/update/swiftcon2026`