### PR TITLE
Fix Backend Deploy: pin google-beta and set the LB scheme explicitly

### DIFF
--- a/backend/terraform/main.tf
+++ b/backend/terraform/main.tf
@@ -3,6 +3,16 @@ terraform {
     bucket = "confetti-tfstate"
     prefix = "terraform/state"
   }
+
+  # Pinned deliberately. With no constraint here and no committed .terraform.lock.hcl, every CI
+  # run downloaded whatever google-beta was newest, so a change to a provider *default* could
+  # (and did) break apply with no commit to this repo - see load_balancing_scheme below.
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 8.0"
+    }
+  }
 }
 
 variable "region" {
@@ -105,6 +115,11 @@ resource "google_compute_backend_service" "router" {
   enable_cdn                      = true
   timeout_sec                     = 10
   connection_draining_timeout_sec = 10
+  # Set explicitly: the provider default moved to EXTERNAL_MANAGED, which GCP rejects as an
+  # in-place change ("Cannot change the load balancing scheme until the migration state is
+  # set to TEST_ALL_TRAFFIC"). The forwarding rules further down are EXTERNAL, so the
+  # backend services have to match.
+  load_balancing_scheme           = "EXTERNAL"
 
   custom_request_headers  = ["Host: ${google_compute_global_network_endpoint.router.fqdn}"]
   custom_response_headers = ["X-Cache-Hit: {cdn_cache_status}"]
@@ -131,9 +146,14 @@ resource "google_compute_backend_service" "router" {
 }
 
 resource "google_compute_backend_service" "graphql" {
-  provider   = google-beta
-  name       = "graphql"
-  enable_cdn = true
+  provider              = google-beta
+  name                  = "graphql"
+  enable_cdn            = true
+  # Set explicitly: the provider default moved to EXTERNAL_MANAGED, which GCP rejects as an
+  # in-place change ("Cannot change the load balancing scheme until the migration state is
+  # set to TEST_ALL_TRAFFIC"). The forwarding rules further down are EXTERNAL, so the
+  # backend services have to match.
+  load_balancing_scheme = "EXTERNAL"
 
   custom_response_headers = ["X-Cache-Hit: {cdn_cache_status}"]
 
@@ -160,9 +180,14 @@ resource "google_compute_backend_service" "graphql" {
 }
 
 resource "google_compute_backend_service" "import" {
-  provider   = google-beta
-  name       = "import"
-  enable_cdn = true
+  provider              = google-beta
+  name                  = "import"
+  enable_cdn            = true
+  # Set explicitly: the provider default moved to EXTERNAL_MANAGED, which GCP rejects as an
+  # in-place change ("Cannot change the load balancing scheme until the migration state is
+  # set to TEST_ALL_TRAFFIC"). The forwarding rules further down are EXTERNAL, so the
+  # backend services have to match.
+  load_balancing_scheme = "EXTERNAL"
 
   custom_response_headers = ["X-Cache-Hit: {cdn_cache_status}"]
 


### PR DESCRIPTION
## Summary

Backend Deploy has failed on `main` since **2026-08-31** with no commit causing it — runs on 08-31, 09-01, 09-06 and 09-11 all die the same way:

```
Error 400: Invalid value for field 'resource.loadBalancingScheme': 'EXTERNAL_MANAGED'.
Cannot change the load balancing scheme until the migration state is set to TEST_ALL_TRAFFIC.
```

...once each for `router`, `graphql` and `import`, after a plan of `0 to add, 3 to change, 0 to destroy`.

**Cause.** Those three `google_compute_backend_service` resources never set `load_balancing_scheme`, and `main.tf` had no `required_providers` constraint and no committed `.terraform.lock.hcl` — so every CI run downloaded whatever `google-beta` was newest. When the provider's default for that field became `EXTERNAL_MANAGED`, the config began planning a change against live infra that is still `EXTERNAL`, which GCP refuses to do in place. The repo broke itself with no commit; that's what an unpinned provider plus no lockfile buys.

**Fix.**
1. `load_balancing_scheme = "EXTERNAL"` on the three services. The two `google_compute_global_forwarding_rule` resources already pin `EXTERNAL`, so the backend services have to match — this restores the intended classic-ALB config rather than changing intent.
2. `required_providers` pinning `google-beta` to `~> 8.0`, so a default cannot move underneath the repo again.

## Test plan

- [x] Braces/brackets balanced; 26 resource blocks unchanged; all 5 `load_balancing_scheme` values are `EXTERNAL`; HCL alignment correct
- [ ] **`terraform validate` / `plan` NOT run** — terraform is not installed on the machine this was written on

### Please read before merging

I could not run a plan, so the key claim is reasoned, not observed: `terraform plan` should go from `0 to add, 3 to change, 0 to destroy` to **no changes**, because the config would then match live infra. **If the live services are not actually `EXTERNAL`, this swaps one mismatch for another.** Worth confirming with `gcloud compute backend-services describe router --global --format='value(loadBalancingScheme)'` (and the same for `graphql`, `import`) before merging.

Two open decisions:

- **The `~> 8.0` pin is a judgment call.** Latest is 8.2.0, but the last *successful* apply predates 2026-08-31 and may have run 7.x. The evidence for 8.x being otherwise compatible is that the failing plan showed only those 3 changes and nothing else drifting — inference, not proof. `~> 7.0` is the more conservative choice.
- **A committed `.terraform.lock.hcl` would close this properly.** Generating one needs `terraform init` against the real GCS backend, so it's left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Syr6Ss5YAKH69qjbVUe4