### PR TITLE
Add previews for recent mobile UI changes

### DIFF
--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/AndroidScreenPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/AndroidScreenPreviews.kt
@@ -39,7 +39,7 @@ import dev.johnoreilly.confetti.ui.speakers.SpeakerDetailsView
 )
 @Composable
 internal fun AndroidSessionDetailPreview() {
-    ConfettiTheme {
+    CatalogTheme {
         SessionDetailViewShared(
             conference = "kotlinconf2023",
             session = sessionDetails,
@@ -70,7 +70,7 @@ internal fun AndroidSessionDetailPreview() {
 )
 @Composable
 internal fun AndroidSpeakerDetailsPreview() {
-    ConfettiTheme {
+    CatalogTheme {
         SpeakerDetailsView(
             conference = "kotlinconf2023",
             speaker = johnOreillySpeaker,

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/ComponentCatalog.kt
@@ -55,7 +55,7 @@ import dev.johnoreilly.confetti.ui.speakers.SpeakerItemView
 
 /** Confetti's brand theme with dynamic (Material You) theming disabled, so the catalog is deterministic. */
 @Composable
-private fun CatalogTheme(content: @Composable () -> Unit) {
+internal fun CatalogTheme(content: @Composable () -> Unit) {
     ConfettiTheme(disableDynamicTheming = true) {
         // The catalog renders with LocalInspectionMode = true, where Coil never executes a network
         // request — so speaker/venue AsyncImages would sit blank. A preview handler supplies the

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
@@ -11,6 +11,7 @@ import dev.johnoreilly.confetti.decompose.ConferenceAgentComponent
 import dev.johnoreilly.confetti.decompose.ConferencesComponent
 import dev.johnoreilly.confetti.preview.previewConferenceListState
 import dev.johnoreilly.confetti.ui.account.AccountView
+import dev.johnoreilly.confetti.ui.settings.SettingsPreviewContent
 
 /**
  * Android-discoverable previews for the mobile UI work landed in August 2026. Shared-source
@@ -72,6 +73,26 @@ fun OnboardingHazePreview() {
             onNotificationsToggle = {},
             onComplete = {},
         )
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun OnboardingSignInStepPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        OnboardingSignInStep(
+            visible = true,
+            user = null,
+            onSignInClicked = {},
+        )
+    }
+}
+
+@RecentMobileScreen
+@Composable
+fun SettingsScreenPreview() {
+    ConfettiTheme(disableDynamicTheming = true) {
+        SettingsPreviewContent()
     }
 }
 

--- a/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
+++ b/androidApp/src/main/java/dev/johnoreilly/confetti/ui/RecentMobileUiPreviews.kt
@@ -37,7 +37,7 @@ annotation class RecentMobileScreen
 @RecentMobileScreen
 @Composable
 fun HazeBottomNavigationPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         HazeBottomBarPreviewContent()
     }
 }
@@ -58,7 +58,7 @@ fun HazeBottomNavigationPreview() {
 )
 @Composable
 fun HazeBottomNavigationDetailPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         HazeBottomBarContrastPreviewContent()
     }
 }
@@ -66,7 +66,7 @@ fun HazeBottomNavigationDetailPreview() {
 @RecentMobileScreen
 @Composable
 fun OnboardingHazePreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         OnboardingContent(
             notificationsEnabled = false,
             supportsNotifications = true,
@@ -79,7 +79,7 @@ fun OnboardingHazePreview() {
 @RecentMobileScreen
 @Composable
 fun OnboardingSignInStepPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         OnboardingSignInStep(
             visible = true,
             user = null,
@@ -91,7 +91,7 @@ fun OnboardingSignInStepPreview() {
 @RecentMobileScreen
 @Composable
 fun SettingsScreenPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         SettingsPreviewContent()
     }
 }
@@ -99,7 +99,7 @@ fun SettingsScreenPreview() {
 @RecentMobileScreen
 @Composable
 fun AccountScreenPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         AccountView(
             state = AccountUiState.Success(
                 conferenceName = "KotlinConf 2026",
@@ -119,7 +119,7 @@ fun AccountScreenPreview() {
 @RecentMobileScreen
 @Composable
 fun AssistantConversationPreview() {
-    ConfettiTheme(disableDynamicTheming = true) {
+    CatalogTheme {
         ConferenceAgentView(
             component = PreviewConferenceAgentComponent(),
             onCloseClick = {},

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/settings/SettingsUI.kt
@@ -660,6 +660,12 @@ private fun ActionSettingsRow(
 @MobilePreviews
 @Composable
 private fun SettingsScreenPreview() {
+    SettingsPreviewContent()
+}
+
+/** Stable sample state used by platform preview catalogs for the redesigned settings screen. */
+@Composable
+fun SettingsPreviewContent() {
     SettingsUI(
         userEditableSettings = UserEditableSettings(
             darkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
@@ -682,5 +688,4 @@ private fun SettingsScreenPreview() {
         popBack = {}
     )
 }
-
 


### PR DESCRIPTION
## Summary
- add Android-discoverable light and dark previews for the onboarding sign-in step
- add Android-discoverable light and dark previews for the redesigned Settings screen
- reuse the shared Settings fixture and preserve existing Haze navigation and onboarding coverage

## Verification
- compose-preview list --module androidApp
- rendered Haze, SettingsScreenPreview, and OnboardingSignInStepPreview filters
- visually inspected the generated light and dark PNGs