### PR TITLE
Fix remaining config-cache incompatibility in terraform:createGcpCredentials

### DIFF
--- a/backend/terraform/build.gradle.kts
+++ b/backend/terraform/build.gradle.kts
@@ -1,9 +1,11 @@
 val file = layout.buildDirectory.file("service-account.json").get().asFile
 
 val createGcpCredentials = tasks.register("createGcpCredentials") {
+    val credentialsFile = file
+    val serviceAccountJson = provider { gcpServiceAccountJson }
     doLast {
-        file.parentFile.mkdirs()
-        file.writeText(gcpServiceAccountJson)
+        credentialsFile.parentFile.mkdirs()
+        credentialsFile.writeText(serviceAccountJson.get())
     }
 }
 val init = tasks.register("init", Exec::class.java) {


### PR DESCRIPTION
## Summary
- PR #1836 fixed two of the three config-cache breakages in the Backend Deploy workflow, but the workflow still failed on the very next run — this time on `./gradlew :backend:terraform:apply`, because `:backend:terraform:createGcpCredentials` has the same root cause: its `doLast` closure referenced a top-level script `val file`, which requires capturing the non-serializable build script object.
- Since the deploy workflow runs each step as a separate `./gradlew` invocation and stops on the first failure (`.github/workflows/backend-deploy.yml`), this meant the two `bumpCloudRunRevision` steps after it never ran — so nothing has actually been deployed since configuration cache was enabled two days ago, despite `terraform apply` appearing to make changes.
- Fix: capture the credentials file/JSON as local vals inside the task registration block, matching the pattern from #1836.
- Audited the rest of the deploy path (`setupCredentials`, `uploadLandingPage`, `terraform:{init,apply,plan}`, both `bumpCloudRunRevision` tasks) — no other raw `doLast` closures capturing script state remain. The `bumpCloudRunRevision`/`deployImageToGcp` tasks are Gratatouille-generated (`@GTask`), which are config-cache-safe by construction.

## Test plan
- [x] Dry-run with config cache enabled for all four Backend Deploy workflow steps (`setupCredentials uploadLandingPage`, `terraform:apply`, `service-graphql:bumpCloudRunRevision`, `service-import:bumpCloudRunRevision`) — all store the configuration cache successfully now (previously failed on the second step)
- [x] Executed `:backend:terraform:createGcpCredentials` for real (with dummy credentials) and confirmed it writes the expected file
- [ ] Confirm the Backend Deploy workflow goes fully green on merge, deploying the swiftCon 2026 conference from #1835