### PR TITLE
Add merged "next.app devCon Berlin 2026" conference

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -53,6 +53,7 @@ enum class ConferenceId(val id: String) {
     SwiftCon2026("swiftcon2026"),
     FlutterCon2026("fluttercon2026"),
     ReactCon2026("reactcon2026"),
+    NextAppDevConBerlin2026("nextappdevconberlin2026"),
     ;
 
     companion object {

--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/ConferenceId.kt
@@ -49,10 +49,6 @@ enum class ConferenceId(val id: String) {
     KotlinConf2026("kotlinconf2026"),
     AndroidMakers2026("androidmakers2026"),
     DroidconUSA2026("droidconusa2026"),
-    DroidconBerlin2026("droidconberlin2026"),
-    SwiftCon2026("swiftcon2026"),
-    FlutterCon2026("fluttercon2026"),
-    ReactCon2026("reactcon2026"),
     NextAppDevConBerlin2026("nextappdevconberlin2026"),
     ;
 

--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
@@ -328,6 +328,16 @@ class DataStore {
     }
 
 
+    fun deleteConfig(conf: String) {
+        log("deleteConfig")
+        datastore.delete(
+            keyFactory
+                .setKind(KIND_CONFIG)
+                .addAncestor(PathElement.of(KIND_CONF, conf))
+                .newKey(THE_CONFIG)
+        )
+    }
+
     fun readConfigs(orderBy: DOrderBy): List<DConfig> {
         log("readConfig")
         val query: EntityQuery? = Query.newEntityQueryBuilder()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -21,6 +21,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 
@@ -57,6 +58,11 @@ suspend fun main(args: Array<String>) {
             post("/update/{conf}") {
                 val result = update(call.parameters["conf"])
                 call.respondText("$result sessions updated", status = HttpStatusCode.OK)
+            }
+            delete("/config/{conf}") {
+                val conf = call.parameters["conf"]!!
+                DataStore().deleteConfig(conf)
+                call.respondText("$conf config deleted", status = HttpStatusCode.OK)
             }
             post("/update-days") {
                 DataStore().updateDays()
@@ -152,10 +158,6 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.KotlinConf2026 -> Sessionize.importKotlinConf2026()
         ConferenceId.AndroidMakers2026 -> Sessionize.importAndroidMakers2026()
         ConferenceId.DroidconUSA2026 -> Sessionize.importDroidconUSA2026()
-        ConferenceId.DroidconBerlin2026 -> Sessionize.importDroidconBerlin2026()
-        ConferenceId.SwiftCon2026 -> Sessionize.importSwiftCon2026()
-        ConferenceId.FlutterCon2026 -> Sessionize.importFlutterCon2026()
-        ConferenceId.ReactCon2026 -> Sessionize.importReactCon2026()
         ConferenceId.NextAppDevConBerlin2026 -> Sessionize.importNextAppDevConBerlin2026()
         null -> error("")
     }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -156,6 +156,7 @@ private suspend fun update(conf: String?): Int {
         ConferenceId.SwiftCon2026 -> Sessionize.importSwiftCon2026()
         ConferenceId.FlutterCon2026 -> Sessionize.importFlutterCon2026()
         ConferenceId.ReactCon2026 -> Sessionize.importReactCon2026()
+        ConferenceId.NextAppDevConBerlin2026 -> Sessionize.importNextAppDevConBerlin2026()
         null -> error("")
     }
 }

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Main.kt
@@ -21,7 +21,6 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
-import io.ktor.server.routing.delete
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 
@@ -32,6 +31,7 @@ suspend fun main(args: Array<String>) {
         - update a conference: curl -X POST http://localhost:8080/update/droidconsf
         - update the days of a conference: curl -X POST http://localhost:8080/update-days
         - update the shortDescription: ./gradlew localRun --args updateShortDescription
+        - delete a conference's config: ./gradlew localRun --args "deleteConfig droidconsf"
     """.trimIndent()
     )
 
@@ -40,6 +40,12 @@ suspend fun main(args: Array<String>) {
         when (command) {
             "updateShortDescription" -> {
                 updateShortDescription()
+            }
+
+            "deleteConfig" -> {
+                val conf = args.getOrNull(1) ?: error("Usage: deleteConfig <conferenceId>")
+                DataStore().deleteConfig(conf)
+                println("Deleted config for $conf")
             }
 
             else -> error("Unrecognized command $command")
@@ -58,11 +64,6 @@ suspend fun main(args: Array<String>) {
             post("/update/{conf}") {
                 val result = update(call.parameters["conf"])
                 call.respondText("$result sessions updated", status = HttpStatusCode.OK)
-            }
-            delete("/config/{conf}") {
-                val conf = call.parameters["conf"]!!
-                DataStore().deleteConfig(conf)
-                call.respondText("$conf config deleted", status = HttpStatusCode.OK)
             }
             post("/update-days") {
                 DataStore().updateDays()

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -448,62 +448,6 @@ object Sessionize {
         )
     }
 
-    suspend fun importDroidconBerlin2026(): Int {
-        return importDroidconBerlin(
-            ConferenceId.DroidconBerlin2026.id,
-            "droidcon Berlin 2026",
-            "https://sessionize.com/api/v2/syf15uh9/view/All",
-            "0xFFFFBE29",
-            days = listOf(
-                LocalDate(2026, 10, 7),
-                LocalDate(2026, 10, 8),
-                LocalDate(2026, 10, 9)
-            )
-        )
-    }
-
-    suspend fun importSwiftCon2026(): Int {
-        return importDroidconBerlin(
-            ConferenceId.SwiftCon2026.id,
-            "swiftCon Berlin 2026",
-            "https://sessionize.com/api/v2/0ymtl17i/view/All",
-            "0xFFFF4600",
-            days = listOf(
-                LocalDate(2026, 10, 7),
-                LocalDate(2026, 10, 8),
-                LocalDate(2026, 10, 9)
-            )
-        )
-    }
-
-    suspend fun importFlutterCon2026(): Int {
-        return importDroidconBerlin(
-            ConferenceId.FlutterCon2026.id,
-            "flutterCon Berlin 2026",
-            "https://sessionize.com/api/v2/5jb6mz23/view/All",
-            "0xFF008BFF",
-            days = listOf(
-                LocalDate(2026, 10, 7),
-                LocalDate(2026, 10, 8),
-                LocalDate(2026, 10, 9)
-            )
-        )
-    }
-
-    suspend fun importReactCon2026(): Int {
-        return importDroidconBerlin(
-            ConferenceId.ReactCon2026.id,
-            "reactCon Berlin 2026",
-            "https://sessionize.com/api/v2/ampchpg2/view/All",
-            "0xFF8748F3",
-            days = listOf(
-                LocalDate(2026, 10, 7),
-                LocalDate(2026, 10, 8),
-                LocalDate(2026, 10, 9)
-            )
-        )
-    }
-
     suspend fun importNextAppDevConBerlin2026(): Int {
         return importDroidconBerlin(
             ConferenceId.NextAppDevConBerlin2026.id,

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -504,6 +504,20 @@ object Sessionize {
         )
     }
 
+    suspend fun importNextAppDevConBerlin2026(): Int {
+        return importDroidconBerlin(
+            ConferenceId.NextAppDevConBerlin2026.id,
+            "next.app devCon Berlin 2026",
+            "https://sessionize.com/api/v2/yak5yl8m/view/All",
+            "0xFF04723D",
+            days = listOf(
+                LocalDate(2026, 10, 7),
+                LocalDate(2026, 10, 8),
+                LocalDate(2026, 10, 9)
+            )
+        )
+    }
+
 
     private val businessDesignCenter = DVenue(
         id = "main",


### PR DESCRIPTION
## Summary
- droidcon, swiftCon, flutterCon, and reactCon Berlin 2026 (plus masCon, agentic codingCon, xr&game devsCon, and techlead summit) are all part of one underlying Sessionize event at CityCube Berlin, Oct 7-9 2026. Sessions are organized with a "Choose the PRIMARY event you are submitting for" category (single-select) plus a "Which other events is your talk relevant for?" category (multi-select, self-inclusive of the primary), verified directly against the Sessionize data.
- Imports the master feed (`sessionize.com/api/v2/yak5yl8m/view/All`, 447 sessions across all 9 tracks) as a single new conference `nextappdevconberlin2026`. The existing generic Sessionize import already flattens `categoryItems` into `Session.tags`, so every session ends up tagged with its track name(s) (e.g. `["droidCon", "agentic codingCon"]`) with zero backend mapping changes needed — this sets up a future client-side track filter without further backend work.
- Theme color `0xFF04723D` matches the nextappcon.com site logo (distinct from each sub-conference's own color).
- **Retires the 4 separate conferences** (`droidconberlin2026`, `swiftcon2026`, `fluttercon2026`, `reactcon2026`) now superseded by the merged one: removes their `ConferenceId` entries and import functions (can't be re-imported), and adds a `deleteConfig` admin command (backed by new `DataStore.deleteConfig`) to remove their Config entity from Datastore so they stop appearing in the app's conference list. This is a local-only CLI command (`./gradlew localRun --args "deleteConfig <conferenceId>"`), matching the existing `updateShortDescription` pattern — not exposed as a public HTTP route, since a destructive DELETE endpoint isn't something that should be reachable on the deployed service. Underlying session/speaker/room/venue data for those 4 ids is left in Datastore (harmless/unreachable once Config is gone) rather than cascade-deleted — no such tooling exists and the risk/effort isn't justified for this cleanup.

## Test plan
- [x] `:backend:datastore:compileKotlinJvm` and `:backend:service-import:compileKotlinJvm` pass
- [x] Verified via the raw Sessionize API that session counts per track sum correctly (droidCon 95, flutterCon 76, reactCon 69, swiftCon 54, agentic codingCon 44, xr&game devsCon 38, masCon 19, techlead summit 14, cross-over track 14) and that tag double-tagging works as described (a session's "other events" tags are self-inclusive of its primary event)
- [x] Verified no remaining references to the removed `ConferenceId` entries anywhere in the codebase
- [ ] Requires a backend deploy, then: run the import (`curl --data "" https://confetti-app.dev/update/nextappdevconberlin2026`) and locally run `deleteConfig` for each of the 4 old conference ids (requires local GCP Datastore credentials)
- [ ] Client-side track filter UI is a separate follow-up (not part of this PR)