### PR TITLE
Group co-located conferences visually in the conference picker

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
@@ -562,6 +562,7 @@ class DataStore {
             .set("timeZone", timeZone.toValue())
             .set("days", days.map { it.toString() }.toValue())
             .set("themeColor", themeColor.toValue())
+            .set("groupName", groupName.toValue())
             .build()
     }
 
@@ -571,7 +572,8 @@ class DataStore {
             name = getStringOrNull("name") ?: "",
             timeZone = getString("timeZone"),
             days = getList<StringValue>("days").map { LocalDate.parse(it.get()) },
-            themeColor = getStringOrNull("themeColor")
+            themeColor = getStringOrNull("themeColor"),
+            groupName = getStringOrNull("groupName")
         )
     }
 

--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
@@ -72,7 +72,8 @@ data class DConfig(
   val name: String,
   val timeZone: String,
   val days: List<LocalDate> = emptyList(),
-  val themeColor: String? = null
+  val themeColor: String? = null,
+  val groupName: String? = null
 )
 
 /**

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
@@ -23,7 +23,8 @@ fun DConfig.toConference(): Conference {
         name = name,
         timezone = timeZone,
         days = days,
-        themeColor = themeColor
+        themeColor = themeColor,
+        groupName = groupName
     )
 }
 

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
@@ -455,5 +455,6 @@ data class Conference(
     val name: String,
     val timezone: String,
     val days: List<LocalDate>,
-    val themeColor: String? = null
+    val themeColor: String? = null,
+    val groupName: String? = null
 )

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -394,7 +394,8 @@ object Sessionize {
         name: String,
         url: String,
         themeColor: String,
-        days: List<LocalDate> = emptyList()
+        days: List<LocalDate> = emptyList(),
+        groupName: String? = null
     ): Int {
         return writeData(
             getData(url),
@@ -403,7 +404,8 @@ object Sessionize {
                 name = name,
                 timeZone = "Europe/Berlin",
                 days = days,
-                themeColor = themeColor
+                themeColor = themeColor,
+                groupName = groupName
             ),
             venue = DVenue(
                 id = "main",
@@ -458,7 +460,8 @@ object Sessionize {
                 LocalDate(2026, 10, 7),
                 LocalDate(2026, 10, 8),
                 LocalDate(2026, 10, 9)
-            )
+            ),
+            groupName = "next.app devCon Berlin"
         )
     }
 
@@ -472,7 +475,8 @@ object Sessionize {
                 LocalDate(2026, 10, 7),
                 LocalDate(2026, 10, 8),
                 LocalDate(2026, 10, 9)
-            )
+            ),
+            groupName = "next.app devCon Berlin"
         )
     }
 
@@ -486,7 +490,8 @@ object Sessionize {
                 LocalDate(2026, 10, 7),
                 LocalDate(2026, 10, 8),
                 LocalDate(2026, 10, 9)
-            )
+            ),
+            groupName = "next.app devCon Berlin"
         )
     }
 

--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -82,6 +82,7 @@ query GetConferences{
         name
         timezone
         themeColor
+        groupName
     }
 }
 

--- a/shared/src/commonMain/graphql/schema.graphqls
+++ b/shared/src/commonMain/graphql/schema.graphqls
@@ -62,6 +62,8 @@ type Conference {
   days: [LocalDate!]!
 
   themeColor: String
+
+  groupName: String
 }
 
 type Link {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
@@ -207,6 +207,7 @@ val sampleConferences: List<GetConferencesQuery.Conference> = listOf(
         days = listOf(LocalDate.parse("2023-04-13"), LocalDate.parse("2023-04-14")),
         name = "KotlinConf 2023",
         themeColor = "0x7F52FF",
+        groupName = null,
     ),
     GetConferencesQuery.Conference(
         __typename = "Conference",
@@ -215,6 +216,7 @@ val sampleConferences: List<GetConferencesQuery.Conference> = listOf(
         days = listOf(LocalDate.parse("2023-10-26"), LocalDate.parse("2023-10-27")),
         name = "droidcon London 2023",
         themeColor = "0xA4C639",
+        groupName = null,
     ),
     GetConferencesQuery.Conference(
         __typename = "Conference",
@@ -223,6 +225,34 @@ val sampleConferences: List<GetConferencesQuery.Conference> = listOf(
         days = listOf(LocalDate.parse("2022-04-13"), LocalDate.parse("2022-04-14")),
         name = "KotlinConf 2022",
         themeColor = "0x7F52FF",
+        groupName = null,
+    ),
+    GetConferencesQuery.Conference(
+        __typename = "Conference",
+        id = "droidconberlin2026",
+        timezone = "Europe/Berlin",
+        days = listOf(LocalDate.parse("2026-10-07"), LocalDate.parse("2026-10-09")),
+        name = "droidcon Berlin 2026",
+        themeColor = "0xFFFFBE29",
+        groupName = "next.app devCon Berlin",
+    ),
+    GetConferencesQuery.Conference(
+        __typename = "Conference",
+        id = "swiftcon2026",
+        timezone = "Europe/Berlin",
+        days = listOf(LocalDate.parse("2026-10-07"), LocalDate.parse("2026-10-09")),
+        name = "swiftCon Berlin 2026",
+        themeColor = "0xFFFF4600",
+        groupName = "next.app devCon Berlin",
+    ),
+    GetConferencesQuery.Conference(
+        __typename = "Conference",
+        id = "fluttercon2026",
+        timezone = "Europe/Berlin",
+        days = listOf(LocalDate.parse("2026-10-07"), LocalDate.parse("2026-10-09")),
+        name = "flutterCon Berlin 2026",
+        themeColor = "0xFF008BFF",
+        groupName = "next.app devCon Berlin",
     ),
 )
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/ConferenceListView.kt
@@ -27,11 +27,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.graphics.Color
@@ -171,15 +173,34 @@ private fun ConferenceListContent(component: ConferencesComponent) {
                                     YearHeader(year.toString())
                                 }
 
-                                items(conferenceList) { conference ->
-                                    val isSelected = conference.id == uiState1.currentConference
-                                    ConferenceCard(
-                                        conference = conference,
-                                        isSelected = isSelected,
-                                        navigateToConference = {
-                                            component.onConferenceClicked(conference)
+                                val groupedConferenceList = conferenceList.groupBy { it.groupName }
+                                    .entries.toList()
+
+                                items(
+                                    items = groupedConferenceList,
+                                    key = { (groupName, group) -> groupName ?: group.first().id }
+                                ) { (groupName, group) ->
+                                    if (groupName != null && group.size > 1) {
+                                        ConferenceGroupCard(
+                                            groupName = groupName,
+                                            conferences = group,
+                                            currentConference = uiState1.currentConference,
+                                            navigateToConference = { conference ->
+                                                component.onConferenceClicked(conference)
+                                            }
+                                        )
+                                    } else {
+                                        group.forEach { conference ->
+                                            val isSelected = conference.id == uiState1.currentConference
+                                            ConferenceCard(
+                                                conference = conference,
+                                                isSelected = isSelected,
+                                                navigateToConference = {
+                                                    component.onConferenceClicked(conference)
+                                                }
+                                            )
                                         }
-                                    )
+                                    }
                                 }
                             }
                         }
@@ -262,6 +283,50 @@ fun ConferenceCard(
     }
 }
 
+
+@Composable
+fun ConferenceGroupCard(
+    groupName: String,
+    conferences: List<GetConferencesQuery.Conference>,
+    currentConference: String?,
+    navigateToConference: (GetConferencesQuery.Conference) -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(12.dp))
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Groups,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = groupName,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            conferences.forEach { conference ->
+                ConferenceCard(
+                    conference = conference,
+                    isSelected = conference.id == currentConference,
+                    navigateToConference = { navigateToConference(conference) }
+                )
+            }
+        }
+    }
+}
 
 private fun getConferenceDatesString(days: List<LocalDate>): String {
     var conferenceDatesString = ""

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/ConferenceFixtures.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/ConferenceFixtures.kt
@@ -44,6 +44,7 @@ object ConferenceFixtures {
         ),
         name = "KotlinConf 2025",
         themeColor = null,  // theme comes from ConferenceTheme lookup
+        groupName = null,
     )
     val kotlinConfHome = HomeUiState(
         conference = kotlinConf.id,
@@ -75,6 +76,7 @@ object ConferenceFixtures {
         ),
         name = "Android Makers 2025",
         themeColor = null,
+        groupName = null,
     )
     val androidMakersHome = HomeUiState(
         conference = androidMakers.id,
@@ -106,6 +108,7 @@ object ConferenceFixtures {
         ),
         name = "droidcon London",
         themeColor = null,
+        groupName = null,
     )
     val droidconHome = HomeUiState(
         conference = droidcon.id,
@@ -137,6 +140,7 @@ object ConferenceFixtures {
         ),
         name = "DevFest Nantes",
         themeColor = null,
+        groupName = null,
     )
     val devFestHome = HomeUiState(
         conference = devFest.id,

--- a/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
+++ b/wearApp/src/main/java/dev/johnoreilly/confetti/wear/preview/TestFixtures.kt
@@ -21,6 +21,7 @@ object TestFixtures {
         ),
         "KotlinConf 2023",
         "0xFF800000",
+        null,
     )
 
     val kotlinConf2023Config = GetBookmarkedSessionsQuery.Config(
@@ -41,6 +42,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2023-02-04"), LocalDate.parse("2023-02-05")),
             "Fosdem 2023",
             "0xFF008000",
+            null,
         ),
         GetConferencesQuery.Conference(
             __typename = "Conference",
@@ -49,6 +51,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2022-10-27"), LocalDate.parse("2022-10-28")),
             "droidcon London",
             "0xFF800000",
+            null,
         ),
         GetConferencesQuery.Conference(
             __typename = "Conference",
@@ -57,6 +60,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2022-10-20"), LocalDate.parse("2022-10-21")),
             "DevFest Nantes",
             "0xFF800000",
+            null,
         ),
         GetConferencesQuery.Conference(
             __typename = "Conference",
@@ -65,6 +69,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2022-10-04"), LocalDate.parse("2022-10-05")),
             "GraphQL Summit",
             "0xFF800000",
+            null,
         ),
         GetConferencesQuery.Conference(
             __typename = "Conference",
@@ -73,6 +78,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2022-09-29"), LocalDate.parse("2022-09-30")),
             "FrenchKit",
             "0xFF800000",
+            null,
         ),
         GetConferencesQuery.Conference(
             __typename = "Conference",
@@ -81,6 +87,7 @@ object TestFixtures {
             listOf(LocalDate.parse("2022-06-02"), LocalDate.parse("2022-06-03")),
             "droidcon SF",
             "0xFF800000",
+            null,
         )
     )
 


### PR DESCRIPTION
## Summary
- droidcon Berlin, swiftCon Berlin, and flutterCon Berlin 2026 are all part of the same umbrella event ("next.app devCon Berlin"), sharing venue (CityCube Berlin) and dates (Oct 7-9 2026), but the conference picker showed them as three unrelated top-level cards.
- Adds a nullable `groupName: String` field to `Conference`, threaded through the GraphQL schema, backend Datastore model/mapping, backend GraphQL resolver mapping, and the Sessionize import job (`importDroidconBerlin` now takes an optional `groupName`, set to `"next.app devCon Berlin"` for the three 2026 Berlin conferences only).
- Client: within a year, conferences sharing a non-null `groupName` (2+) now render nested inside one umbrella `ConferenceGroupCard` instead of as separate cards. Ungrouped conferences are unaffected.
- Scope is visual grouping only — session/schedule data stays fully partitioned per conference (each keeps its own Apollo client/cache and backend namespace), per discussion.
- Updated 14 hand-written `GetConferencesQuery.Conference(...)` preview/test fixtures for the new required codegen field, and added grouped sample data to `MockData.kt`.

## Test plan
- [x] `:shared:compileKotlinJvm`, `:backend:datastore`, `:backend:service-graphql` (+ tests), `:backend:service-import`, `:androidApp:compileDebugKotlin`, `:common:car:compileReleaseKotlin` all pass
- [x] Verified visually with a Roborazzi screenshot render of `ConferenceListView` using grouped preview data — droidcon/swiftCon/flutterCon Berlin 2026 nest correctly under one "next.app devCon Berlin" card, each keeping its own theme color
- [ ] Requires a backend deploy + re-running `importDroidconBerlin2026`/`importSwiftCon2026`/`importFlutterCon2026` before `groupName` is populated in production (follow-up, not part of this PR)