### PR TITLE
Fix primary color always green on deep link into conference

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/AppComponent.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.decompose
 
+import com.apollographql.cache.normalized.FetchPolicy
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
@@ -108,10 +109,22 @@ class DefaultAppComponent(
     }
 
     private suspend fun selectAndNavigateToDeepLinkedConference(conferenceId: String, sessionId: String? = null) {
-        // todo, consider changing how conference theme colors are decided so that only knowing the conference
-        //  ID is enough to also get the right color
-        repository.setConference(conference = conferenceId, conferenceThemeColor = null)
-        showConference(conference = conferenceId, conferenceThemeColor = null, initialSessionId = sessionId)
+        val conferenceThemeColor = fetchConferenceThemeColor(conferenceId)
+        repository.setConference(conference = conferenceId, conferenceThemeColor = conferenceThemeColor)
+        showConference(conference = conferenceId, conferenceThemeColor = conferenceThemeColor, initialSessionId = sessionId)
+    }
+
+    private suspend fun fetchConferenceThemeColor(conferenceId: String): String? {
+        return try {
+            repository.conferences(FetchPolicy.CacheFirst).data?.conferences
+                ?.firstOrNull { it.id == conferenceId }
+                ?.themeColor
+                ?: repository.conferences(FetchPolicy.NetworkOnly).data?.conferences
+                    ?.firstOrNull { it.id == conferenceId }
+                    ?.themeColor
+        } catch (e: Exception) {
+            null
+        }
     }
 
     private fun onUserChanged(uid: String?) {


### PR DESCRIPTION
## Summary
- Deep-linking into the app (e.g. tapping a bookmark notification, or opening a `confetti-app.dev/conference/<id>/...` URL) always rendered the app with the hardcoded green fallback theme color, regardless of the target conference's actual branding.
- Root cause: `selectAndNavigateToDeepLinkedConference` in `AppComponent.kt` hardcoded `conferenceThemeColor = null` because it only knows the conference ID at that point (there was a pre-existing TODO acknowledging this). `ConferenceMaterialTheme.kt` falls back to a hardcoded `0xFF008000` (green) whenever the theme color is `null`, and nothing ever corrected it afterward.
- Fix: look up the real `themeColor` for the deep-linked conference via the existing `GetConferencesQuery` (the same lightweight query the Conferences picker screen already uses) — cache-first, falling back to network if not yet cached. Exceptions (e.g. offline with an empty cache) fall back to `null`, preserving the old behavior rather than crashing the deep link.

## Test plan
- [x] `./gradlew :shared:compileKotlinJvm` passes
- [ ] Manually verify: tap a bookmark notification / open a conference deep link and confirm the app renders with that conference's actual theme color instead of green