### PR TITLE
Add reactCon 2026 conference

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -52,6 +52,7 @@ enum class ConferenceId(val id: String) {
     DroidconBerlin2026("droidconberlin2026"),
     SwiftCon2026("swiftcon2026"),
     FlutterCon2026("fluttercon2026"),
+    ReactCon2026("reactcon2026"),
     ;
 
     companion object {

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -155,6 +155,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.DroidconBerlin2026 -> Sessionize.importDroidconBerlin2026()
         ConferenceId.SwiftCon2026 -> Sessionize.importSwiftCon2026()
         ConferenceId.FlutterCon2026 -> Sessionize.importFlutterCon2026()
+        ConferenceId.ReactCon2026 -> Sessionize.importReactCon2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -490,6 +490,20 @@ object Sessionize {
         )
     }
 
+    suspend fun importReactCon2026(): Int {
+        return importDroidconBerlin(
+            ConferenceId.ReactCon2026.id,
+            "reactCon Berlin 2026",
+            "https://sessionize.com/api/v2/ampchpg2/view/All",
+            "0xFF8748F3",
+            days = listOf(
+                LocalDate(2026, 10, 7),
+                LocalDate(2026, 10, 8),
+                LocalDate(2026, 10, 9)
+            )
+        )
+    }
+
 
     private val businessDesignCenter = DVenue(
         id = "main",


### PR DESCRIPTION
## Summary
- New conference sourced from Sessionize (`https://sessionize.com/api/v2/ampchpg2/view/All`), held alongside droidcon/swiftCon/flutterCon Berlin 2026 at the same venue (CityCube Berlin, Oct 7-9 2026).
- Theme color `0xFF8748F3` matches the purple button/icon accent used on nextappcon.com/reactcon.
- Follows the exact pattern used for the droidcon/swiftCon/flutterCon Berlin 2026 additions: new `ConferenceId` enum entry, new `Sessionize.importReactCon2026()` (reusing the shared `importDroidconBerlin` helper), and registered in `Main.kt`'s import dispatcher.

## Test plan
- [x] `:backend:datastore:compileKotlinJvm` and `:backend:service-import:compileKotlinJvm` pass
- [x] Verified the Sessionize view id (`ampchpg2`) is correctly scoped to reactCon's own sessions (69 sessions across reactCon Stage 1-3 + shared unconference roundtables), not the full multi-track event feed
- [ ] Requires a backend deploy + running the import (`curl --data "" https://confetti-app.dev/update/reactcon2026`) before this conference appears in the app