### PR TITLE
Pin Gradle registries for Renovate and fix the tapmoc coordinate

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -229,7 +229,8 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 tink = "com.google.crypto.tink:tink:1.23.0"
 jib-core = "com.google.cloud.tools:jib-core:0.27.2"
 google-cloud-run = "com.google.cloud:google-cloud-run:0.67.0"
-tapmoc = { module = "com.gradleup.tapmoc:com.gradleup.tapmoc.gradle.plugin", version.ref = "tapmoc" }
+# The real artifact, not the `...gradle.plugin` marker: Renovate cannot look markers up.
+tapmoc = { module = "com.gradleup.tapmoc:tapmoc-gradle-plugin", version.ref = "tapmoc" }
 generativeai = { module = "dev.shreyaspatil.generativeai:generativeai-google", version.ref = "generativeai" }
 
 roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }

--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,18 @@
         "/^com\\.android\\.(application|library|test|dynamic-feature|kotlin\\.multiplatform\\.library|lint)$/"
       ],
       "enabled": false
+    },
+    {
+      "description": "KEEP IN SYNC WITH settings.gradle.kts. Renovate parses that file statically and cannot follow the loop that declares the repositories, so it detected none, fell back to Maven Central, and reported all 47 Google-Maven-only dependencies as \"no-result\" — silently freezing androidx out of updates. plugins.gradle.org is here because Renovate skips Maven Central for plugin markers. The apollo-snapshots repo is omitted on purpose: it is filtered to SNAPSHOTs, which Renovate must not offer.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "registryUrls": [
+        "https://dl.google.com/android/maven2/",
+        "https://repo.maven.apache.org/maven2/",
+        "https://plugins.gradle.org/m2/",
+        "https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes the warning on the dependency dashboard (#315): 47 dependencies reported as `Failed to look up maven package ...: no-result` — every androidx artifact, plus play-services, firebase-bom, googleid and desugar_jdk_libs.

## Cause

Renovate parses `settings.gradle.kts` **statically** and cannot follow the loop that declares the repositories:

```kotlin
listOf(repositories, dependencyResolutionManagement.repositories).forEach { it.apply { google { … }; mavenCentral(); … } }
```

So it detected none — `"registryUrls": []` — and fell back to Maven Central, where none of those artifacts exist:

```
https://repo.maven.apache.org/maven2/androidx/activity/activity-compose/maven-metadata.xml -> HTTP 404
https://dl.google.com/android/maven2/androidx/activity/group-index.xml                     -> HTTP 200
```

It is the loop specifically, not the `google { content { … } }` block form — a plain `google()` *inside* the loop still yields `[]`.

The 47th failure is separate: the catalog named the generated `com.gradleup.tapmoc.gradle.plugin` marker, and Renovate deliberately skips Maven Central for marker-shaped coordinates, so it was unlookupable regardless of registries. The entry now names `com.gradleup.tapmoc:tapmoc-gradle-plugin`, the artifact the marker resolves to.

## What this was costing

Not cosmetic. An audit of all 59 Google Maven pins against latest stable: **24 current, 23 behind** — roughly 9 grouped PRs' worth of updates that Renovate could never raise.

| update | artifacts |
|---|---|
| compose 1.11.4 → **1.12.0** | 7 |
| protolayout 1.4.1 → 1.4.2 | 5 |
| car.app 1.4.0 → **1.7.0** (3 minors) | 2 |
| wear tiles 1.6.1 → 1.6.2 | 2 |
| core-splashscreen, espresso-core, uiautomator, wear-phone-interactions, firebase-bom | 5 |

(AGP 9.1.1 → 9.3.1 also appears, but stays suppressed by the existing hold rule.)

## Approach

Declare the registries in `renovate.json` rather than unrolling the loop, so `settings.gradle.kts` keeps its current shape and no build file changes. The trade-off is that the repository list now lives in two places, so the rule carries a keep-in-sync warning.

`plugins.gradle.org` is included because Renovate skips Maven Central for plugin markers and Gradle's default portal is dropped once `pluginManagement.repositories` is customised. The apollo-snapshots repo is omitted on purpose — it is `exclusiveContent`-filtered to SNAPSHOTs, which Renovate must not offer.

The alternative, spelling both repository lists out literally in `settings.gradle.kts`, was validated too (it works, and keeps one source of truth) but costs 18 duplicated lines in the build.

## Verification

```bash
LOG_LEVEL=debug RENOVATE_PLATFORM=local RENOVATE_ENABLED_MANAGERS=gradle \
  npx --yes --package renovate@latest -- renovate --dry-run=lookup
```

- **0** lookup failures across all 188 dependencies; `main` reports 47.
- `androidx.activity:activity-compose` now resolves against Google Maven (98 releases); `com.gradleup.tapmoc` resolves against the plugin portal.
- `renovate-config-validator` passes; `:backend:datastore` still compiles through the tapmoc convention plugin.

Rebased onto main after #1840 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)