### PR TITLE
Fix config-cache incompatibility breaking Backend Deploy

### DIFF
--- a/build-logic/src/main/kotlin/landing.kt
+++ b/build-logic/src/main/kotlin/landing.kt
@@ -3,11 +3,10 @@ import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
-import org.gradle.api.Project
 import java.io.ByteArrayInputStream
 import java.io.File
 
-fun Project.uploadLandingPage() {
+fun uploadLandingPage(base: File, gcpServiceAccountJson: String) {
     val storage: Storage = StorageOptions.newBuilder()
         .setCredentials(GoogleCredentials.fromStream(ByteArrayInputStream(gcpServiceAccountJson.encodeToByteArray())))
         .build()
@@ -16,7 +15,6 @@ fun Project.uploadLandingPage() {
     val bucketName = "confetti-landing-page"
 
     println("uploading landing page...")
-    val base = file("public")
     base.walk().filter { it.isFile }
         .forEach { file ->
             file.inputStream().use {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,16 +10,19 @@ buildscript {
 }
 
 tasks.register("setupCredentials") {
-    fun File.writeEnv(name: String) {
-        parentFile.mkdirs()
-        writeText(System.getenv(name))
-    }
+    val gcpServiceAccountKeyFile = file("backend/datastore/src/jvmMain/resources/gcp_service_account_key.json")
+    val firebaseServiceAccountKeyFile = file("backend/service-graphql/src/main/resources/firebase_service_account_key.json")
+    val apolloKeyFile = file("backend/service-graphql/src/main/resources/apollo.key")
     doLast {
+        fun File.writeEnv(name: String) {
+            parentFile.mkdirs()
+            writeText(System.getenv(name))
+        }
         if (System.getenv("CI")?.isNotEmpty() == true) {
             println("setting up google services...")
-            file("backend/datastore/src/jvmMain/resources/gcp_service_account_key.json").writeEnv("GOOGLE_SERVICES_JSON")
-            file("backend/service-graphql/src/main/resources/firebase_service_account_key.json").writeEnv("FIREBASE_SERVICES_JSON")
-            file("backend/service-graphql/src/main/resources/apollo.key").writeEnv("APOLLO_KEY")
+            gcpServiceAccountKeyFile.writeEnv("GOOGLE_SERVICES_JSON")
+            firebaseServiceAccountKeyFile.writeEnv("FIREBASE_SERVICES_JSON")
+            apolloKeyFile.writeEnv("APOLLO_KEY")
         }
     }
 }

--- a/landing-page/build.gradle.kts
+++ b/landing-page/build.gradle.kts
@@ -1,5 +1,7 @@
 tasks.register("uploadLandingPage") {
+    val baseDir = file("public")
+    val serviceAccountJson = provider { gcpServiceAccountJson }
     doLast {
-        uploadLandingPage()
+        uploadLandingPage(baseDir, serviceAccountJson.get())
     }
 }


### PR DESCRIPTION
## Summary
- PR #1825 enabled the Gradle configuration cache, which broke the "Backend Deploy" workflow on every push since (failing on the last two main-branch pushes, including the swiftCon 2026 conference PR #1835).
- Both `:setupCredentials` and `:landing-page:uploadLandingPage` called `Project` methods (`file()`, and the `Project.uploadLandingPage()` extension) from inside `doLast`, which implicitly captures the non-serializable script/Project object in the task action closure — configuration cache storage fails with "cannot serialize Gradle script object references".
- Fix: resolve the needed `File`/`Provider` values at configuration time (outside `doLast`) and turn `uploadLandingPage()` into a plain function taking explicit `File`/`String` params instead of a `Project` extension function.

## Test plan
- [x] `GOOGLE_SERVICES_JSON=... FIREBASE_SERVICES_JSON=... APOLLO_KEY=... CI=true ./gradlew :setupCredentials :landing-page:uploadLandingPage --dry-run` stores the configuration cache successfully (previously failed with a serialization error)
- [x] `./gradlew :setupCredentials` executes successfully and writes the expected files with the configuration cache enabled
- [ ] Confirm the Backend Deploy workflow goes green on merge