### PR TITLE
Always send Access-Control-Allow-Origin so CDN-cached responses stay usable

### DIFF
--- a/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
+++ b/backend/service-graphql/src/main/kotlin/dev/johnoreilly/confetti/backend/DefaultApplication.kt
@@ -33,6 +33,9 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationListener
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.client.reactive.JdkClientHttpConnector
 import org.springframework.http.codec.ServerCodecConfigurer
@@ -43,6 +46,8 @@ import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.server.*
 import org.springframework.web.reactive.result.view.ViewResolver
+import org.springframework.web.server.WebFilter
+import reactor.core.publisher.Mono
 import java.net.http.HttpClient
 import kotlin.jvm.optionals.getOrNull
 
@@ -60,6 +65,36 @@ class DefaultApplication {
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", corsConfig)
         return CorsWebFilter(source)
+    }
+
+    /**
+     * Emit Access-Control-Allow-Origin even when the request carries no Origin header.
+     *
+     * Apollo sends persisted queries as GETs, and those responses are `public, max-age=1800`, so
+     * Cloud CDN caches them - under a key of {protocol, host, query string, conference header}
+     * that does NOT include Origin (see backend/terraform/main.tf). [corsWebFilter] follows the
+     * CORS spec and only adds the header when the request has an Origin, which browsers send and
+     * the mobile apps do not. So whichever client warmed a cache entry decided, for the next 30
+     * minutes, whether browsers could read it: an entry warmed by a mobile request had no
+     * Access-Control-Allow-Origin, and every browser served that copy had the response blocked,
+     * silently leaving the web client with no data.
+     *
+     * The policy above is "*" regardless of caller, so emitting it unconditionally makes every
+     * cached copy valid for every client. Only fills in a header [corsWebFilter] did not already
+     * set, so genuine Origin requests keep their spec-compliant handling.
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    fun cacheSafeCorsHeaderFilter(): WebFilter = WebFilter { exchange, chain ->
+        exchange.response.beforeCommit {
+            exchange.response.headers.apply {
+                if (getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN) == null) {
+                    set(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                }
+            }
+            Mono.empty()
+        }
+        chain.filter(exchange)
     }
 
     @Bean


### PR DESCRIPTION
## Summary

Fixes the web client intermittently showing no data — empty conference list, empty schedule — with no error in the UI, recovering on its own after a while.

**Cause.** Apollo sends persisted queries as `GET`s, and those responses are `public, max-age=1800`, so Cloud CDN caches them. The cache key is `{protocol, host, query string, conference header}` and **does not include `Origin`** (`backend/terraform/main.tf`, the `graphql` backend service's `cache_key_policy`). `CorsWebFilter` correctly follows the CORS spec and only emits `Access-Control-Allow-Origin` when the request *has* an `Origin` — which browsers send and the mobile apps do not.

So whichever client warms a cache entry decides, for the next 30 minutes, whether browsers can read it:

| Cache entry warmed by | Cached copy has CORS header | Browser result |
|---|---|---|
| A browser (sends `Origin`) | yes | works |
| A mobile app / server (no `Origin`) | **no** | response blocked, silent empty screen |

The mobile apps poll far more often than anyone opens the web client, so they usually win that race — which is why the web client is the visible victim of traffic it doesn't generate, and why it comes and goes on a ~30 minute cycle.

Measured on production before the fix:

```
# APQ GET, hash registered -> served from CDN
x-cache-hit: hit          age: 136      cache-control: public, max-age=1800
(no access-control-allow-origin)                      <-- browsers blocked

# APQ GET, hash not registered -> PersistedQueryNotFound, goes to origin
x-cache-hit: miss         cache-control: no-store
access-control-allow-origin: *                        <-- falls back to POST, works
```

From the page context the request fails with `TypeError: Failed to fetch` — a CORS block, not an HTTP error the app can surface, which is why it renders as a silent empty list rather than an error view.

I also confirmed the entry is sticky regardless of caller: after warming `GetConferenceData` with an `Origin` request, the cached copy returned `access-control-allow-origin: *` even to a request sending **no** `Origin`. Nothing distinguishes the conference-list query from the per-conference one; both are equally exposed.

**Fix.** The CORS policy is `*` for every caller anyway, so emit the header unconditionally. Every cached copy is then valid for every client, with no cache fragmentation. The filter only fills in a header `CorsWebFilter` did not already set, so genuine `Origin` requests keep their spec-compliant handling.

Adding `Origin` to the CDN cache key would also work, but fragments the cache per origin and leaves the no-`Origin` variant still missing the header.

## Test plan

- [x] `:backend:service-graphql:compileKotlin` — success
- [ ] CI: `Backend Test` (`:backend:service-graphql:build`)
- [ ] **Post-deploy verification** (the part that actually proves it):

```bash
# Must now show access-control-allow-origin even with NO Origin header.
# Use a fresh query string so it is a cache miss, then repeat for the cached copy.
curl -sD - -o /dev/null 'https://confetti-app.dev/graphql?query=%7Bconferences%7Bid%7D%7D' \
  | grep -iE 'access-control-allow-origin|x-cache-hit'
```

### Not verified locally

I could not run the service on this machine — `bootRun` fails with `IllegalStateException: no credentials found for firebase_service_account_key.json`, and I did not work around that. So the header behaviour is verified by reading the filter, not by executing it.

`backend/service-graphql` currently has **no test sources**, and only `testImplementation(libs.junit)` — no `spring-test`/`WebTestClient`. A regression test for this is worth having (the bug is subtle and invisible in the UI), but it means adding test dependencies and a test source set to a module that has neither, so I left that as a separate call rather than bundling it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Syr6Ss5YAKH69qjbVUe4