### PR TITLE
Show session track color as a room chip outline

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/sessions/SessionItemView.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.confetti.ui.sessions
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -32,8 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -159,17 +158,7 @@ private fun TalkSessionItemView(
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = { sessionSelected(session.id) })
-            .let { m ->
-                // A left-edge accent in the session's track color, mirroring nextappcon.com's own
-                // agenda - sessions with no matching track keep the plain row look instead of
-                // guessing at a fallback color. drawWithContent (not drawBehind) so the accent
-                // paints on top of ListItem's own background fill instead of underneath it.
-                if (trackColor == null) m else m.drawWithContent {
-                    drawContent()
-                    drawRect(color = trackColor, size = Size(3.dp.toPx(), size.height))
-                }
-            },
+            .clickable(onClick = { sessionSelected(session.id) }),
         headlineContent = {
             Text(
                 text = session.title,
@@ -197,9 +186,15 @@ private fun TalkSessionItemView(
                         modifier = Modifier.padding(top = 8.dp)
                     ) {
                         session.room?.let { room ->
+                            // Outlined (not filled) in the session's track color, mirroring
+                            // nextappcon.com's own agenda, without needing per-track contrast
+                            // tuning a filled chip would (dark text over a bright track color
+                            // like agentic codingCon's orange reads fine; white text wouldn't).
+                            // Sessions with no matching track keep today's plain chip look.
                             Surface(
                                 shape = RoundedCornerShape(6.dp),
                                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                border = trackColor?.let { BorderStroke(1.dp, it) },
                             ) {
                                 Text(
                                     text = room.name,


### PR DESCRIPTION
## Summary

Replaces the left-edge track-color accent bar on schedule session rows with a 1dp outline in the track color on the room chip.

- Drops the `drawWithContent` accent rect (and its `drawWithContent` / `Size` imports) from `TalkSessionItemView`
- Adds `border = trackColor?.let { BorderStroke(1.dp, it) }` to the room chip `Surface`
- An outline avoids the per-track contrast tuning a filled chip would need (dark text over a bright track color like agentic codingCon's orange reads fine; white text wouldn't)
- Sessions with no matching track are unchanged — plain row, plain chip, no fallback color

