### PR TITLE
Fix desktop crash on startup from removed Compose LocalWindow

### DIFF
--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/ui/App.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -85,6 +84,7 @@ import dev.johnoreilly.confetti.ui.settings.SettingsUI
 import dev.johnoreilly.confetti.ui.speakers.SpeakerDetailsUI
 import dev.johnoreilly.confetti.ui.speakers.SpeakersUI
 import dev.johnoreilly.confetti.ui.venue.VenueUI
+import dev.johnoreilly.confetti.utils.currentWindowSizeClass
 import dev.johnoreilly.confetti.utils.isExpanded
 import org.jetbrains.compose.resources.stringResource
 
@@ -106,7 +106,7 @@ fun App(component: DefaultAppComponent) {
 @OptIn(ExperimentalDecomposeApi::class, ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ConferenceView(component: ConferenceComponent) {
-    val windowSizeClass = calculateWindowSizeClass()
+    val windowSizeClass = currentWindowSizeClass()
     ConferenceMaterialThemeFromSettings(component.conferenceThemeColor) {
         ChildStack(
             stack = component.stack,
@@ -146,7 +146,7 @@ fun ConferenceView(component: ConferenceComponent) {
                 is ConferenceComponent.Child.Search -> {
                     SearchUI(
                         component = child.component,
-                        windowSizeClass = calculateWindowSizeClass(),
+                        windowSizeClass = currentWindowSizeClass(),
                         onBackClick = component::onBackClicked,
                     )
                 }
@@ -159,7 +159,7 @@ fun ConferenceView(component: ConferenceComponent) {
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun HomeView(component: HomeComponent) {
-    val windowSizeClass = calculateWindowSizeClass()
+    val windowSizeClass = currentWindowSizeClass()
     val shouldShowNavRail = windowSizeClass.isExpanded
     val snackbarHostState = remember { SnackbarHostState() }
     val hazeState = remember { HazeState() }

--- a/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/UIUtils.kt
+++ b/shared/src/commonMain/kotlin/dev/johnoreilly/confetti/utils/UIUtils.kt
@@ -1,7 +1,12 @@
 package dev.johnoreilly.confetti.utils
 
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.toSize
 
 val WindowSizeClass.isExpanded: Boolean
     get() = widthSizeClass == WindowWidthSizeClass.Expanded
@@ -9,3 +14,20 @@ val WindowSizeClass.isExpanded: Boolean
 
 val WindowSizeClass.isCompact: Boolean
     get() = widthSizeClass == WindowWidthSizeClass.Compact
+
+
+/**
+ * Replacement for material3-window-size-class-multiplatform's own
+ * `calculateWindowSizeClass()`. Its desktop actual reaches for
+ * `androidx.compose.ui.window.LocalWindow`, which Compose Multiplatform 1.12 removed, so calling it
+ * throws NoClassDefFoundError at first composition on desktop. Deriving the size from
+ * LocalWindowInfo instead uses only common Compose UI API, so one implementation serves every
+ * target.
+ */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Composable
+fun currentWindowSizeClass(): WindowSizeClass =
+    WindowSizeClass.calculateFromSize(
+        size = LocalWindowInfo.current.containerSize.toSize(),
+        density = LocalDensity.current,
+    )


### PR DESCRIPTION
## Summary

The Compose desktop client crashed at first composition:

```
java.lang.NoClassDefFoundError: androidx/compose/ui/window/LocalWindowKt
  at ...windowsizeclass.WindowSizeClass_desktopKt.calculateWindowSizeClass(WindowSizeClass.desktop.kt:25)
  at dev.johnoreilly.confetti.ui.AppKt.ConferenceView(App.kt:109)
```

`dev.chrisbanes.material3:material3-window-size-class-multiplatform:0.5.0`'s **desktop** actual for `calculateWindowSizeClass()` calls `androidx.compose.ui.window.LocalWindow`, which Compose Multiplatform 1.12 removed — verified that `ui-desktop-1.12.0.jar` contains no `window/LocalWindow` entry. 0.5.0 is that library's latest release (`0.1.0 … 0.3.2, 0.5.0-alpha01 … 0.5.0`), so there's no version to bump to.

The fix adds a `currentWindowSizeClass()` helper in `UIUtils.kt` that derives the size from `LocalWindowInfo` + `LocalDensity` — both common Compose UI API — and passes it to the library's own public `WindowSizeClass.calculateFromSize(size, density)`. Keeping the `WindowSizeClass` type means the ~10 files that thread it as a parameter are untouched; only the 3 call sites in `App.kt` change.

**Why CI never caught this:** nothing in CI launches the desktop app, and the Android actual goes through the Activity rather than `LocalWindow`, so every existing job stays green.

**Scope note:** `App.kt` is `commonMain`, so Android and iOS now go through this path too. Neither was broken before — this changes how they obtain the size, not the resulting size class.

## Test plan

- [x] `:compose-desktop:run` — app launches, window renders the schedule, zero `NoClassDefFoundError` (screenshot verified: conference header, track filter chips, session list, bottom nav all present)
- [x] `:shared:compileAndroidMain` — success
- [x] `:shared:compileKotlinIosSimulatorArm64` — success
- [x] `:shared:compileKotlinJvm` — success
- [ ] CI: full matrix, incl. Android app + Wear, which I did not build locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Syr6Ss5YAKH69qjbVUe4