### PR TITLE
Add flutterCon 2026 conference

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -51,6 +51,7 @@ enum class ConferenceId(val id: String) {
     DroidconUSA2026("droidconusa2026"),
     DroidconBerlin2026("droidconberlin2026"),
     SwiftCon2026("swiftcon2026"),
+    FlutterCon2026("fluttercon2026"),
     ;
 
     companion object {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -154,6 +154,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.DroidconUSA2026 -> Sessionize.importDroidconUSA2026()
         ConferenceId.DroidconBerlin2026 -> Sessionize.importDroidconBerlin2026()
         ConferenceId.SwiftCon2026 -> Sessionize.importSwiftCon2026()
+        ConferenceId.FlutterCon2026 -> Sessionize.importFlutterCon2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -476,6 +476,20 @@ object Sessionize {
         )
     }
 
+    suspend fun importFlutterCon2026(): Int {
+        return importDroidconBerlin(
+            ConferenceId.FlutterCon2026.id,
+            "flutterCon 2026",
+            "https://sessionize.com/api/v2/5jb6mz23/view/All",
+            "0xFF008BFF",
+            days = listOf(
+                LocalDate(2026, 10, 7),
+                LocalDate(2026, 10, 8),
+                LocalDate(2026, 10, 9)
+            )
+        )
+    }
+
 
     private val businessDesignCenter = DVenue(
         id = "main",


### PR DESCRIPTION
## Summary
- Adds a new conference, flutterCon 2026, sourced from Sessionize (`https://sessionize.com/api/v2/5jb6mz23/view/All`).
- Same location and dates as droidcon Berlin 2026: CityCube Berlin, Oct 7-9 2026 (Europe/Berlin), reusing the existing `importDroidconBerlin` helper/venue.
- Theme color `0xFF008BFF`, matching the blue "Get Tickets" CTA button color (`rgb(0, 139, 255)`) on https://www.nextappcon.com/fluttercon.

## Test plan
- [x] `./gradlew :backend:datastore:compileKotlinJvm :backend:service-import:compileKotlinJvm` succeeds
- [ ] After merge, trigger the import: `curl --data "" https://confetti-app.dev/update/fluttercon2026`