### PR TITLE
Support preview diff comments for fork PRs

### DIFF
--- a/.github/workflows/compose-preview-publish.yml
+++ b/.github/workflows/compose-preview-publish.yml
@@ -1,0 +1,71 @@
+name: Compose Preview Publish
+
+# Trusted half of the fork-PR preview handoff. It checks out only the base
+# repository's default branch and treats downloaded fork artifacts as data.
+# Never add a step here that executes files from the handoff artifact.
+on:
+  workflow_run:
+    workflows: [Compose Preview]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+# Let an in-flight publisher finish; the next run then supersedes its shared
+# preview branch and sticky comment with the newer head's output.
+concurrency:
+  group: compose-preview-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish fork preview comment
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - id: pr
+        run: echo "number=$(cat _compose_preview_handoff/_pr_number)" >> "$GITHUB_OUTPUT"
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.61.2
+        with:
+          phase: publish
+          handoff-dir: _compose_preview_handoff
+          pr-number: ${{ steps.pr.outputs.number }}
+
+  publish-a11y:
+    name: Publish fork a11y comment
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: compose-preview-a11y-handoff
+          path: _compose_preview_a11y_handoff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - id: pr
+        run: echo "number=$(cat _compose_preview_a11y_handoff/_pr_number)" >> "$GITHUB_OUTPUT"
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.61.2
+        with:
+          phase: publish
+          handoff-dir: _compose_preview_a11y_handoff
+          pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -11,13 +11,10 @@ name: Compose Preview
 # rather than the sum. Notifications are skipped (Confetti has no notification
 # previews).
 #
-# NOTE: pushing the compose-preview/* baseline + PR branches needs a writable
-# GITHUB_TOKEN, which only same-repo events get. Fork PRs (e.g. yschimke ->
-# joreilly/Confetti) receive a read-only token, so the render would succeed but
-# the branch push 403s and fails the job. Both jobs are therefore gated to run
-# on push / workflow_dispatch and *same-repo* PRs only; external-fork PRs are
-# skipped (no write token to post a comment with anyway). On joreilly/Confetti
-# the default token already has contents:write, so its own PRs render + diff.
+# Fork PRs use an explicit two-workflow handoff. This workflow renders their
+# untrusted code with a read-only token and uploads data-only artifacts. The
+# trusted Compose Preview Publish workflow consumes those artifacts without
+# executing fork code, pushes the render branches, and posts sticky comments.
 
 # `paths-ignore` keeps the two 45-minute render jobs off changes that cannot
 # reach a Compose @Preview: the GraphQL/Ktor backend, the iOS app, the landing
@@ -50,9 +47,7 @@ on:
       - '**.md'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: compose-preview-${{ github.event.pull_request.number || github.ref }}
@@ -61,13 +56,15 @@ concurrency:
 jobs:
   apply:
     name: Render previews (baseline or PR comment, auto-selected)
-    # Skip external-fork PRs: they get a read-only token, so the render succeeds
-    # but the compose-preview/* branch push 403s and fails the job.
+    # Trusted path: same-repository PRs and baseline runs publish inline.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       # BuildFetch remote cache (see settings.gradle.kts). On main-branch runs ON_CI=true and the RW
       # token seed the cache from the render/compile task outputs; on PRs ON_CI is false so the same
@@ -105,12 +102,15 @@ jobs:
 
   a11y:
     name: A11y previews
-    # Same fork-token gate as the apply job above.
+    # Trusted path: same-repository PRs and baseline runs publish inline.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       # BuildFetch remote cache (see settings.gradle.kts). On main-branch runs ON_CI=true and the RW
       # token seed the cache from the render/compile task outputs; on PRs ON_CI is false so the same
@@ -137,3 +137,86 @@ jobs:
           catalog-key: composeai-preview
           missing-renders: warn
           only: a11y
+
+  render-fork:
+    name: Render previews (fork handoff)
+    # Keep this separate from the write-scoped job above. Some organizations
+    # allow write tokens for fork workflows; job-level read permission keeps
+    # untrusted Gradle code read-only even under that setting.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      ON_CI: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          lfs: 'true'
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+      - name: Warm Gradle wrapper
+        run: ./gradlew help
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.61.2
+        with:
+          phase: render
+          handoff-dir: _compose_preview_handoff
+          cli-version: catalog
+          catalog-key: composeai-preview
+          missing-renders: warn
+          only: compose
+      - uses: actions/upload-artifact@v7
+        with:
+          name: compose-preview-handoff
+          path: _compose_preview_handoff/
+          if-no-files-found: error
+          retention-days: 1
+
+  a11y-fork:
+    name: A11y previews (fork handoff)
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      ON_CI: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          lfs: 'true'
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+      - name: Warm Gradle wrapper
+        run: ./gradlew help
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.61.2
+        with:
+          phase: render
+          handoff-dir: _compose_preview_a11y_handoff
+          cli-version: catalog
+          catalog-key: composeai-preview
+          missing-renders: warn
+          only: a11y
+      - uses: actions/upload-artifact@v7
+        with:
+          name: compose-preview-a11y-handoff
+          path: _compose_preview_a11y_handoff/
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Summary
- split fork preview rendering from privileged publishing using the apply action handoff phases
- keep Compose and accessibility rendering parallel with separate one-day artifacts
- enforce read-only job permissions while executing fork Gradle code
- publish only successful fork runs from trusted base-branch code

## Security model
The `pull_request` workflow executes untrusted fork code with `contents: read` only. The `workflow_run` publisher has write permissions but checks out the default branch and treats the downloaded handoff as data; it never executes files from the fork artifact.

## Verification
- parsed both workflow files as YAML
- `git diff --check`
- configuration follows the compose-ai-tools v1.61.2 Fork PRs phase=render/phase=publish pattern