### PR TITLE
Add per-track color support (backend + client)

### DIFF
--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/DataStore.kt
@@ -572,7 +572,10 @@ class DataStore {
             .set("timeZone", timeZone.toValue())
             .set("days", days.map { it.toString() }.toValue())
             .set("themeColor", themeColor.toValue())
-            .set("tracks", tracks.toValue())
+            .set(
+                "tracks",
+                tracks.map { it.toMap().toJsonElement().toString() }.toValue()
+            )
             .build()
     }
 
@@ -583,7 +586,23 @@ class DataStore {
             timeZone = getString("timeZone"),
             days = getList<StringValue>("days").map { LocalDate.parse(it.get()) },
             themeColor = getStringOrNull("themeColor"),
-            tracks = getListOrNull<StringValue>("tracks")?.map { it.get() } ?: emptyList()
+            tracks = getListOrNull<StringValue>("tracks").orEmpty().map {
+                Json.parseToJsonElement(it.get()).toAny().asMap.toTrack()
+            }
+        )
+    }
+
+    private fun DTrack.toMap(): Map<String, Any?> {
+        return mapOf(
+            "name" to name,
+            "color" to color,
+        )
+    }
+
+    private fun Map<String, Any?>.toTrack(): DTrack {
+        return DTrack(
+            name = get("name").asString,
+            color = get("color")?.asString,
         )
     }
 

--- a/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
+++ b/backend/datastore/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/datastore/model.kt
@@ -73,7 +73,12 @@ data class DConfig(
   val timeZone: String,
   val days: List<LocalDate> = emptyList(),
   val themeColor: String? = null,
-  val tracks: List<String> = emptyList()
+  val tracks: List<DTrack> = emptyList()
+)
+
+data class DTrack(
+  val name: String,
+  val color: String? = null,
 )
 
 /**

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/DataStoreDataSource.kt
@@ -24,7 +24,7 @@ fun DConfig.toConference(): Conference {
         timezone = timeZone,
         days = days,
         themeColor = themeColor,
-        tracks = tracks
+        tracks = tracks.map { Track(name = it.name, color = it.color) }
     )
 }
 

--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/graphql/model.kt
@@ -456,5 +456,10 @@ data class Conference(
     val timezone: String,
     val days: List<LocalDate>,
     val themeColor: String? = null,
-    val tracks: List<String> = emptyList()
+    val tracks: List<Track> = emptyList()
+)
+
+data class Track(
+    val name: String,
+    val color: String? = null,
 )

--- a/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
+++ b/backend/service-import/src/jvmMain/kotlin/dev/johnoreilly/confetti/backend/import/Sessionize.kt
@@ -11,6 +11,7 @@ import dev.johnoreilly.confetti.backend.datastore.DPartnerGroup
 import dev.johnoreilly.confetti.backend.datastore.DRoom
 import dev.johnoreilly.confetti.backend.datastore.DSession
 import dev.johnoreilly.confetti.backend.datastore.DSpeaker
+import dev.johnoreilly.confetti.backend.datastore.DTrack
 import dev.johnoreilly.confetti.backend.datastore.DVenue
 import dev.johnoreilly.confetti.backend.datastore.DataStore
 import kotlinx.datetime.LocalDate
@@ -395,7 +396,7 @@ object Sessionize {
         url: String,
         themeColor: String,
         days: List<LocalDate> = emptyList(),
-        tracks: List<String> = emptyList()
+        tracks: List<DTrack> = emptyList()
     ): Int {
         return writeData(
             getData(url),
@@ -465,15 +466,17 @@ object Sessionize {
             // reactcon, swiftcon, mascon, xr-mobile-showcase, agentic-coding-con,
             // techlead-summit). "cross-over track" is a Sessionize tagging artifact, not a
             // sub-conference attendees pick, so it's deliberately excluded here.
+            // Colors sampled directly from nextappcon.com/agenda's own topic filter dots, so
+            // Confetti's track colors match the official site rather than being invented here.
             tracks = listOf(
-                "droidCon",
-                "flutterCon",
-                "reactCon",
-                "swiftCon",
-                "masCon",
-                "xr&game devsCon",
-                "agentic codingCon",
-                "techlead summit",
+                DTrack("droidCon", "0xFF00FF4F"),
+                DTrack("flutterCon", "0xFF008BFF"),
+                DTrack("reactCon", "0xFFA26CFF"),
+                DTrack("swiftCon", "0xFFFF4600"),
+                DTrack("masCon", "0xFF29F3E9"),
+                DTrack("xr&game devsCon", "0xFFFF55E7"),
+                DTrack("agentic codingCon", "0xFFFFA400"),
+                DTrack("techlead summit", "0xFF7EBFF9"),
             )
         )
     }

--- a/shared/src/commonMain/graphql/Queries.graphql
+++ b/shared/src/commonMain/graphql/Queries.graphql
@@ -21,7 +21,10 @@ query GetConferenceData($first: Int! = 1000, $after: String = null) {
         timezone
         days
         themeColor
-        tracks
+        tracks {
+            name
+            color
+        }
     }
     venues {
         id

--- a/shared/src/commonMain/graphql/schema.graphqls
+++ b/shared/src/commonMain/graphql/schema.graphqls
@@ -63,7 +63,7 @@ type Conference {
 
   themeColor: String
 
-  tracks: [String!]!
+  tracks: [Track!]!
 }
 
 type Link {
@@ -238,6 +238,12 @@ type SpeakerConnection {
   nodes: [Speaker!]!
 
   pageInfo: PageInfo!
+}
+
+type Track {
+  name: String!
+
+  color: String
 }
 
 type Venue {

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/decompose/SessionsComponent.kt
@@ -396,7 +396,7 @@ sealed interface SessionsUiState {
         val now: LocalDateTime,
         val conference: String,
         val conferenceName: String,
-        val tracks: List<String>,
+        val tracks: List<GetConferenceDataQuery.Track>,
         val selectedTrack: String?,
         val venueLat: Double?,
         val venueLon: Double?,
@@ -415,7 +415,7 @@ sealed interface SessionsUiState {
 
 private data class ParsedConferenceData(
     val conferenceName: String,
-    val tracks: List<String>,
+    val tracks: List<GetConferenceDataQuery.Track>,
     val venueLat: Double?,
     val venueLon: Double?,
     val confDates: List<LocalDate>,

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/preview/MockData.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.preview
 
+import dev.johnoreilly.confetti.GetConferenceDataQuery
 import dev.johnoreilly.confetti.GetConferencesQuery
 import dev.johnoreilly.confetti.decompose.ConferencesComponent
 import dev.johnoreilly.confetti.decompose.SessionsUiState
@@ -180,7 +181,12 @@ val sessionsSuccessState: SessionsUiState.Success = SessionsUiState.Success(
     searchString = "",
     selectedSessionId = null,
     notificationsActive = false,
-    tracks = listOf("droidCon", "swiftCon", "flutterCon", "reactCon"),
+    tracks = listOf(
+        GetConferenceDataQuery.Track(__typename = "Track", name = "droidCon", color = "0xFF00FF4F"),
+        GetConferenceDataQuery.Track(__typename = "Track", name = "swiftCon", color = "0xFFFF4600"),
+        GetConferenceDataQuery.Track(__typename = "Track", name = "flutterCon", color = "0xFF008BFF"),
+        GetConferenceDataQuery.Track(__typename = "Track", name = "reactCon", color = "0xFFA26CFF"),
+    ),
     selectedTrack = null,
 )
 

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/TrackFilterRow.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/TrackFilterRow.kt
@@ -1,17 +1,25 @@
 package dev.johnoreilly.confetti.ui.sessions
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import dev.johnoreilly.confetti.GetConferenceDataQuery
 
 @Composable
 fun TrackFilterRow(
-    tracks: List<String>,
+    tracks: List<GetConferenceDataQuery.Track>,
     selectedTrack: String?,
     onTrackSelected: (String?) -> Unit,
 ) {
@@ -29,11 +37,32 @@ fun TrackFilterRow(
             )
         }
         items(tracks) { track ->
+            val dotColor = track.color?.toColorOrNull()
             FilterChip(
-                selected = selectedTrack == track,
-                onClick = { onTrackSelected(if (selectedTrack == track) null else track) },
-                label = { Text(track) },
+                selected = selectedTrack == track.name,
+                onClick = { onTrackSelected(if (selectedTrack == track.name) null else track.name) },
+                label = { Text(track.name) },
+                leadingIcon = dotColor?.let {
+                    {
+                        Box(
+                            modifier = Modifier
+                                .size(8.dp)
+                                .clip(CircleShape)
+                                .background(it)
+                        )
+                    }
+                },
             )
         }
+    }
+}
+
+/** Parses a "0xAARRGGBB" string (as used for [dev.johnoreilly.confetti.GetConferenceDataQuery.Config.themeColor]) into a [Color], or null if absent/malformed. */
+@OptIn(ExperimentalStdlibApi::class)
+private fun String.toColorOrNull(): Color? {
+    return try {
+        Color(hexToLong(HexFormat { number.prefix = "0x" }))
+    } catch (e: Exception) {
+        null
     }
 }


### PR DESCRIPTION
## Summary
- `tracks` was a flat `List<String>` on `Conference`, with no room for per-track metadata, so there was no way to color-code sub-conference tracks in the UI.
- Introduces a `Track { name, color }` GraphQL type, following the exact same pattern already used for `Conference.themeColor`: hex-string color, plumbed through the datastore model, Firestore serialization, GraphQL service model/mapping, and the Sessionize import config.
- next.app's track colors are seeded with values **sampled directly from nextappcon.com/agenda's own topic filter dots** (via its shadow-DOM `session-schedule` widget), so Confetti's colors match the official site rather than being guessed.
- Client: `TrackFilterRow` now renders a colored dot per track chip (mirroring nextapp's own filter UI) — the minimal consumer needed to prove the field flows end-to-end. Per-session-card accent coloring is left as a natural follow-up now that the data is available.

## Backend changes
- `schema.graphqls`: new `type Track { name: String!, color: String }`; `Conference.tracks` is now `[Track!]!`
- `backend/datastore`: `DConfig.tracks: List<DTrack>`, Firestore round-trip serialized as JSON strings (same idiom already used for `DSpeaker.links`)
- `backend/service-graphql`: new `Track` model + `DataStoreDataSource` mapping
- `backend/service-import/Sessionize.kt`: next.app's `tracks` list now carries real colors

## Test plan
- [x] `:backend:datastore:compileKotlinJvm`, `:backend:service-graphql:compileKotlin`, `:backend:service-import:compileKotlinJvm` all compile clean
- [x] `:shared:generateServiceApolloSources` regenerates the `Track` type correctly from the updated schema/query
- [x] `:shared:compileKotlinJvm`, `:shared:compileAndroidMain`, `:shared:compileKotlinIosArm64`, `:shared:compileKotlinWasmJs` all compile clean
- [ ] After deploy, re-trigger the Sessionize import for next.app devCon Berlin 2026 (`curl --data "" https://confetti-app.dev/update/<conferenceId>`) to populate colors for the already-imported conference, then verify the filter chips in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCB1UHcVvfoWWAZQU5yY3C