### PR TITLE
Skip the Gradle framework build when the IDE already ran it

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary

Adds the `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` guard to the `iosApp` run script build phase. The phase previously ran Gradle unconditionally:

```sh
cd "$SRCROOT/.."
./gradlew :shared:embedAndSignAppleFrameworkForXcode
```

The Kotlin IntelliJ / Android Studio plugin sets `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` when it is driving the build and has already produced the shared framework. Without the guard, the phase invokes `:shared:embedAndSignAppleFrameworkForXcode` a second time on every IDE-driven build. This is the script the KMP tooling generates.

No behaviour change for `xcodebuild` on the command line or in CI — the variable is unset there, so the guard falls through and Gradle runs exactly as before.

## Test plan

- [ ] CI: iOS job builds and tests as normal (the guard is inert there, since `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` is not set)
- [ ] Local: building `iosApp` from Android Studio / IntelliJ no longer re-runs the Gradle framework task

Note: I verified the diff and the resulting script text, but did not build `iosApp` from Xcode or the IDE locally — CI covers the command-line path, and the IDE path is the one worth a quick manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Syr6Ss5YAKH69qjbVUe4