### PR TITLE
Update Koog to 1.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,8 +57,8 @@ buildkonfig = "0.22.0"
 roborazzi = "1.73.0"
 screenshot = "0.0.1-alpha16"
 composeai-preview = "1.61.2"
-koogAgents = "1.1.1"
-koogPromptExecutorAll = "1.1.1-beta"
+koogAgents = "1.2.0"
+koogPromptExecutorAll = "1.2.0-beta"
 
 
 [libraries]
@@ -252,7 +252,7 @@ koog-prompt-executor-llms-all = { module = "ai.koog:prompt-executor-llms-all", v
 koog-prompt-executor-google-client = { module = "ai.koog:prompt-executor-google-client", version.ref = "koogPromptExecutorAll" }
 koog-http-client-ktor = { module = "ai.koog:http-client-ktor", version.ref = "koogAgents" }
 koog-embeddings-base = { module = "ai.koog:embeddings-base", version.ref = "koogAgents" }
-koog-rag-base = { module = "ai.koog:rag-base", version.ref = "koogPromptExecutorAll" }
+koog-rag-base = { module = "ai.koog:rag-base", version.ref = "koogAgents" }
 koog-rag-vector = { module = "ai.koog:rag-vector", version.ref = "koogPromptExecutorAll" }
 
 [bundles]


### PR DESCRIPTION
## Summary

Moves the whole Koog dependency set to 1.2.0, superseding Renovate's #1887 (which bumped `rag-base` alone and failed CI).

- `koogAgents` 1.1.1 → 1.2.0
- `koogPromptExecutorAll` 1.1.1-beta → 1.2.0-beta
- Repoints `koog-rag-base` from the `koogPromptExecutorAll` ref to `koogAgents`

That last one is a latent bug, not just a bump. Koog splits its publishing across two tracks — `koog-agents`, `http-client-ktor`, `embeddings-base` and `rag-base` publish plain versions, while `prompt-executor-*` and `rag-vector` publish `-beta`. `koog-rag-base` was pointed at the beta ref, so it named `rag-base:1.1.1-beta`, which does not exist on Maven Central (the published list goes `... 1.0.0-preview7, 1.1.1, 1.2.0`). The build only worked because `koog-agents` pulls `rag-base:1.1.1` in transitively and Gradle's conflict resolution picked the real version over the phantom one. Bumping `rag-base` in isolation — what #1887 did — removes that cover and is the likely reason it failed.

No source changes were needed; there are no API breaks in 1.2.0 for how this repo uses Koog.

## Test plan

Verified locally before pushing:

- [x] `:shared:compileKotlinJvm` — success
- [x] `:shared:compileKotlinIosSimulatorArm64` — success (forced with `--rerun-tasks --no-build-cache`; 5.2 MB klib written)
- [x] `:shared:compileAndroidMain` — success
- [x] Resolved versions confirmed on `jvmRuntimeClasspath`: `ragbase:1.2.0`, `ragvector:1.2.0beta`, `agentscore:1.2.0`
- [ ] CI: full matrix (the `shared` module's only JVM test is `@Ignore`d, so local test runs prove nothing here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Syr6Ss5YAKH69qjbVUe4